### PR TITLE
Final updates version 2 by S7evin

### DIFF
--- a/TwitchLib.Api/TwitchAPI.cs
+++ b/TwitchLib.Api/TwitchAPI.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using TwitchLib.Api.Enums;
@@ -15,6 +16,7 @@ namespace TwitchLib.Api
 {
     public class TwitchAPI : ITwitchAPI
     {
+        private readonly ILogger<TwitchAPI> _logger;
         private readonly TwitchLibJsonSerializer _jsonSerializer;
         private readonly IRateLimiter _rateLimiter;
         public IApiSettings Settings { get; }
@@ -46,16 +48,12 @@ namespace TwitchLib.Api
         /// <summary>
         /// Creates an Instance of the TwitchAPI Class.
         /// </summary>
-        /// <param name="rateLimit">Should RateLimit Requests?</param>
-        /// <param name="rateLimiter">Instance Of RateLimiter. Useful if using multiple API instances on one connection and you wish to share the requests ratelimiter.</param>
-        /// <param name="callsPerPeriod">Number of Requests per Period to rate limit to</param>
-        /// <param name="ratePeriod">Period for Rate Limit (In Seconds)</param>
-        public TwitchAPI(bool rateLimit = true, IRateLimiter rateLimiter = null, int callsPerPeriod = 1, int ratePeriod = 1)
+        /// <param name="logger">Instance Of Logger, otherwise no logging is used,  </param>
+        /// <param name="rateLimiter">Instance Of RateLimiter, otherwise no ratelimiter is used. </param>
+        public TwitchAPI(ILogger<TwitchAPI> logger = null, IRateLimiter rateLimiter = null)
         {
-            _rateLimiter = rateLimit ?
-                (rateLimiter ?? TimeLimiter.GetFromMaxCountByInterval(callsPerPeriod, TimeSpan.FromSeconds(ratePeriod)))
-                : BypassLimiter.CreateLimiterBypassInstance();
-
+            _logger = logger;
+            _rateLimiter = rateLimiter ?? BypassLimiter.CreateLimiterBypassInstance();
             Auth = new Auth(this);
             Blocks = new Blocks(this);
             Badges = new Badges(this);
@@ -96,6 +94,7 @@ namespace TwitchLib.Api
             if (!string.IsNullOrWhiteSpace(accessToken))
                 await Settings.SetAccessTokenAsync(accessToken);
         }
+       
 
         #region Requests
 

--- a/TwitchLib.Api/TwitchLib.Api.csproj
+++ b/TwitchLib.Api/TwitchLib.Api.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
     <PackageId>TwitchLib.Api</PackageId>
-    <Version>1.0.0</Version>
+    <Version>2.0.0</Version>
     <Description>Api component of TwitchLib. This component allows you to access the Twitch API using both authenticated and unauthenticated calls, as well as undocumented and third party APIs.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>swiftyspiffy, Prom3theu5</Authors>
@@ -17,17 +17,14 @@
     <RepositoryType>Git</RepositoryType>
     <PackageTags>twitch library irc chat c# csharp api events pubsub net standard 2.0</PackageTags>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>1.0.0.0</FileVersion>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+    <FileVersion>2.0.0.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Services\Exceptions\" />
-    <Folder Include="Services\Events\" />
-  </ItemGroup>
-
+  
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net452'">
     <DefineConstants>NET452</DefineConstants>
   </PropertyGroup>


### PR DESCRIPTION
Changed a few project settings and added DI for logging and Ratelimiter
You have to supply a ratelimiter if you want to limit the api. this cuts down on initialization properties and and puts it down to developer