### PR TITLE
Remove unnecessary async state machine creation.

### DIFF
--- a/TwitchLib.Api/RateLimiter/BypassLimiter.cs
+++ b/TwitchLib.Api/RateLimiter/BypassLimiter.cs
@@ -17,16 +17,16 @@ namespace TwitchLib.Api.RateLimiter
             return Perform(perform, CancellationToken.None);
         }
 
-        public async Task Perform(Func<Task> perform, CancellationToken cancellationToken)
+        public Task Perform(Func<Task> perform, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            await perform();
+            return perform();
         }
 
-        public async Task<T> Perform<T>(Func<Task<T>> perform, CancellationToken cancellationToken)
+        public Task<T> Perform<T>(Func<Task<T>> perform, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            return await perform();
+            return perform();
         }
 
         private static Func<Task> Transform(Action act)

--- a/TwitchLib.Api/Sections/Auth.cs
+++ b/TwitchLib.Api/Sections/Auth.cs
@@ -27,7 +27,7 @@ namespace TwitchLib.Api.Sections
             /// <para>Throws a BadRequest Exception if the request fails due to a bad refresh token</para>
             /// </summary>
             /// <returns>A RefreshResponse object that holds your new auth and refresh token and the list of scopes for that token</returns>
-            public async Task<Models.v5.Auth.RefreshResponse> RefreshAuthTokenAsync(string refreshToken, string clientSecret, string clientId = null)
+            public Task<Models.v5.Auth.RefreshResponse> RefreshAuthTokenAsync(string refreshToken, string clientSecret, string clientId = null)
             {
                 var internalClientId = clientId ?? Api.Settings.ClientId;
 
@@ -43,7 +43,7 @@ namespace TwitchLib.Api.Sections
                     new KeyValuePair<string, string> ("client_secret", clientSecret)
                 };
 
-                return await Api.TwitchPostGenericAsync<Models.v5.Auth.RefreshResponse>("/oauth2/token", ApiVersion.v5, null, getParams, customBase: "https://id.twitch.tv");
+                return Api.TwitchPostGenericAsync<Models.v5.Auth.RefreshResponse>("/oauth2/token", ApiVersion.v5, null, getParams, customBase: "https://id.twitch.tv");
             }
             #endregion
         }

--- a/TwitchLib.Api/Sections/Badges.cs
+++ b/TwitchLib.Api/Sections/Badges.cs
@@ -19,17 +19,17 @@ namespace TwitchLib.Api.Sections
             }
 
             #region GetSubscriberBadgesForChannel
-            public async Task<Models.v5.Badges.ChannelDisplayBadges> GetSubscriberBadgesForChannelAsync(string channelId)
+            public Task<Models.v5.Badges.ChannelDisplayBadges> GetSubscriberBadgesForChannelAsync(string channelId)
             {
                 if (string.IsNullOrWhiteSpace(channelId)) { throw new BadParameterException("The channel id is not valid. It is not allowed to be null, empty or filled with whitespaces."); }
-                return await Api.TwitchGetGenericAsync<Models.v5.Badges.ChannelDisplayBadges>($"/v1/badges/channels/{channelId}/display", Enums.ApiVersion.v5, customBase: "https://badges.twitch.tv").ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Badges.ChannelDisplayBadges>($"/v1/badges/channels/{channelId}/display", Enums.ApiVersion.v5, customBase: "https://badges.twitch.tv");
             }
             #endregion
 
             #region GetGlobalBadges
-            public async Task<Models.v5.Badges.GlobalBadgesResponse> GetGlobalBadgesAsync()
+            public Task<Models.v5.Badges.GlobalBadgesResponse> GetGlobalBadgesAsync()
             {
-                return await Api.TwitchGetGenericAsync<Models.v5.Badges.GlobalBadgesResponse>("/v1/badges/gloal/display", Enums.ApiVersion.v5, customBase: "https://badges.twitch.tv").ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Badges.GlobalBadgesResponse>("/v1/badges/gloal/display", Enums.ApiVersion.v5, customBase: "https://badges.twitch.tv");
             }
             #endregion
         }

--- a/TwitchLib.Api/Sections/Bits.cs
+++ b/TwitchLib.Api/Sections/Bits.cs
@@ -24,7 +24,7 @@ namespace TwitchLib.Api.Sections
             }
 
             #region GetBitsLeaderboard
-            public async Task<Models.Helix.Bits.GetBitsLeaderboardResponse> GetBitsLeaderboardAsync(int count = 10, BitsLeaderboardPeriodEnum period = BitsLeaderboardPeriodEnum.All, DateTime? startedAt = null, string userid = null, string accessToken = null)
+            public Task<Models.Helix.Bits.GetBitsLeaderboardResponse> GetBitsLeaderboardAsync(int count = 10, BitsLeaderboardPeriodEnum period = BitsLeaderboardPeriodEnum.All, DateTime? startedAt = null, string userid = null, string accessToken = null)
             {
                 Api.Settings.DynamicScopeValidation(AuthScopes.Helix_Bits_Read, accessToken);
                 List<KeyValuePair<string, string>> getParams = new List<KeyValuePair<string, string>>();
@@ -52,7 +52,7 @@ namespace TwitchLib.Api.Sections
                 if (userid != null)
                     getParams.Add(new KeyValuePair<string, string>("user_id", userid));
 
-                return await Api.TwitchGetGenericAsync<Models.Helix.Bits.GetBitsLeaderboardResponse>("/bits/leaderboard", ApiVersion.Helix, getParams).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.Helix.Bits.GetBitsLeaderboardResponse>("/bits/leaderboard", ApiVersion.Helix, getParams);
             }
             #endregion 
         }
@@ -64,12 +64,12 @@ namespace TwitchLib.Api.Sections
             }
 
             #region GetCheermotes
-            public async Task<Models.v5.Bits.Cheermotes> GetCheermotesAsync(string channelId = null)
+            public Task<Models.v5.Bits.Cheermotes> GetCheermotesAsync(string channelId = null)
             {
                 List<KeyValuePair<string, string>> getParams = null;
                 if (channelId != null)
                     getParams = new List<KeyValuePair<string, string>> { new KeyValuePair<string, string>("channel_id", channelId) };
-                return await Api.TwitchGetGenericAsync<Models.v5.Bits.Cheermotes>("/bits/actions", ApiVersion.v5, getParams).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Bits.Cheermotes>("/bits/actions", ApiVersion.v5, getParams);
             }
             #endregion
         }

--- a/TwitchLib.Api/Sections/ChannelFeeds.cs
+++ b/TwitchLib.Api/Sections/ChannelFeeds.cs
@@ -20,7 +20,7 @@ namespace TwitchLib.Api.Sections
             {
             }
             #region GetMultipleFeedPosts
-            public async Task<Models.v5.ChannelFeed.MultipleFeedPosts> GetMultipleFeedPostsAsync(string channelId, long? limit = null, string cursor = null, long? comments = null, string authToken = null)
+            public Task<Models.v5.ChannelFeed.MultipleFeedPosts> GetMultipleFeedPostsAsync(string channelId, long? limit = null, string cursor = null, long? comments = null, string authToken = null)
             {
                 Api.Settings.DynamicScopeValidation(AuthScopes.Channel_Feed_Read, authToken);
                 if (string.IsNullOrWhiteSpace(channelId)) { throw new BadParameterException("The channel id is not valid for fetching channel feed posts. It is not allowed to be null, empty or filled with whitespaces."); }
@@ -34,11 +34,11 @@ namespace TwitchLib.Api.Sections
                 if (comments != null && comments < 6 && comments >= 0)
                     getParams.Add(new KeyValuePair<string, string>("comments", comments.Value.ToString()));
 
-                return await Api.TwitchGetGenericAsync<Models.v5.ChannelFeed.MultipleFeedPosts>($"/feed/{channelId}/posts", ApiVersion.v5, getParams, accessToken: authToken).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.ChannelFeed.MultipleFeedPosts>($"/feed/{channelId}/posts", ApiVersion.v5, getParams, accessToken: authToken);
             }
             #endregion
             #region GetFeedPosts
-            public async Task<Models.v5.ChannelFeed.FeedPost> GetFeedPostAsync(string channelId, string postId, long? comments = null, string authToken = null)
+            public Task<Models.v5.ChannelFeed.FeedPost> GetFeedPostAsync(string channelId, string postId, long? comments = null, string authToken = null)
             {
                 Api.Settings.DynamicScopeValidation(AuthScopes.Channel_Feed_Read, authToken);
                 if (string.IsNullOrWhiteSpace(channelId)) { throw new BadParameterException("The channel id is not valid for fetching channel feed posts. It is not allowed to be null, empty or filled with whitespaces."); }
@@ -48,12 +48,12 @@ namespace TwitchLib.Api.Sections
                 var getParams = new List<KeyValuePair<string, string>>();
                 if (comments != null && comments < 6 && comments >= 0)
                     getParams.Add(new KeyValuePair<string, string>("comments", comments.Value.ToString()));
-                return await Api.TwitchGetGenericAsync<Models.v5.ChannelFeed.FeedPost>($"/feed/{channelId}/posts/{postId}", ApiVersion.v5, getParams, accessToken: authToken).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.ChannelFeed.FeedPost>($"/feed/{channelId}/posts/{postId}", ApiVersion.v5, getParams, accessToken: authToken);
             }
         
             #endregion
             #region CreateFeedPost
-            public async Task<Models.v5.ChannelFeed.FeedPostCreation> CreateFeedPostAsync(string channelId, string content, bool? share = null, string authToken = null)
+            public Task<Models.v5.ChannelFeed.FeedPostCreation> CreateFeedPostAsync(string channelId, string content, bool? share = null, string authToken = null)
             {
                 Api.Settings.DynamicScopeValidation(AuthScopes.Channel_Feed_Edit, authToken);
                 if (string.IsNullOrWhiteSpace(channelId)) { throw new BadParameterException("The channel id is not valid for fetching channel feed posts. It is not allowed to be null, empty or filled with whitespaces."); }
@@ -62,27 +62,27 @@ namespace TwitchLib.Api.Sections
                 if (share.HasValue)
                     getParams.Add(new KeyValuePair<string, string>("share", share.Value.ToString()));
                 string payload = "{\"content\": \"" + content + "\"}";
-                return await Api.TwitchPostGenericAsync<Models.v5.ChannelFeed.FeedPostCreation>($"/feed/{channelId}/posts", ApiVersion.v5, payload, getParams, authToken).ConfigureAwait(false);
+                return Api.TwitchPostGenericAsync<Models.v5.ChannelFeed.FeedPostCreation>($"/feed/{channelId}/posts", ApiVersion.v5, payload, getParams, authToken);
             }
             #endregion
             #region DeleteFeedPost
-            public async Task<Models.v5.ChannelFeed.FeedPost> DeleteFeedPostAsync(string channelId, string postId, string authToken = null)
+            public Task<Models.v5.ChannelFeed.FeedPost> DeleteFeedPostAsync(string channelId, string postId, string authToken = null)
             {
                 Api.Settings.DynamicScopeValidation(AuthScopes.Channel_Feed_Edit, authToken);
                 if (string.IsNullOrWhiteSpace(channelId)) { throw new BadParameterException("The channel id is not valid for fetching channel feed posts. It is not allowed to be null, empty or filled with whitespaces."); }
                 if (string.IsNullOrWhiteSpace(postId)) { throw new BadParameterException("The post id is not valid for fetching channel feed posts. It is not allowed to be null, empty or filled with whitespaces."); }
-                return await Api.TwitchDeleteGenericAsync<Models.v5.ChannelFeed.FeedPost>($"/feed/{channelId}/posts/{postId}", ApiVersion.v5, authToken).ConfigureAwait(false);
+                return Api.TwitchDeleteGenericAsync<Models.v5.ChannelFeed.FeedPost>($"/feed/{channelId}/posts/{postId}", ApiVersion.v5, authToken);
             }
             #endregion
             #region CreateReactionToFeedPost
-            public async Task<Models.v5.ChannelFeed.FeedPostReactionPost> CreateReactionToFeedPostAsync(string channelId, string postId, string emoteId, string authToken = null)
+            public Task<Models.v5.ChannelFeed.FeedPostReactionPost> CreateReactionToFeedPostAsync(string channelId, string postId, string emoteId, string authToken = null)
             {
                 Api.Settings.DynamicScopeValidation(AuthScopes.Channel_Feed_Edit, authToken);
                 if (string.IsNullOrWhiteSpace(channelId)) { throw new BadParameterException("The channel id is not valid for fetching channel feed posts. It is not allowed to be null, empty or filled with whitespaces."); }
                 if (string.IsNullOrWhiteSpace(postId)) { throw new BadParameterException("The post id is not valid for fetching channel feed posts. It is not allowed to be null, empty or filled with whitespaces."); }
                 if (string.IsNullOrWhiteSpace(emoteId)) { throw new BadParameterException("The emote id is not valid for posting a channel feed post reaction. It is not allowed to be null, empty or filled with whitespaces."); }
                 var getParams = new List<KeyValuePair<string, string>> { new KeyValuePair<string, string>("emote_id", emoteId) };
-                return await Api.TwitchPostGenericAsync<Models.v5.ChannelFeed.FeedPostReactionPost>($"/feed/{channelId}/posts/{postId}/reactions", ApiVersion.v5, null, getParams, authToken).ConfigureAwait(false);
+                return Api.TwitchPostGenericAsync<Models.v5.ChannelFeed.FeedPostReactionPost>($"/feed/{channelId}/posts/{postId}/reactions", ApiVersion.v5, null, getParams, authToken);
             }
             #endregion
             #region DeleteReactionToFeedPost
@@ -97,7 +97,7 @@ namespace TwitchLib.Api.Sections
             }
             #endregion
             #region GetFeedComments
-            public async Task<Models.v5.ChannelFeed.FeedPostComments> GetFeedCommentsAsync(string channelId, string postId, long? limit = null, string cursor = null, string authToken = null)
+            public Task<Models.v5.ChannelFeed.FeedPostComments> GetFeedCommentsAsync(string channelId, string postId, long? limit = null, string cursor = null, string authToken = null)
             {
                 Api.Settings.DynamicScopeValidation(AuthScopes.Channel_Feed_Read, authToken);
                 if (string.IsNullOrWhiteSpace(channelId)) { throw new BadParameterException("The channel id is not valid for fetching channel feed posts. It is not allowed to be null, empty or filled with whitespaces."); }
@@ -108,32 +108,32 @@ namespace TwitchLib.Api.Sections
                     getParams.Add(new KeyValuePair<string, string>("limit", limit.Value.ToString()));
                 if (!string.IsNullOrEmpty(cursor))
                     getParams.Add(new KeyValuePair<string, string>("cursor", cursor));
-                return await Api.TwitchGetGenericAsync<Models.v5.ChannelFeed.FeedPostComments>($"/feed/{channelId}/posts/{postId}/comments", ApiVersion.v5, getParams, authToken).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.ChannelFeed.FeedPostComments>($"/feed/{channelId}/posts/{postId}/comments", ApiVersion.v5, getParams, authToken);
             }
             #endregion
             #region CreateFeedComment
-            public async Task<Models.v5.ChannelFeed.FeedPostComment> CreateFeedCommentAsync(string channelId, string postId, string content, string authToken = null)
+            public Task<Models.v5.ChannelFeed.FeedPostComment> CreateFeedCommentAsync(string channelId, string postId, string content, string authToken = null)
             {
                 Api.Settings.DynamicScopeValidation(AuthScopes.Channel_Feed_Edit, authToken);
                 if (string.IsNullOrWhiteSpace(channelId)) { throw new BadParameterException("The channel id is not valid for fetching channel feed posts. It is not allowed to be null, empty or filled with whitespaces."); }
                 if (string.IsNullOrWhiteSpace(postId)) { throw new BadParameterException("The post id is not valid for fetching channel feed posts. It is not allowed to be null, empty or filled with whitespaces."); }
                 if (string.IsNullOrWhiteSpace(content)) { throw new BadParameterException("The content is not valid for commenting channel feed posts. It is not allowed to be null, empty or filled with whitespaces."); }
                 string payload = "{\"content\": \"" + content + "\"}";
-                return await Api.TwitchPostGenericAsync<Models.v5.ChannelFeed.FeedPostComment>($"/feed/{channelId}/posts/{postId}/comments", ApiVersion.v5, payload, accessToken: authToken).ConfigureAwait(false);
+                return Api.TwitchPostGenericAsync<Models.v5.ChannelFeed.FeedPostComment>($"/feed/{channelId}/posts/{postId}/comments", ApiVersion.v5, payload, accessToken: authToken);
             }
             #endregion
             #region DeleteFeedComment
-            public async Task<Models.v5.ChannelFeed.FeedPostComment> DeleteFeedCommentAsync(string channelId, string postId, string commentId, string authToken = null)
+            public Task<Models.v5.ChannelFeed.FeedPostComment> DeleteFeedCommentAsync(string channelId, string postId, string commentId, string authToken = null)
             {
                 Api.Settings.DynamicScopeValidation(AuthScopes.Channel_Feed_Edit, authToken);
                 if (string.IsNullOrWhiteSpace(channelId)) { throw new BadParameterException("The channel id is not valid for fetching channel feed posts. It is not allowed to be null, empty or filled with whitespaces."); }
                 if (string.IsNullOrWhiteSpace(postId)) { throw new BadParameterException("The post id is not valid for fetching channel feed posts. It is not allowed to be null, empty or filled with whitespaces."); }
                 if (string.IsNullOrWhiteSpace(commentId)) { throw new BadParameterException("The comment id is not valid for fetching channel feed post comments. It is not allowed to be null, empty or filled with whitespaces."); }
-                return await Api.TwitchDeleteGenericAsync<Models.v5.ChannelFeed.FeedPostComment>($"/feed/{channelId}/posts/{postId}/comments/{commentId}", ApiVersion.v5, authToken).ConfigureAwait(false);
+                return Api.TwitchDeleteGenericAsync<Models.v5.ChannelFeed.FeedPostComment>($"/feed/{channelId}/posts/{postId}/comments/{commentId}", ApiVersion.v5, authToken);
             }
             #endregion
             #region CreateReactionToFeedComments
-            public async Task<Models.v5.ChannelFeed.FeedPostReactionPost> CreateReactionToFeedCommentAsync(string channelId, string postId, string commentId, string emoteId, string authToken = null)
+            public Task<Models.v5.ChannelFeed.FeedPostReactionPost> CreateReactionToFeedCommentAsync(string channelId, string postId, string commentId, string emoteId, string authToken = null)
             {
                 Api.Settings.DynamicScopeValidation(AuthScopes.Channel_Feed_Edit, authToken);
                 if (string.IsNullOrWhiteSpace(channelId)) { throw new BadParameterException("The channel id is not valid for fetching channel feed posts. It is not allowed to be null, empty or filled with whitespaces."); }
@@ -141,7 +141,7 @@ namespace TwitchLib.Api.Sections
                 if (string.IsNullOrWhiteSpace(commentId)) { throw new BadParameterException("The comment id is not valid for fetching channel feed post comments. It is not allowed to be null, empty or filled with whitespaces."); }
                 if (string.IsNullOrWhiteSpace(emoteId)) { throw new BadParameterException("The emote id is not valid for posting a channel feed post comment reaction. It is not allowed to be null, empty or filled with whitespaces."); }
                 var getParams = new List<KeyValuePair<string, string>> { new KeyValuePair<string, string>("emote_id", emoteId) };
-                return await Api.TwitchPostGenericAsync<Models.v5.ChannelFeed.FeedPostReactionPost>($"/feed/{channelId}/posts/{postId}/comments/{commentId}/reactions", ApiVersion.v5, null, getParams, authToken).ConfigureAwait(false);
+                return Api.TwitchPostGenericAsync<Models.v5.ChannelFeed.FeedPostReactionPost>($"/feed/{channelId}/posts/{postId}/comments/{commentId}/reactions", ApiVersion.v5, null, getParams, authToken);
             }
             #endregion
             #region DeleteReactionToFeedComments

--- a/TwitchLib.Api/Sections/Channels.cs
+++ b/TwitchLib.Api/Sections/Channels.cs
@@ -28,9 +28,9 @@ namespace TwitchLib.Api.Sections
             /// <para>Required Authentication Scope: channel_read</para>
             /// </summary>
             /// <returns>A ChannelPrivileged object including all Channel object info plus email and streamkey.</returns>
-            public async Task<Models.v5.Channels.ChannelAuthed> GetChannelAsync(string authToken = null)
+            public Task<Models.v5.Channels.ChannelAuthed> GetChannelAsync(string authToken = null)
             {
-                return await Api.TwitchGetGenericAsync<Models.v5.Channels.ChannelAuthed>("/channel", ApiVersion.v5, accessToken: authToken).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Channels.ChannelAuthed>("/channel", ApiVersion.v5, accessToken: authToken);
             }
             #endregion
             #region GetChannelById
@@ -39,10 +39,10 @@ namespace TwitchLib.Api.Sections
             /// </summary>
             /// <param name="channelId">The specified channelId of the channel to get the information from.</param>
             /// <returns>A Channel object from the response of the Twitch API.</returns>
-            public async Task<Models.v5.Channels.Channel> GetChannelByIDAsync(string channelId)
+            public Task<Models.v5.Channels.Channel> GetChannelByIDAsync(string channelId)
             {
                 if (string.IsNullOrWhiteSpace(channelId)) { throw new BadParameterException("The channel id is not valid. It is not allowed to be null, empty or filled with whitespaces."); }
-                return await Api.TwitchGetGenericAsync<Models.v5.Channels.Channel>($"/channels/{channelId}", ApiVersion.v5).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Channels.Channel>($"/channels/{channelId}", ApiVersion.v5);
             }
             #endregion
             #region UpdateChannel
@@ -59,7 +59,7 @@ namespace TwitchLib.Api.Sections
             /// <param name="channelFeedEnabled">If true, the channel’s feed is turned on. Requires the channel owner’s OAuth token. Default: false.</param>
             /// <param name="authToken"></param>
             /// <returns>A Channel object with the newly changed properties.</returns>
-            public async Task<Models.v5.Channels.Channel> UpdateChannelAsync(string channelId, string status = null, string game = null, string delay = null, bool? channelFeedEnabled = null, string authToken = null)
+            public Task<Models.v5.Channels.Channel> UpdateChannelAsync(string channelId, string status = null, string game = null, string delay = null, bool? channelFeedEnabled = null, string authToken = null)
             {
                 Api.Settings.DynamicScopeValidation(AuthScopes.Channel_Editor, authToken);
                 if (string.IsNullOrWhiteSpace(channelId)) { throw new BadParameterException("The channel id is not valid. It is not allowed to be null, empty or filled with whitespaces."); }
@@ -91,7 +91,7 @@ namespace TwitchLib.Api.Sections
 
                 payload = "{ \"channel\": {" + payload + "} }";
 
-                return await Api.TwitchPutGenericAsync<Models.v5.Channels.Channel>($"/channels/{channelId}", ApiVersion.v5, payload, accessToken: authToken).ConfigureAwait(false);
+                return Api.TwitchPutGenericAsync<Models.v5.Channels.Channel>($"/channels/{channelId}", ApiVersion.v5, payload, accessToken: authToken);
             }
             #endregion
             #region GetChannelEditors
@@ -103,11 +103,11 @@ namespace TwitchLib.Api.Sections
             /// <param name="channelId">The specified channelId of the channel to get the information from.</param>
             /// <param name="authToken"></param>
             /// <returns>A ChannelEditors object that contains an array of the Users which are Editor of the channel.</returns>
-            public async Task<Models.v5.Channels.ChannelEditors> GetChannelEditorsAsync(string channelId, string authToken = null)
+            public Task<Models.v5.Channels.ChannelEditors> GetChannelEditorsAsync(string channelId, string authToken = null)
             {
                 Api.Settings.DynamicScopeValidation(AuthScopes.Channel_Read, authToken);
                 if (string.IsNullOrWhiteSpace(channelId)) { throw new BadParameterException("The channel id is not valid. It is not allowed to be null, empty or filled with whitespaces."); }
-                return await Api.TwitchGetGenericAsync<Models.v5.Channels.ChannelEditors>($"/channels/{channelId}/editors", ApiVersion.v5, accessToken: authToken).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Channels.ChannelEditors>($"/channels/{channelId}/editors", ApiVersion.v5, accessToken: authToken);
             }
             #endregion
             #region GetChannelFollowers
@@ -120,7 +120,7 @@ namespace TwitchLib.Api.Sections
             /// <param name="cursor">Tells the server where to start fetching the next set of results, in a multi-page response.</param>
             /// <param name="direction">Sorting direction. Valid values: "asc", "desc" (newest first). Default: "desc".</param>
             /// <returns>A ChannelFollowers object that represents the response from the Twitch API.</returns>
-            public async Task<Models.v5.Channels.ChannelFollowers> GetChannelFollowersAsync(string channelId, int? limit = null, int? offset = null, string cursor = null, string direction = null)
+            public Task<Models.v5.Channels.ChannelFollowers> GetChannelFollowersAsync(string channelId, int? limit = null, int? offset = null, string cursor = null, string direction = null)
             {
                 if (string.IsNullOrWhiteSpace(channelId)) { throw new BadParameterException("The channel id is not valid. It is not allowed to be null, empty or filled with whitespaces."); }
                 var getParams = new List<KeyValuePair<string, string>>();
@@ -133,7 +133,7 @@ namespace TwitchLib.Api.Sections
                 if (!string.IsNullOrEmpty(direction) && (direction == "asc" || direction == "desc"))
                     getParams.Add(new KeyValuePair<string, string>("direction", direction));
 
-                return await Api.TwitchGetGenericAsync<Models.v5.Channels.ChannelFollowers>($"/channels/{channelId}/follows", ApiVersion.v5, getParams).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Channels.ChannelFollowers>($"/channels/{channelId}/follows", ApiVersion.v5, getParams);
             }
             #endregion
             #region GetAllChannelFollowers
@@ -179,10 +179,10 @@ namespace TwitchLib.Api.Sections
             /// </summary>
             /// <param name="channelId">The specified channelId of the channel to get the information from.</param>
             /// <returns>An Array of the Teams the Channel belongs to.</returns>
-            public async Task<Models.v5.Channels.ChannelTeams> GetChannelTeamsAsync(string channelId)
+            public Task<Models.v5.Channels.ChannelTeams> GetChannelTeamsAsync(string channelId)
             {
                 if (string.IsNullOrWhiteSpace(channelId)) { throw new BadParameterException("The channel id is not valid. It is not allowed to be null, empty or filled with whitespaces."); }
-                return await Api.TwitchGetGenericAsync<Models.v5.Channels.ChannelTeams>($"/channels/{channelId}/teams", ApiVersion.v5).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Channels.ChannelTeams>($"/channels/{channelId}/teams", ApiVersion.v5);
             }
             #endregion
             #region GetChannelSubscribers
@@ -196,7 +196,7 @@ namespace TwitchLib.Api.Sections
             /// <param name="direction">Sorting direction. Valid values: "asc", "desc" (newest first). Default: "desc".</param>
             /// <param name="authToken">The associated auth token for this request.</param>
             /// <returns></returns>
-            public async Task<Models.v5.Channels.ChannelSubscribers> GetChannelSubscribersAsync(string channelId, int? limit = null, int? offset = null, string direction = null, string authToken = null)
+            public Task<Models.v5.Channels.ChannelSubscribers> GetChannelSubscribersAsync(string channelId, int? limit = null, int? offset = null, string direction = null, string authToken = null)
             {
                 Api.Settings.DynamicScopeValidation(AuthScopes.Channel_Subscriptions, authToken);
                 if (string.IsNullOrWhiteSpace(channelId)) { throw new BadParameterException("The channel id is not valid. It is not allowed to be null, empty or filled with whitespaces."); }
@@ -208,7 +208,7 @@ namespace TwitchLib.Api.Sections
                 if (!string.IsNullOrEmpty(direction) && (direction == "asc" || direction == "desc"))
                     getParams.Add(new KeyValuePair<string, string>("direction", direction));
 
-                return await Api.TwitchGetGenericAsync<Models.v5.Channels.ChannelSubscribers>($"/channels/{channelId}/subscriptions", ApiVersion.v5, getParams, authToken).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Channels.ChannelSubscribers>($"/channels/{channelId}/subscriptions", ApiVersion.v5, getParams, authToken);
             }
             #endregion
             #region GetAllSubscribers
@@ -263,17 +263,17 @@ namespace TwitchLib.Api.Sections
             /// <param name="userId">The specified user to check for.</param>
             /// <param name="authToken"></param>
             /// <returns>Returns a subscription object or null if not subscribed.</returns>
-            public async Task<Models.v5.Subscriptions.Subscription> CheckChannelSubscriptionByUserAsync(string channelId, string userId, string authToken = null)
+            public Task<Models.v5.Subscriptions.Subscription> CheckChannelSubscriptionByUserAsync(string channelId, string userId, string authToken = null)
             {
                 Api.Settings.DynamicScopeValidation(AuthScopes.Channel_Check_Subscription, authToken);
                 if (string.IsNullOrWhiteSpace(channelId)) { throw new BadParameterException("The channel id is not valid. It is not allowed to be null, empty or filled with whitespaces."); }
                 if (string.IsNullOrWhiteSpace(userId)) { throw new BadParameterException("The user id is not valid. It is not allowed to be null, empty or filled with whitespaces."); }
-                return await Api.TwitchGetGenericAsync<Models.v5.Subscriptions.Subscription>($"/channels/{channelId}/subscriptions/{userId}", ApiVersion.v5, accessToken: authToken).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Subscriptions.Subscription>($"/channels/{channelId}/subscriptions/{userId}", ApiVersion.v5, accessToken: authToken);
             }
         
             #endregion
             #region GetChannelVideos
-            public async Task<Models.v5.Channels.ChannelVideos> GetChannelVideosAsync(string channelId, int? limit = null, int? offset = null, List<string> broadcastType = null, List<string> language = null, string sort = null)
+            public Task<Models.v5.Channels.ChannelVideos> GetChannelVideosAsync(string channelId, int? limit = null, int? offset = null, List<string> broadcastType = null, List<string> language = null, string sort = null)
             {
                 if (string.IsNullOrWhiteSpace(channelId)) { throw new BadParameterException("The channel id is not valid. It is not allowed to be null, empty or filled with whitespaces."); }
                 var getParams = new List<KeyValuePair<string, string>>();
@@ -297,16 +297,16 @@ namespace TwitchLib.Api.Sections
                 if (!string.IsNullOrWhiteSpace(sort) && (sort == "views" || sort == "time"))
                     getParams.Add(new KeyValuePair<string, string>("sort", sort));
 
-                return await Api.TwitchGetGenericAsync<Models.v5.Channels.ChannelVideos>($"/channels/{channelId}/videos", ApiVersion.v5, getParams).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Channels.ChannelVideos>($"/channels/{channelId}/videos", ApiVersion.v5, getParams);
             }
             #endregion
             #region StartChannelCommercial
-            public async Task<Models.v5.Channels.ChannelCommercial> StartChannelCommercialAsync(string channelId, CommercialLength duration, string authToken = null)
+            public Task<Models.v5.Channels.ChannelCommercial> StartChannelCommercialAsync(string channelId, CommercialLength duration, string authToken = null)
             {
                 Api.Settings.DynamicScopeValidation(AuthScopes.Channel_Commercial, authToken);
                 if (string.IsNullOrWhiteSpace(channelId)) { throw new BadParameterException("The channel id is not valid. It is not allowed to be null, empty or filled with whitespaces."); }
                 string payload = "{\"duration\": " + (int)duration + "}";
-                return await Api.TwitchPostGenericAsync<Models.v5.Channels.ChannelCommercial>($"/channels/{channelId}/commercial", ApiVersion.v5, payload, accessToken: authToken).ConfigureAwait(false);
+                return Api.TwitchPostGenericAsync<Models.v5.Channels.ChannelCommercial>($"/channels/{channelId}/commercial", ApiVersion.v5, payload, accessToken: authToken);
             }
             #endregion
             #region ResetChannelStreamKey
@@ -319,11 +319,11 @@ namespace TwitchLib.Api.Sections
             /// <param name="channelId">The specified channel to reset the StreamKey on.</param>
             /// <param name="authToken"></param>
             /// <returns>A ChannelPrivileged object that also contains the email and stream key of the channel aside from the normal channel values.</returns>
-            public async Task<Models.v5.Channels.ChannelAuthed> ResetChannelStreamKeyAsync(string channelId, string authToken = null)
+            public Task<Models.v5.Channels.ChannelAuthed> ResetChannelStreamKeyAsync(string channelId, string authToken = null)
             {
                 Api.Settings.DynamicScopeValidation(AuthScopes.Channel_Stream, authToken);
                 if (string.IsNullOrWhiteSpace(channelId)) { throw new BadParameterException("The channel id is not valid. It is not allowed to be null, empty or filled with whitespaces."); }
-                return await Api.TwitchDeleteGenericAsync<Models.v5.Channels.ChannelAuthed>($"/channels/{channelId}/stream_key", ApiVersion.v5, authToken).ConfigureAwait(false);
+                return Api.TwitchDeleteGenericAsync<Models.v5.Channels.ChannelAuthed>($"/channels/{channelId}/stream_key", ApiVersion.v5, authToken);
             }
             #endregion
 
@@ -337,17 +337,17 @@ namespace TwitchLib.Api.Sections
             /// <param name="channelId">The specified channel ID to get the community from.</param>
             /// <param name="authToken"></param>
             /// <returns>A Community object that represents the community the channel is in.</returns>
-            public async Task<Models.v5.Communities.Community> GetChannelCommunityAsync(string channelId, string authToken = null)
+            public Task<Models.v5.Communities.Community> GetChannelCommunityAsync(string channelId, string authToken = null)
             {
                 if (string.IsNullOrWhiteSpace(channelId)) { throw new BadParameterException("The channel id is not valid. It is not allowed to be null, empty or filled with whitespaces."); }
-                return await Api.TwitchGetGenericAsync<Models.v5.Communities.Community>($"/channels/{channelId}/community", ApiVersion.v5, accessToken: authToken).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Communities.Community>($"/channels/{channelId}/community", ApiVersion.v5, accessToken: authToken);
             }
             #endregion
             #region GetChannelCommunities
-            public async Task<Models.v5.Communities.CommunitiesResponse> GetChannelCommunitiesAsync(string channelId, string authToken = null)
+            public Task<Models.v5.Communities.CommunitiesResponse> GetChannelCommunitiesAsync(string channelId, string authToken = null)
             {
                 if (string.IsNullOrEmpty(channelId)) { throw new BadParameterException("The channel id is not valid. It is now allowed to be null, empty or filled with whitespaces."); }
-                return await Api.TwitchGetGenericAsync<Models.v5.Communities.CommunitiesResponse>($"/channels/{channelId}/communities", ApiVersion.v5, accessToken: authToken).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Communities.CommunitiesResponse>($"/channels/{channelId}/communities", ApiVersion.v5, accessToken: authToken);
             }
             #endregion
             #region SetChannelCommunities

--- a/TwitchLib.Api/Sections/Chat.cs
+++ b/TwitchLib.Api/Sections/Chat.cs
@@ -20,32 +20,32 @@ namespace TwitchLib.Api.Sections
             {
             }
             #region GetChatBadgesByChannel
-            public async Task<Models.v5.Chat.ChannelBadges> GetChatBadgesByChannelAsync(string channelId)
+            public Task<Models.v5.Chat.ChannelBadges> GetChatBadgesByChannelAsync(string channelId)
             {
                 if (string.IsNullOrWhiteSpace(channelId)) { throw new BadParameterException("The channel id is not valid for catching the channel badges. It is not allowed to be null, empty or filled with whitespaces."); }
-                return await Api.TwitchGetGenericAsync<Models.v5.Chat.ChannelBadges>($"/chat/{channelId}/badges", ApiVersion.v5).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Chat.ChannelBadges>($"/chat/{channelId}/badges", ApiVersion.v5);
             }
             #endregion
             #region GetChatEmoticonsBySet
-            public async Task<Models.v5.Chat.EmoteSet> GetChatEmoticonsBySetAsync(List<int> emotesets = null)
+            public Task<Models.v5.Chat.EmoteSet> GetChatEmoticonsBySetAsync(List<int> emotesets = null)
             {
                 List<KeyValuePair<string, string>> getParams = null;
                 if(emotesets != null && emotesets.Count > 0)
                     getParams = new List<KeyValuePair<string, string>> { new KeyValuePair<string, string>("emotesets", string.Join(",", emotesets)) };
-                return await Api.TwitchGetGenericAsync<Models.v5.Chat.EmoteSet>("/chat/emoticon_images", ApiVersion.v5, getParams).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Chat.EmoteSet>("/chat/emoticon_images", ApiVersion.v5, getParams);
             }
             #endregion
             #region GetAllChatEmoticons
-            public async Task<Models.v5.Chat.AllChatEmotes> GetAllChatEmoticonsAsync()
+            public Task<Models.v5.Chat.AllChatEmotes> GetAllChatEmoticonsAsync()
             {
-                return await Api.TwitchGetGenericAsync<Models.v5.Chat.AllChatEmotes>("/chat/emoticons", ApiVersion.v5).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Chat.AllChatEmotes>("/chat/emoticons", ApiVersion.v5);
             }
             #endregion
             #region GetChatRoomsByChannel 
-            public async Task<Models.v5.Chat.ChatRoomsByChannelResponse> GetChatRoomsByChannelAsync(string channelId, string authToken = null)
+            public Task<Models.v5.Chat.ChatRoomsByChannelResponse> GetChatRoomsByChannelAsync(string channelId, string authToken = null)
             {
                 Api.Settings.DynamicScopeValidation(AuthScopes.Any, authToken);
-                return await Api.TwitchGetGenericAsync<Models.v5.Chat.ChatRoomsByChannelResponse>($"/chat/{channelId}/rooms", ApiVersion.v5, accessToken: authToken).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Chat.ChatRoomsByChannelResponse>($"/chat/{channelId}/rooms", ApiVersion.v5, accessToken: authToken);
             }
             #endregion
         }

--- a/TwitchLib.Api/Sections/Clips.cs
+++ b/TwitchLib.Api/Sections/Clips.cs
@@ -23,13 +23,13 @@ namespace TwitchLib.Api.Sections
             {
             }
             #region GetClip
-            public async Task<Models.v5.Clips.Clip> GetClipAsync(string slug)
+            public Task<Models.v5.Clips.Clip> GetClipAsync(string slug)
             {
-                return await Api.TwitchGetGenericAsync<Models.v5.Clips.Clip>($"/clips/{slug}", ApiVersion.v5).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Clips.Clip>($"/clips/{slug}", ApiVersion.v5);
             }
             #endregion
             #region GetTopClips
-            public async Task<Models.v5.Clips.TopClipsResponse> GetTopClipsAsync(string channel = null, string cursor = null, string game = null, long limit = 10, Models.v5.Clips.Period period = Models.v5.Clips.Period.Week, bool trending = false)
+            public Task<Models.v5.Clips.TopClipsResponse> GetTopClipsAsync(string channel = null, string cursor = null, string game = null, long limit = 10, Models.v5.Clips.Period period = Models.v5.Clips.Period.Week, bool trending = false)
             {
                 var getParams = new List<KeyValuePair<string, string>> { new KeyValuePair<string, string>("limit", limit.ToString()) };
                 if (channel != null)
@@ -59,11 +59,11 @@ namespace TwitchLib.Api.Sections
                         throw new ArgumentOutOfRangeException(nameof(period), period, null);
                 }
 
-                return await Api.TwitchGetGenericAsync<Models.v5.Clips.TopClipsResponse>("/clips/top", ApiVersion.v5, getParams).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Clips.TopClipsResponse>("/clips/top", ApiVersion.v5, getParams);
             }
             #endregion
             #region GetFollowedClips
-            public async Task<Models.v5.Clips.FollowClipsResponse> GetFollowedClipsAsync(long limit = 10, string cursor = null, bool trending = false, string authToken = null)
+            public Task<Models.v5.Clips.FollowClipsResponse> GetFollowedClipsAsync(long limit = 10, string cursor = null, bool trending = false, string authToken = null)
             {
                 Api.Settings.DynamicScopeValidation(Enums.AuthScopes.User_Read, authToken);
                 var getParams = new List<KeyValuePair<string, string>> { new KeyValuePair<string, string>("limit", limit.ToString()) };
@@ -73,7 +73,7 @@ namespace TwitchLib.Api.Sections
                     ? new KeyValuePair<string, string>("trending", "true")
                     : new KeyValuePair<string, string>("trending", "false"));
 
-                return await Api.TwitchGetGenericAsync<Models.v5.Clips.FollowClipsResponse>("/clips/followed", ApiVersion.v5, getParams, accessToken: authToken).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Clips.FollowClipsResponse>("/clips/followed", ApiVersion.v5, getParams, accessToken: authToken);
             }
             #endregion
         }
@@ -85,24 +85,24 @@ namespace TwitchLib.Api.Sections
             }
 
             #region GetClip
-            public async Task<Models.Helix.Clips.GetClip.GetClipResponse> GetClipAsync(string id)
+            public Task<Models.Helix.Clips.GetClip.GetClipResponse> GetClipAsync(string id)
             {
                 var getParams = new List<KeyValuePair<string, string>>
                 {
                     new KeyValuePair<string, string>("id", id)
                 };
-                return await Api.TwitchGetGenericAsync<Models.Helix.Clips.GetClip.GetClipResponse>("/clips", ApiVersion.Helix, getParams).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.Helix.Clips.GetClip.GetClipResponse>("/clips", ApiVersion.Helix, getParams);
             }
             #endregion
             #region CreateClip
-            public async Task<Models.Helix.Clips.CreateClip.CreatedClipResponse> CreateClipAsync(string broadcasterId, string authToken = null)
+            public Task<Models.Helix.Clips.CreateClip.CreatedClipResponse> CreateClipAsync(string broadcasterId, string authToken = null)
             {
                 Api.Settings.DynamicScopeValidation(Enums.AuthScopes.Helix_Clips_Edit);
                 var getParams = new List<KeyValuePair<string, string>>
                 {
                     new KeyValuePair<string, string>("broadcaster_id", broadcasterId)
                 };
-                return await Api.TwitchPostGenericAsync<Models.Helix.Clips.CreateClip.CreatedClipResponse>("/clips", ApiVersion.Helix, null, getParams, accessToken: authToken).ConfigureAwait(false);
+                return Api.TwitchPostGenericAsync<Models.Helix.Clips.CreateClip.CreatedClipResponse>("/clips", ApiVersion.Helix, null, getParams, accessToken: authToken);
             }
             #endregion
         }

--- a/TwitchLib.Api/Sections/Collections.cs
+++ b/TwitchLib.Api/Sections/Collections.cs
@@ -20,24 +20,24 @@ namespace TwitchLib.Api.Sections
             {
             }
             #region GetCollectionMetadata
-            public async Task<Models.v5.Collections.CollectionMetadata> GetCollectionMetadataAsync(string collectionId)
+            public Task<Models.v5.Collections.CollectionMetadata> GetCollectionMetadataAsync(string collectionId)
             {
                 if (string.IsNullOrWhiteSpace(collectionId)) { throw new BadParameterException("The collection id is not valid for a collection. It is not allowed to be null, empty or filled with whitespaces."); }
-                return await Api.TwitchGetGenericAsync<Models.v5.Collections.CollectionMetadata>($"/collections/{collectionId}", ApiVersion.v5).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Collections.CollectionMetadata>($"/collections/{collectionId}", ApiVersion.v5);
             }
             #endregion
             #region GetCollection
-            public async Task<Models.v5.Collections.Collection> GetCollectionAsync(string collectionId, bool? includeAllItems = null)
+            public Task<Models.v5.Collections.Collection> GetCollectionAsync(string collectionId, bool? includeAllItems = null)
             {
                 if (string.IsNullOrWhiteSpace(collectionId)) { throw new BadParameterException("The collection id is not valid for a collection. It is not allowed to be null, empty or filled with whitespaces."); }
                 var getParams = new List<KeyValuePair<string, string>>();
                 if (includeAllItems.HasValue)
                     getParams.Add(new KeyValuePair<string, string>("include_all_items", ((bool)includeAllItems).ToString()));
-                return await Api.TwitchGetGenericAsync<Models.v5.Collections.Collection>($"/collections/{collectionId}/items", ApiVersion.v5, getParams).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Collections.Collection>($"/collections/{collectionId}/items", ApiVersion.v5, getParams);
             }
             #endregion
             #region GetCollectionsByChannel
-            public async Task<Models.v5.Collections.CollectionsByChannel> GetCollectionsByChannelAsync(string channelId, long? limit = null, string cursor = null, string containingItem = null)
+            public Task<Models.v5.Collections.CollectionsByChannel> GetCollectionsByChannelAsync(string channelId, long? limit = null, string cursor = null, string containingItem = null)
             {
                 if (string.IsNullOrWhiteSpace(channelId)) { throw new BadParameterException("The channel id is not valid for catching a collection. It is not allowed to be null, empty or filled with whitespaces."); }
                 var getParams = new List<KeyValuePair<string, string>>();
@@ -48,17 +48,17 @@ namespace TwitchLib.Api.Sections
                 if (!string.IsNullOrWhiteSpace(containingItem))
                     getParams.Add(new KeyValuePair<string, string>("containing_item", containingItem.StartsWith("video:") ? containingItem : $"video:{containingItem}"));
                 
-                return await Api.TwitchGetGenericAsync<Models.v5.Collections.CollectionsByChannel>($"/channels/{channelId}/collections", ApiVersion.v5, getParams).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Collections.CollectionsByChannel>($"/channels/{channelId}/collections", ApiVersion.v5, getParams);
             }
             #endregion
             #region CreateCollection
-            public async Task<Models.v5.Collections.CollectionMetadata> CreateCollectionAsync(string channelId, string collectionTitle, string authToken = null)
+            public Task<Models.v5.Collections.CollectionMetadata> CreateCollectionAsync(string channelId, string collectionTitle, string authToken = null)
             {
                 Api.Settings.DynamicScopeValidation(AuthScopes.Collections_Edit, authToken);
                 if (string.IsNullOrWhiteSpace(channelId)) { throw new BadParameterException("The channel id is not valid for a collection creation. It is not allowed to be null, empty or filled with whitespaces."); }
                 if (string.IsNullOrWhiteSpace(collectionTitle)) { throw new BadParameterException("The collection title is not valid for a collection. It is not allowed to be null, empty or filled with whitespaces."); }
                 string payload = "{\"title\": \"" + collectionTitle + "\"}";
-                return await Api.TwitchPostGenericAsync<Models.v5.Collections.CollectionMetadata>($"/channels/{channelId}/collections", ApiVersion.v5, payload, accessToken: authToken).ConfigureAwait(false);
+                return Api.TwitchPostGenericAsync<Models.v5.Collections.CollectionMetadata>($"/channels/{channelId}/collections", ApiVersion.v5, payload, accessToken: authToken);
             }
             #endregion
             #region UpdateCollection
@@ -90,14 +90,14 @@ namespace TwitchLib.Api.Sections
             }
             #endregion
             #region AddItemToCollection
-            public async Task<Models.v5.Collections.CollectionItem> AddItemToCollectionAsync(string collectionId, string itemId, string itemType, string authToken = null)
+            public Task<Models.v5.Collections.CollectionItem> AddItemToCollectionAsync(string collectionId, string itemId, string itemType, string authToken = null)
             {
                 Api.Settings.DynamicScopeValidation(AuthScopes.Collections_Edit, authToken);
                 if (string.IsNullOrWhiteSpace(collectionId)) { throw new BadParameterException("The collection id is not valid for a collection. It is not allowed to be null, empty or filled with whitespaces."); }
                 if (string.IsNullOrWhiteSpace(itemId)) { throw new BadParameterException("The item id is not valid for a collection. It is not allowed to be null, empty or filled with whitespaces."); }
                 if (itemType != "video") { throw new BadParameterException($"The item_type {itemType} is not valid for a collection. Item type MUST be \"video\"."); }
                 string payload = "{\"id\": \"" + itemId + "\", \"type\": \"" + itemType + "\"}";
-                return await Api.TwitchPostGenericAsync<Models.v5.Collections.CollectionItem>($"/collections/{collectionId}/items", ApiVersion.v5, payload, accessToken: authToken).ConfigureAwait(false);
+                return Api.TwitchPostGenericAsync<Models.v5.Collections.CollectionItem>($"/collections/{collectionId}/items", ApiVersion.v5, payload, accessToken: authToken);
             }
             #endregion
             #region DeleteItemFromCollection

--- a/TwitchLib.Api/Sections/Communities.cs
+++ b/TwitchLib.Api/Sections/Communities.cs
@@ -20,18 +20,18 @@ namespace TwitchLib.Api.Sections
             {
             }
             #region GetCommunityByName
-            public async Task<Models.v5.Communities.Community> GetCommunityByNameAsync(string communityName)
+            public Task<Models.v5.Communities.Community> GetCommunityByNameAsync(string communityName)
             {
                 if (string.IsNullOrWhiteSpace(communityName)) { throw new BadParameterException("The community name is not valid. It is not allowed to be null, empty or filled with whitespaces."); }
                 var getParams = new List<KeyValuePair<string, string>> { new KeyValuePair<string, string>("name", communityName) };
-                return await Api.TwitchGetGenericAsync<Models.v5.Communities.Community>("/communities", ApiVersion.v5, getParams).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Communities.Community>("/communities", ApiVersion.v5, getParams);
             }
             #endregion
             #region GetCommunityByID
-            public async Task<Models.v5.Communities.Community> GetCommunityByIDAsync(string communityId)
+            public Task<Models.v5.Communities.Community> GetCommunityByIDAsync(string communityId)
             {
                 if (string.IsNullOrWhiteSpace(communityId)) { throw new BadParameterException("The community id is not valid. It is not allowed to be null, empty or filled with whitespaces."); }
-                return await Api.TwitchGetGenericAsync<Models.v5.Communities.Community>($"/communities/{communityId}", ApiVersion.v5).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Communities.Community>($"/communities/{communityId}", ApiVersion.v5);
             }
             #endregion
             #region UpdateCommunity
@@ -71,7 +71,7 @@ namespace TwitchLib.Api.Sections
             }
             #endregion
             #region GetTopCommunities
-            public async Task<Models.v5.Communities.TopCommunities> GetTopCommunitiesAsync(long? limit = null, string cursor = null)
+            public Task<Models.v5.Communities.TopCommunities> GetTopCommunitiesAsync(long? limit = null, string cursor = null)
             {
                 var getParams = new List<KeyValuePair<string, string>>();
                 if (limit.HasValue)
@@ -79,11 +79,11 @@ namespace TwitchLib.Api.Sections
                 if (!string.IsNullOrEmpty(cursor))
                     getParams.Add(new KeyValuePair<string, string>("cursor", cursor));
 
-                return await Api.TwitchGetGenericAsync<Models.v5.Communities.TopCommunities>("/communities/top", ApiVersion.v5, getParams).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Communities.TopCommunities>("/communities/top", ApiVersion.v5, getParams);
             }
             #endregion
             #region GetCommunityBannedUsers
-            public async Task<Models.v5.Communities.BannedUsers> GetCommunityBannedUsersAsync(string communityId, long? limit = null, string cursor = null, string authToken = null)
+            public Task<Models.v5.Communities.BannedUsers> GetCommunityBannedUsersAsync(string communityId, long? limit = null, string cursor = null, string authToken = null)
             {
                 Api.Settings.DynamicScopeValidation(AuthScopes.Communities_Moderate, authToken);
                 if (string.IsNullOrWhiteSpace(communityId)) { throw new BadParameterException("The community id is not valid. It is not allowed to be null, empty or filled with whitespaces."); }
@@ -93,7 +93,7 @@ namespace TwitchLib.Api.Sections
                 if (!string.IsNullOrEmpty(cursor))
                     getParams.Add(new KeyValuePair<string, string>("cursor", cursor));
                 
-                return await Api.TwitchGetGenericAsync<Models.v5.Communities.BannedUsers>($"/communities/{communityId}/bans", ApiVersion.v5, getParams, authToken).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Communities.BannedUsers>($"/communities/{communityId}/bans", ApiVersion.v5, getParams, authToken);
             }
             #endregion
             #region BanCommunityUser
@@ -151,11 +151,11 @@ namespace TwitchLib.Api.Sections
             }
             #endregion
             #region GetCommunityModerators
-            public async Task<Models.v5.Communities.Moderators> GetCommunityModeratorsAsync(string communityId, string authToken)
+            public Task<Models.v5.Communities.Moderators> GetCommunityModeratorsAsync(string communityId, string authToken)
             {
                 Api.Settings.DynamicScopeValidation(AuthScopes.Communities_Edit, authToken);
                 if (string.IsNullOrWhiteSpace(communityId)) { throw new BadParameterException("The community id is not valid. It is not allowed to be null, empty or filled with whitespaces."); }
-                return await Api.TwitchGetGenericAsync<Models.v5.Communities.Moderators>($"/communities/{communityId}/moderators", ApiVersion.v5, accessToken: authToken).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Communities.Moderators>($"/communities/{communityId}/moderators", ApiVersion.v5, accessToken: authToken);
             }
             #endregion
             #region AddCommunityModerator
@@ -177,11 +177,11 @@ namespace TwitchLib.Api.Sections
             }
             #endregion
             #region GetCommunityPermissions
-            public async Task<Dictionary<string, bool>> GetCommunityPermissionsAsync(string communityId, string authToken = null)
+            public Task<Dictionary<string, bool>> GetCommunityPermissionsAsync(string communityId, string authToken = null)
             {
                 Api.Settings.DynamicScopeValidation(AuthScopes.Any, authToken);
                 if (string.IsNullOrWhiteSpace(communityId)) { throw new BadParameterException("The community id is not valid. It is not allowed to be null, empty or filled with whitespaces."); }
-                return await Api.TwitchGetGenericAsync<Dictionary<string, bool>>($"/communities/{communityId}/permissions", ApiVersion.v5, accessToken: authToken).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Dictionary<string, bool>>($"/communities/{communityId}/permissions", ApiVersion.v5, accessToken: authToken);
             }
             #endregion
             #region ReportCommunityViolation
@@ -194,7 +194,7 @@ namespace TwitchLib.Api.Sections
             }
             #endregion
             #region GetCommunityTimedOutUsers
-            public async Task<Models.v5.Communities.TimedOutUsers> GetCommunityTimedOutUsersAsync(string communityId, long? limit = null, string cursor = null, string authToken = null)
+            public Task<Models.v5.Communities.TimedOutUsers> GetCommunityTimedOutUsersAsync(string communityId, long? limit = null, string cursor = null, string authToken = null)
             {
                 Api.Settings.DynamicScopeValidation(AuthScopes.Communities_Moderate, authToken);
                 if (string.IsNullOrWhiteSpace(communityId)) { throw new BadParameterException("The community id is not valid. It is not allowed to be null, empty or filled with whitespaces."); }
@@ -204,7 +204,7 @@ namespace TwitchLib.Api.Sections
                 if (!string.IsNullOrEmpty(cursor))
                     getParams.Add(new KeyValuePair<string, string>("cursor", cursor));
 
-                return await Api.TwitchGetGenericAsync<Models.v5.Communities.TimedOutUsers>($"/communities/{communityId}/timeouts", ApiVersion.v5, getParams, accessToken: authToken).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Communities.TimedOutUsers>($"/communities/{communityId}/timeouts", ApiVersion.v5, getParams, accessToken: authToken);
             }
             #endregion
             #region AddCommunityTimedOutUser

--- a/TwitchLib.Api/Sections/Games.cs
+++ b/TwitchLib.Api/Sections/Games.cs
@@ -22,7 +22,7 @@ namespace TwitchLib.Api.Sections
             {
             }
             #region GetTopGames
-            public async Task<Models.v5.Games.TopGames> GetTopGamesAsync(int? limit = null, int? offset = null)
+            public Task<Models.v5.Games.TopGames> GetTopGamesAsync(int? limit = null, int? offset = null)
             {
                 var getParams = new List<KeyValuePair<string, string>>();
                 if (limit.HasValue)
@@ -30,7 +30,7 @@ namespace TwitchLib.Api.Sections
                 if (offset.HasValue)
                     getParams.Add(new KeyValuePair<string, string>("offset", offset.Value.ToString()));
                 
-                return await Api.TwitchGetGenericAsync<Models.v5.Games.TopGames>("/games/top", ApiVersion.v5, getParams).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Games.TopGames>("/games/top", ApiVersion.v5, getParams);
             }
             #endregion
         }
@@ -41,7 +41,7 @@ namespace TwitchLib.Api.Sections
             {
             }
             #region GetGames
-            public async Task<Models.Helix.Games.GetGames.GetGamesResponse> GetGamesAsync(List<string> gameIds = null, List<string> gameNames = null)
+            public Task<Models.Helix.Games.GetGames.GetGamesResponse> GetGamesAsync(List<string> gameIds = null, List<string> gameNames = null)
             {
                 if (gameIds == null && gameNames == null ||
                     gameIds != null && gameIds.Count == 0 && gameNames == null ||
@@ -60,7 +60,7 @@ namespace TwitchLib.Api.Sections
                     foreach (var gameName in gameNames)
                         getParams.Add(new KeyValuePair<string, string>("name", gameName));
                 
-                return await Api.TwitchGetGenericAsync<Models.Helix.Games.GetGames.GetGamesResponse>("/games", ApiVersion.Helix, getParams).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.Helix.Games.GetGames.GetGamesResponse>("/games", ApiVersion.Helix, getParams);
             }
             #endregion
         }

--- a/TwitchLib.Api/Sections/Ingests.cs
+++ b/TwitchLib.Api/Sections/Ingests.cs
@@ -18,9 +18,9 @@ namespace TwitchLib.Api.Sections
             {
             }
             #region GetIngestServerList
-            public async Task<Models.v5.Ingests.Ingests> GetIngestServerListAsync()
+            public Task<Models.v5.Ingests.Ingests> GetIngestServerListAsync()
             {
-                return await Api.TwitchGetGenericAsync<Models.v5.Ingests.Ingests>("/ingests", ApiVersion.v5).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Ingests.Ingests>("/ingests", ApiVersion.v5);
             }
             #endregion
         }

--- a/TwitchLib.Api/Sections/Root.cs
+++ b/TwitchLib.Api/Sections/Root.cs
@@ -19,9 +19,9 @@ namespace TwitchLib.Api.Sections
             }
             #region GetRoot
 
-            public async Task<Models.v5.Root.Root> GetRootAsync(string authToken = null, string clientId = null)
+            public Task<Models.v5.Root.Root> GetRootAsync(string authToken = null, string clientId = null)
             {
-                return await Api.TwitchGetGenericAsync<Models.v5.Root.Root>("", ApiVersion.v5, accessToken: authToken, clientId: clientId).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Root.Root>("", ApiVersion.v5, accessToken: authToken, clientId: clientId);
             }
 
             #endregion

--- a/TwitchLib.Api/Sections/Search.cs
+++ b/TwitchLib.Api/Sections/Search.cs
@@ -20,7 +20,7 @@ namespace TwitchLib.Api.Sections
             {
             }
             #region SearchChannels
-            public async Task<Models.v5.Search.SearchChannels> SearchChannelsAsync(string encodedSearchQuery, int? limit = null, int? offset = null)
+            public Task<Models.v5.Search.SearchChannels> SearchChannelsAsync(string encodedSearchQuery, int? limit = null, int? offset = null)
             {
                 var getParams = new List<KeyValuePair<string, string>> { new KeyValuePair<string, string>("query", encodedSearchQuery) };
                 if (limit.HasValue)
@@ -28,11 +28,11 @@ namespace TwitchLib.Api.Sections
                 if (offset.HasValue)
                     getParams.Add(new KeyValuePair<string, string>("offset", offset.Value.ToString()));
 
-                return await Api.TwitchGetGenericAsync<Models.v5.Search.SearchChannels>("/search/channels", ApiVersion.v5, getParams).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Search.SearchChannels>("/search/channels", ApiVersion.v5, getParams);
             }
             #endregion
             #region SearchGames
-            public async Task<Models.v5.Search.SearchGames> SearchGamesAsync(string encodedSearchQuery, bool? live = null)
+            public Task<Models.v5.Search.SearchGames> SearchGamesAsync(string encodedSearchQuery, bool? live = null)
             {
                 var getParams = new List<KeyValuePair<string, string>>();
                 getParams.Add(new KeyValuePair<string, string>("query", encodedSearchQuery));
@@ -42,11 +42,11 @@ namespace TwitchLib.Api.Sections
                         ? new KeyValuePair<string, string>("live", "true")
                         : new KeyValuePair<string, string>("live", "false"));
                 }
-                return await Api.TwitchGetGenericAsync<Models.v5.Search.SearchGames>("/search/games", ApiVersion.v5, getParams).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Search.SearchGames>("/search/games", ApiVersion.v5, getParams);
             }
             #endregion
             #region SearchStreams
-            public async Task<Models.v5.Search.SearchStreams> SearchStreamsAsync(string encodedSearchQuery, int? limit = null, int? offset = null, bool? hls = null)
+            public Task<Models.v5.Search.SearchStreams> SearchStreamsAsync(string encodedSearchQuery, int? limit = null, int? offset = null, bool? hls = null)
             {
                 var getParams = new List<KeyValuePair<string, string>> { new KeyValuePair<string, string>("query", encodedSearchQuery) };
                 if (limit.HasValue)
@@ -56,7 +56,7 @@ namespace TwitchLib.Api.Sections
                 if (hls.HasValue)
                     getParams.Add(new KeyValuePair<string, string>("hls", hls.Value.ToString()));
 
-                return await Api.TwitchGetGenericAsync<Models.v5.Search.SearchStreams>("/search/streams", ApiVersion.v5, getParams).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Search.SearchStreams>("/search/streams", ApiVersion.v5, getParams);
             }
             #endregion
         }

--- a/TwitchLib.Api/Sections/Streams.cs
+++ b/TwitchLib.Api/Sections/Streams.cs
@@ -23,7 +23,7 @@ namespace TwitchLib.Api.Sections
             {
             }
             #region GetStreamByUser
-            public async Task<Models.v5.Streams.StreamByUser> GetStreamByUserAsync(string channelId, string streamType = null)
+            public Task<Models.v5.Streams.StreamByUser> GetStreamByUserAsync(string channelId, string streamType = null)
             {
                 if (string.IsNullOrWhiteSpace(channelId)) { throw new BadParameterException("The channel id is not valid for fetching streams. It is not allowed to be null, empty or filled with whitespaces."); }
                 var getParams = new List<KeyValuePair<string, string>>();
@@ -31,11 +31,11 @@ namespace TwitchLib.Api.Sections
                 {
                     getParams.Add(new KeyValuePair<string, string>("stream_type", streamType));
                 }
-                return await Api.TwitchGetGenericAsync<Models.v5.Streams.StreamByUser>($"/streams/{channelId}", ApiVersion.v5, getParams).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Streams.StreamByUser>($"/streams/{channelId}", ApiVersion.v5, getParams);
             }
             #endregion
             #region GetLiveStreams
-            public async Task<Models.v5.Streams.LiveStreams> GetLiveStreamsAsync(List<string> channelList = null, string game = null, string language = null, string streamType = null, int? limit = null, int? offset = null)
+            public Task<Models.v5.Streams.LiveStreams> GetLiveStreamsAsync(List<string> channelList = null, string game = null, string language = null, string streamType = null, int? limit = null, int? offset = null)
             {
                 var getParams = new List<KeyValuePair<string, string>>();
                 if (channelList != null && channelList.Count > 0)
@@ -51,20 +51,20 @@ namespace TwitchLib.Api.Sections
                 if (offset.HasValue)
                     getParams.Add(new KeyValuePair<string, string>("offset", offset.Value.ToString()));
                 
-                return await Api.TwitchGetGenericAsync<Models.v5.Streams.LiveStreams>("/streams", ApiVersion.v5, getParams).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Streams.LiveStreams>("/streams", ApiVersion.v5, getParams);
             }
             #endregion
             #region GetStreamsSummary
-            public async Task<Models.v5.Streams.StreamsSummary> GetStreamsSummaryAsync(string game = null)
+            public Task<Models.v5.Streams.StreamsSummary> GetStreamsSummaryAsync(string game = null)
             {
                 var getParams = new List<KeyValuePair<string, string>>();
                 if (game != null)
                     getParams.Add(new KeyValuePair<string, string>("game", game));
-                return await Api.TwitchGetGenericAsync<Models.v5.Streams.StreamsSummary>("/streams/summary", ApiVersion.v5, getParams).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Streams.StreamsSummary>("/streams/summary", ApiVersion.v5, getParams);
             }
             #endregion
             #region GetFeaturedStreams
-            public async Task<Models.v5.Streams.FeaturedStreams> GetFeaturedStreamAsync(int? limit = null, int? offset = null)
+            public Task<Models.v5.Streams.FeaturedStreams> GetFeaturedStreamAsync(int? limit = null, int? offset = null)
             {
                 var getParams = new List<KeyValuePair<string, string>>();
                 if (limit.HasValue)
@@ -72,11 +72,11 @@ namespace TwitchLib.Api.Sections
                 if (offset.HasValue)
                     getParams.Add(new KeyValuePair<string, string>("offset", offset.Value.ToString()));
                 
-                return await Api.TwitchGetGenericAsync<Models.v5.Streams.FeaturedStreams>("/streams/featured", ApiVersion.v5, getParams).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Streams.FeaturedStreams>("/streams/featured", ApiVersion.v5, getParams);
             }
             #endregion
             #region GetFollowedStreams
-            public async Task<Models.v5.Streams.FollowedStreams> GetFollowedStreamsAsync(string streamType = null, int? limit = null, int? offset = null, string authToken = null)
+            public Task<Models.v5.Streams.FollowedStreams> GetFollowedStreamsAsync(string streamType = null, int? limit = null, int? offset = null, string authToken = null)
             {
                 Api.Settings.DynamicScopeValidation(AuthScopes.User_Read, authToken);
                 var getParams = new List<KeyValuePair<string, string>>();
@@ -87,7 +87,7 @@ namespace TwitchLib.Api.Sections
                 if (offset != null)
                     getParams.Add(new KeyValuePair<string, string>("offset", offset.ToString()));
 
-                return await Api.TwitchGetGenericAsync<Models.v5.Streams.FollowedStreams>("/streams/followed", ApiVersion.v5, getParams, authToken).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Streams.FollowedStreams>("/streams/followed", ApiVersion.v5, getParams, authToken);
             }
             #endregion
             #region GetUptime
@@ -118,7 +118,7 @@ namespace TwitchLib.Api.Sections
             public Helix(TwitchAPI api) : base(api)
             {
             }
-            public async Task<Models.Helix.Streams.GetStreams.GetStreamsResponse> GetStreamsAsync(string after = null, List<string> communityIds = null, int first = 20, List<string> gameIds = null, List<string> languages = null, string type = "all", List<string> userIds = null, List<string> userLogins = null)
+            public Task<Models.Helix.Streams.GetStreams.GetStreamsResponse> GetStreamsAsync(string after = null, List<string> communityIds = null, int first = 20, List<string> gameIds = null, List<string> languages = null, string type = "all", List<string> userIds = null, List<string> userLogins = null)
             {
                 var getParams = new List<KeyValuePair<string, string>> { new KeyValuePair<string, string>("first", first.ToString()), new KeyValuePair<string, string>("type", type) };
                 if (after != null)
@@ -139,10 +139,10 @@ namespace TwitchLib.Api.Sections
                     foreach (var userLogin in userLogins)
                         getParams.Add(new KeyValuePair<string, string>("user_login", userLogin));
                 
-                return await Api.TwitchGetGenericAsync<Models.Helix.Streams.GetStreams.GetStreamsResponse>($"/streams", ApiVersion.Helix, getParams).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.Helix.Streams.GetStreams.GetStreamsResponse>($"/streams", ApiVersion.Helix, getParams);
             }
 
-            public async Task<Models.Helix.StreamsMetadata.GetStreamsMetadataResponse> GetStreamsMetadataAsync(string after = null, List<string> communityIds = null, int first = 20, List<string> gameIds = null, List<string> languages = null, string type = "all", List<string> userIds = null, List<string> userLogins = null)
+            public Task<Models.Helix.StreamsMetadata.GetStreamsMetadataResponse> GetStreamsMetadataAsync(string after = null, List<string> communityIds = null, int first = 20, List<string> gameIds = null, List<string> languages = null, string type = "all", List<string> userIds = null, List<string> userLogins = null)
             {
                 var getParams = new List<KeyValuePair<string, string>> { new KeyValuePair<string, string>("first", first.ToString()), new KeyValuePair<string, string>("type", type) };
                 if (after != null)
@@ -163,7 +163,7 @@ namespace TwitchLib.Api.Sections
                     foreach (var userLogin in userLogins)
                         getParams.Add(new KeyValuePair<string, string>("user_login", userLogin));
 
-                return await Api.TwitchGetGenericAsync<Models.Helix.StreamsMetadata.GetStreamsMetadataResponse>("/streams/metadata", ApiVersion.Helix, getParams).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.Helix.StreamsMetadata.GetStreamsMetadataResponse>("/streams/metadata", ApiVersion.Helix, getParams);
             }
         }
     }

--- a/TwitchLib.Api/Sections/Teams.cs
+++ b/TwitchLib.Api/Sections/Teams.cs
@@ -20,7 +20,7 @@ namespace TwitchLib.Api.Sections
             {
             }
             #region GetAllTeams
-            public async Task<Models.v5.Teams.AllTeams> GetAllTeamsAsync(int? limit = null, int? offset = null)
+            public Task<Models.v5.Teams.AllTeams> GetAllTeamsAsync(int? limit = null, int? offset = null)
             {
                 var getParams = new List<KeyValuePair<string, string>>();
                 if (limit.HasValue)
@@ -28,14 +28,14 @@ namespace TwitchLib.Api.Sections
                 if (offset.HasValue)
                     getParams.Add(new KeyValuePair<string, string>("offset", offset.Value.ToString()));
                 
-                return await Api.TwitchGetGenericAsync<Models.v5.Teams.AllTeams>("/teams", ApiVersion.v5, getParams).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Teams.AllTeams>("/teams", ApiVersion.v5, getParams);
             }
             #endregion
             #region GetTeam
-            public async Task<Models.v5.Teams.Team> GetTeamAsync(string teamName)
+            public Task<Models.v5.Teams.Team> GetTeamAsync(string teamName)
             {
                 if (string.IsNullOrWhiteSpace(teamName)) { throw new BadParameterException("The team name is not valid for fetching teams. It is not allowed to be null, empty or filled with whitespaces."); }
-                return await Api.TwitchGetGenericAsync<Models.v5.Teams.Team>($"/teams/{teamName}", ApiVersion.v5).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Teams.Team>($"/teams/{teamName}", ApiVersion.v5);
             }
             #endregion
         }

--- a/TwitchLib.Api/Sections/ThirdParty.cs
+++ b/TwitchLib.Api/Sections/ThirdParty.cs
@@ -29,14 +29,14 @@ namespace TwitchLib.Api.Sections
             {
             }
             #region GetUsernameChanges
-            public async Task<List<Models.ThirdParty.UsernameChange.UsernameChangeListing>> GetUsernameChangesAsync(string username)
+            public Task<List<Models.ThirdParty.UsernameChange.UsernameChangeListing>> GetUsernameChangesAsync(string username)
             {
                 var getParams = new List<KeyValuePair<string, string>>
                 {
                     new KeyValuePair<string, string>("q", username),
                     new KeyValuePair<string, string>("format", "json")
                 };
-                return await Api.GetGenericAsync<List<Models.ThirdParty.UsernameChange.UsernameChangeListing>>("https://twitch-tools.rootonline.de/username_changelogs_search.php", getParams, null, ApiVersion.Void).ConfigureAwait(false);
+                return Api.GetGenericAsync<List<Models.ThirdParty.UsernameChange.UsernameChangeListing>>("https://twitch-tools.rootonline.de/username_changelogs_search.php", getParams, null, ApiVersion.Void);
             }
             #endregion
         }
@@ -46,7 +46,7 @@ namespace TwitchLib.Api.Sections
             public modLookup(TwitchAPI api) : base(api)
             {
             }
-            public async Task<Models.ThirdParty.ModLookup.ModLookupResponse> GetChannelsModdedForByNameAsync(string username, int offset = 0, int limit = 100, bool useTls12 = true)
+            public Task<Models.ThirdParty.ModLookup.ModLookupResponse> GetChannelsModdedForByNameAsync(string username, int offset = 0, int limit = 100, bool useTls12 = true)
             {
                 if (useTls12)
                     ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
@@ -55,21 +55,21 @@ namespace TwitchLib.Api.Sections
                     new KeyValuePair<string, string>("offset", offset.ToString()),
                     new KeyValuePair<string, string>("limit", limit.ToString())
                 };
-                return await Api.GetGenericAsync<Models.ThirdParty.ModLookup.ModLookupResponse>($"https://twitchstuff.3v.fi/modlookup/api/user/{username}").ConfigureAwait(false);
+                return Api.GetGenericAsync<Models.ThirdParty.ModLookup.ModLookupResponse>($"https://twitchstuff.3v.fi/modlookup/api/user/{username}");
             }
 
-            public async Task<Models.ThirdParty.ModLookup.TopResponse> GetChannelsModdedForByTopAsync(bool useTls12 = true)
+            public Task<Models.ThirdParty.ModLookup.TopResponse> GetChannelsModdedForByTopAsync(bool useTls12 = true)
             {
                 if (useTls12)
                     ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
-                return await Api.GetGenericAsync<Models.ThirdParty.ModLookup.TopResponse>("https://twitchstuff.3v.fi/modlookup/api/top");
+                return Api.GetGenericAsync<Models.ThirdParty.ModLookup.TopResponse>("https://twitchstuff.3v.fi/modlookup/api/top");
             }
 
-            public async Task<Models.ThirdParty.ModLookup.StatsResponse> GetChannelsModdedForStatsAsync(bool useTls12 = true)
+            public Task<Models.ThirdParty.ModLookup.StatsResponse> GetChannelsModdedForStatsAsync(bool useTls12 = true)
             {
                 if (useTls12)
                     ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
-                return await Api.GetGenericAsync<Models.ThirdParty.ModLookup.StatsResponse>("https://twitchstuff.3v.fi/modlookup/api/stats").ConfigureAwait(false);
+                return Api.GetGenericAsync<Models.ThirdParty.ModLookup.StatsResponse>("https://twitchstuff.3v.fi/modlookup/api/stats");
             }
         }
 

--- a/TwitchLib.Api/Sections/Undocumented.cs
+++ b/TwitchLib.Api/Sections/Undocumented.cs
@@ -47,7 +47,7 @@ namespace TwitchLib.Api.Sections
         }
         #endregion
         #region GetComments
-        public async Task<Models.Undocumented.Comments.CommentsPage> GetCommentsPageAsync(string videoId, int? contentOffsetSeconds = null, string cursor = null)
+        public Task<Models.Undocumented.Comments.CommentsPage> GetCommentsPageAsync(string videoId, int? contentOffsetSeconds = null, string cursor = null)
         {
             var getParams = new List<KeyValuePair<string, string>>();
             if (string.IsNullOrWhiteSpace(videoId))
@@ -62,7 +62,7 @@ namespace TwitchLib.Api.Sections
             {
                 getParams.Add(new KeyValuePair<string, string>("cursor", cursor));
             }
-            return await Api.GetGenericAsync<Models.Undocumented.Comments.CommentsPage>($"https://api.twitch.tv/kraken/videos/{videoId}/comments", getParams).ConfigureAwait(false);
+            return Api.GetGenericAsync<Models.Undocumented.Comments.CommentsPage>($"https://api.twitch.tv/kraken/videos/{videoId}/comments", getParams);
         }
 
         public async Task<List<Models.Undocumented.Comments.CommentsPage>> GetAllCommentsAsync(string videoId)
@@ -76,52 +76,52 @@ namespace TwitchLib.Api.Sections
         }
         #endregion
         #region GetTwitchPrimeOffers
-        public async Task<Models.Undocumented.TwitchPrimeOffers.TwitchPrimeOffers> GetTwitchPrimeOffersAsync()
+        public Task<Models.Undocumented.TwitchPrimeOffers.TwitchPrimeOffers> GetTwitchPrimeOffersAsync()
         {
             var getParams = new List<KeyValuePair<string, string>> { new KeyValuePair<string, string>("on_site", "1") };
-            return await Api.GetGenericAsync<Models.Undocumented.TwitchPrimeOffers.TwitchPrimeOffers>("https://api.twitch.tv/api/premium/offers", getParams).ConfigureAwait(false);
+            return Api.GetGenericAsync<Models.Undocumented.TwitchPrimeOffers.TwitchPrimeOffers>("https://api.twitch.tv/api/premium/offers", getParams);
         }
         #endregion
         #region GetChannelHosts
-        public async Task<Models.Undocumented.Hosting.ChannelHostsResponse> GetChannelHostsAsync(string channelId)
+        public Task<Models.Undocumented.Hosting.ChannelHostsResponse> GetChannelHostsAsync(string channelId)
         {
             var getParams = new List<KeyValuePair<string, string>> { new KeyValuePair<string, string>("include_logins", "1"), new KeyValuePair<string, string>("target", channelId) };
-            return await Api.GetSimpleGenericAsync<Models.Undocumented.Hosting.ChannelHostsResponse>("https://tmi.twitch.tv/hosts", getParams);
+            return Api.GetSimpleGenericAsync<Models.Undocumented.Hosting.ChannelHostsResponse>("https://tmi.twitch.tv/hosts", getParams);
         }
         #endregion
         #region GetChatProperties
-        public async Task<Models.Undocumented.ChatProperties.ChatProperties> GetChatPropertiesAsync(string channelName)
+        public Task<Models.Undocumented.ChatProperties.ChatProperties> GetChatPropertiesAsync(string channelName)
         {
-            return await Api.GetGenericAsync<Models.Undocumented.ChatProperties.ChatProperties>($"https://api.twitch.tv/api/channels/{channelName}/chat_properties");
+            return Api.GetGenericAsync<Models.Undocumented.ChatProperties.ChatProperties>($"https://api.twitch.tv/api/channels/{channelName}/chat_properties");
         }
         #endregion
         #region GetChannelPanels
-        public async Task<Models.Undocumented.ChannelPanels.Panel[]> GetChannelPanelsAsync(string channelName)
+        public Task<Models.Undocumented.ChannelPanels.Panel[]> GetChannelPanelsAsync(string channelName)
         {
-            return await Api.GetGenericAsync<Models.Undocumented.ChannelPanels.Panel[]>($"https://api.twitch.tv/api/channels/{channelName}/panels");
+            return Api.GetGenericAsync<Models.Undocumented.ChannelPanels.Panel[]>($"https://api.twitch.tv/api/channels/{channelName}/panels");
         }
         #endregion
         #region GetCSMaps
-        public async Task<Models.Undocumented.CSMaps.CSMapsResponse> GetCSMapsAsync()
+        public Task<Models.Undocumented.CSMaps.CSMapsResponse> GetCSMapsAsync()
         {
-            return await Api.GetGenericAsync<Models.Undocumented.CSMaps.CSMapsResponse>("https://api.twitch.tv/api/cs/maps");
+            return Api.GetGenericAsync<Models.Undocumented.CSMaps.CSMapsResponse>("https://api.twitch.tv/api/cs/maps");
         }
         #endregion
         #region GetCSStreams
-        public async Task<Models.Undocumented.CSStreams.CSStreams> GetCSStreamsAsync(int limit = 25, int offset = 0)
+        public Task<Models.Undocumented.CSStreams.CSStreams> GetCSStreamsAsync(int limit = 25, int offset = 0)
         {
             var getParams = new List<KeyValuePair<string, string>>
             {
                 new KeyValuePair<string, string>("limit", limit.ToString()),
                 new KeyValuePair<string, string>("offset", offset.ToString())
             };
-            return await Api.GetGenericAsync<Models.Undocumented.CSStreams.CSStreams>("https://api.twitch.tv/api/cs", getParams);
+            return Api.GetGenericAsync<Models.Undocumented.CSStreams.CSStreams>("https://api.twitch.tv/api/cs", getParams);
         }
         #endregion
         #region GetRecentMessages
-        public async Task<Models.Undocumented.RecentMessages.RecentMessagesResponse> GetRecentMessagesAsync(string channelId)
+        public Task<Models.Undocumented.RecentMessages.RecentMessagesResponse> GetRecentMessagesAsync(string channelId)
         {
-            return await Api.GetGenericAsync<Models.Undocumented.RecentMessages.RecentMessagesResponse>($"https://tmi.twitch.tv/api/rooms/{channelId}/recent_messages");
+            return Api.GetGenericAsync<Models.Undocumented.RecentMessages.RecentMessagesResponse>($"https://tmi.twitch.tv/api/rooms/{channelId}/recent_messages");
         }
         #endregion
         #region GetChatters
@@ -143,18 +143,18 @@ namespace TwitchLib.Api.Sections
         }
         #endregion
         #region GetRecentChannelEvents
-        public async Task<Models.Undocumented.RecentEvents.RecentEvents> GetRecentChannelEventsAsync(string channelId)
+        public Task<Models.Undocumented.RecentEvents.RecentEvents> GetRecentChannelEventsAsync(string channelId)
         {
-            return await Api.GetGenericAsync<Models.Undocumented.RecentEvents.RecentEvents>($"https://api.twitch.tv/bits/channels/{channelId}/events/recent");
+            return Api.GetGenericAsync<Models.Undocumented.RecentEvents.RecentEvents>($"https://api.twitch.tv/bits/channels/{channelId}/events/recent");
         }
         #endregion
         #region GetChatUser
-        public async Task<Models.Undocumented.ChatUser.ChatUserResponse> GetChatUserAsync(string userId, string channelId = null)
+        public Task<Models.Undocumented.ChatUser.ChatUserResponse> GetChatUserAsync(string userId, string channelId = null)
         {
             if (channelId != null)
-                return await Api.GetGenericAsync<Models.Undocumented.ChatUser.ChatUserResponse>($"https://api.twitch.tv/kraken/users/{userId}/chat/channels/{channelId}");
+                return Api.GetGenericAsync<Models.Undocumented.ChatUser.ChatUserResponse>($"https://api.twitch.tv/kraken/users/{userId}/chat/channels/{channelId}");
 
-            return await Api.GetGenericAsync<Models.Undocumented.ChatUser.ChatUserResponse>($"https://api.twitch.tv/kraken/users/{userId}/chat/");
+            return Api.GetGenericAsync<Models.Undocumented.ChatUser.ChatUserResponse>($"https://api.twitch.tv/kraken/users/{userId}/chat/");
         }
         #endregion
         #region IsUsernameAvailable

--- a/TwitchLib.Api/Sections/Users.cs
+++ b/TwitchLib.Api/Sections/Users.cs
@@ -23,54 +23,54 @@ namespace TwitchLib.Api.Sections
             {
             }
             #region GetUsersByName
-            public async Task<Models.v5.Users.Users> GetUsersByNameAsync(List<string> usernames)
+            public Task<Models.v5.Users.Users> GetUsersByNameAsync(List<string> usernames)
             {
                 if (usernames == null || usernames.Count == 0) { throw new BadParameterException("The username list is not valid. It is not allowed to be null or empty."); }
                 var getParams = new List<KeyValuePair<string, string>> { new KeyValuePair<string, string>("login", string.Join(",", usernames)) };
-                return await Api.TwitchGetGenericAsync<Models.v5.Users.Users>("/users", ApiVersion.v5, getParams).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Users.Users>("/users", ApiVersion.v5, getParams);
             }
             #endregion
             #region GetUser
-            public async Task<Models.v5.Users.UserAuthed> GetUserAsync(string authToken = null)
+            public Task<Models.v5.Users.UserAuthed> GetUserAsync(string authToken = null)
             {
                 Api.Settings.DynamicScopeValidation(AuthScopes.User_Read, authToken);
-                return await Api.TwitchGetGenericAsync<Models.v5.Users.UserAuthed>("/user", ApiVersion.v5, accessToken: authToken).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Users.UserAuthed>("/user", ApiVersion.v5, accessToken: authToken);
             }
             #endregion
             #region GetUserByID
-            public async Task<Models.v5.Users.User> GetUserByIDAsync(string userId)
+            public Task<Models.v5.Users.User> GetUserByIDAsync(string userId)
             {
                 if (string.IsNullOrWhiteSpace(userId)) { throw new BadParameterException("The user id is not valid. It is not allowed to be null, empty or filled with whitespaces."); }
-                return await Api.TwitchGetGenericAsync<Models.v5.Users.User>($"/users/{userId}", ApiVersion.v5).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Users.User>($"/users/{userId}", ApiVersion.v5);
             }
             #endregion
             #region GetUserByName
-            public async Task<Models.v5.Users.Users> GetUserByNameAsync(string username)
+            public Task<Models.v5.Users.Users> GetUserByNameAsync(string username)
             {
                 if (string.IsNullOrEmpty(username)) { throw new BadParameterException("The username is not valid."); }
                 var getParams = new List<KeyValuePair<string, string>> { new KeyValuePair<string, string>("login", username) };
-                return await Api.TwitchGetGenericAsync<Models.v5.Users.Users>("/users", ApiVersion.v5, getParams).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Users.Users>("/users", ApiVersion.v5, getParams);
             }
             #endregion
             #region GetUserEmotes
-            public async Task<Models.v5.Users.UserEmotes> GetUserEmotesAsync(string userId, string authToken = null)
+            public Task<Models.v5.Users.UserEmotes> GetUserEmotesAsync(string userId, string authToken = null)
             {
                 Api.Settings.DynamicScopeValidation(AuthScopes.User_Subscriptions, authToken);
                 if (string.IsNullOrWhiteSpace(userId)) { throw new BadParameterException("The user id is not valid. It is not allowed to be null, empty or filled with whitespaces."); }
-                return await Api.TwitchGetGenericAsync<Models.v5.Users.UserEmotes>($"/users/{userId}/emotes", ApiVersion.v5, accessToken: authToken).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Users.UserEmotes>($"/users/{userId}/emotes", ApiVersion.v5, accessToken: authToken);
             }
             #endregion
             #region CheckUserSubscriptionByChannel
-            public async Task<Models.v5.Subscriptions.Subscription> CheckUserSubscriptionByChannelAsync(string userId, string channelId, string authToken = null)
+            public Task<Models.v5.Subscriptions.Subscription> CheckUserSubscriptionByChannelAsync(string userId, string channelId, string authToken = null)
             {
                 Api.Settings.DynamicScopeValidation(AuthScopes.User_Subscriptions, authToken);
                 if (string.IsNullOrWhiteSpace(userId)) { throw new BadParameterException("The user id is not valid. It is not allowed to be null, empty or filled with whitespaces."); }
                 if (string.IsNullOrWhiteSpace(channelId)) { throw new BadParameterException("The channel id is not valid. It is not allowed to be null, empty or filled with whitespaces."); }
-                return await Api.TwitchGetGenericAsync<Models.v5.Subscriptions.Subscription>($"/users/{userId}/subscriptions/{channelId}", ApiVersion.v5, accessToken: authToken).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Subscriptions.Subscription>($"/users/{userId}/subscriptions/{channelId}", ApiVersion.v5, accessToken: authToken);
             }
             #endregion
             #region GetUserFollows
-            public async Task<Models.v5.Users.UserFollows> GetUserFollowsAsync(string userId, int? limit = null, int? offset = null, string direction = null, string sortby = null)
+            public Task<Models.v5.Users.UserFollows> GetUserFollowsAsync(string userId, int? limit = null, int? offset = null, string direction = null, string sortby = null)
             {
                 if (string.IsNullOrWhiteSpace(userId)) { throw new BadParameterException("The user id is not valid. It is not allowed to be null, empty or filled with whitespaces."); }
                 var getParams = new List<KeyValuePair<string, string>>();
@@ -83,15 +83,15 @@ namespace TwitchLib.Api.Sections
                 if (!string.IsNullOrEmpty(sortby) && (sortby == "created_at" || sortby == "last_broadcast" || sortby == "login"))
                     getParams.Add(new KeyValuePair<string, string>("sortby", sortby));
                 
-                return await Api.TwitchGetGenericAsync < Models.v5.Users.UserFollows>($"/users/{userId}/follows/channels", ApiVersion.v5, getParams).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync < Models.v5.Users.UserFollows>($"/users/{userId}/follows/channels", ApiVersion.v5, getParams);
             }
             #endregion
             #region CheckUserFollowsByChannel
-            public async Task<Models.v5.Users.UserFollow> CheckUserFollowsByChannelAsync(string userId, string channelId)
+            public Task<Models.v5.Users.UserFollow> CheckUserFollowsByChannelAsync(string userId, string channelId)
             {
                 if (string.IsNullOrWhiteSpace(userId)) { throw new BadParameterException("The user id is not valid. It is not allowed to be null, empty or filled with whitespaces."); }
                 if (string.IsNullOrWhiteSpace(channelId)) { throw new BadParameterException("The channel id is not valid. It is not allowed to be null, empty or filled with whitespaces."); }
-                return await Api.TwitchGetGenericAsync<Models.v5.Users.UserFollow>($"/users/{userId}/follows/channels/{channelId}", ApiVersion.v5).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Users.UserFollow>($"/users/{userId}/follows/channels/{channelId}", ApiVersion.v5);
             }
             #endregion
             #region UserFollowsChannel
@@ -111,13 +111,13 @@ namespace TwitchLib.Api.Sections
             }
             #endregion
             #region FollowChannel
-            public async Task<Models.v5.Users.UserFollow> FollowChannelAsync(string userId, string channelId, bool? notifications = null, string authToken = null)
+            public Task<Models.v5.Users.UserFollow> FollowChannelAsync(string userId, string channelId, bool? notifications = null, string authToken = null)
             {
                 Api.Settings.DynamicScopeValidation(AuthScopes.User_Follows_Edit, authToken);
                 if (string.IsNullOrWhiteSpace(userId)) { throw new BadParameterException("The user id is not valid. It is not allowed to be null, empty or filled with whitespaces."); }
                 if (string.IsNullOrWhiteSpace(channelId)) { throw new BadParameterException("The channel id is not valid. It is not allowed to be null, empty or filled with whitespaces."); }
                 var optionalRequestBody = notifications.HasValue ? "{\"notifications\": " + notifications.Value + "}" : null;
-                return await Api.TwitchPutGenericAsync<Models.v5.Users.UserFollow>($"/users/{userId}/follows/channels/{channelId}", ApiVersion.v5, optionalRequestBody, accessToken: authToken).ConfigureAwait(false);
+                return Api.TwitchPutGenericAsync<Models.v5.Users.UserFollow>($"/users/{userId}/follows/channels/{channelId}", ApiVersion.v5, optionalRequestBody, accessToken: authToken);
             }
             #endregion
             #region UnfollowChannel
@@ -130,7 +130,7 @@ namespace TwitchLib.Api.Sections
             }
             #endregion
             #region GetUserBlockList
-            public async Task<Models.v5.Users.UserBlocks> GetUserBlockListAsync(string userId, int? limit = null, int? offset = null, string authToken = null)
+            public Task<Models.v5.Users.UserBlocks> GetUserBlockListAsync(string userId, int? limit = null, int? offset = null, string authToken = null)
             {
                 Api.Settings.DynamicScopeValidation(AuthScopes.User_Blocks_Read, authToken);
                 if (string.IsNullOrWhiteSpace(userId)) { throw new BadParameterException("The user id is not valid. It is not allowed to be null, empty or filled with whitespaces."); }
@@ -140,16 +140,16 @@ namespace TwitchLib.Api.Sections
                 if (offset.HasValue)
                     getParams.Add(new KeyValuePair<string, string>("offset", offset.Value.ToString()));
                 
-                return await Api.TwitchGetGenericAsync<Models.v5.Users.UserBlocks>($"/users/{userId}/blocks", ApiVersion.v5, getParams, authToken).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Users.UserBlocks>($"/users/{userId}/blocks", ApiVersion.v5, getParams, authToken);
             }
             #endregion
             #region BlockUser
-            public async Task<Models.v5.Users.UserBlock> BlockUserAsync(string sourceUserId, string targetUserId, string authToken = null)
+            public Task<Models.v5.Users.UserBlock> BlockUserAsync(string sourceUserId, string targetUserId, string authToken = null)
             {
                 Api.Settings.DynamicScopeValidation(AuthScopes.User_Blocks_Edit, authToken);
                 if (string.IsNullOrWhiteSpace(sourceUserId)) { throw new BadParameterException("The source user id is not valid. It is not allowed to be null, empty or filled with whitespaces."); }
                 if (string.IsNullOrWhiteSpace(targetUserId)) { throw new BadParameterException("The target user id is not valid. It is not allowed to be null, empty or filled with whitespaces."); }
-                return await Api.TwitchPutGenericAsync<Models.v5.Users.UserBlock>($"/users/{sourceUserId}/blocks/{targetUserId}", ApiVersion.v5, null, accessToken: authToken).ConfigureAwait(false);
+                return Api.TwitchPutGenericAsync<Models.v5.Users.UserBlock>($"/users/{sourceUserId}/blocks/{targetUserId}", ApiVersion.v5, null, accessToken: authToken);
             }
             #endregion
             #region UnblockUser
@@ -172,10 +172,10 @@ namespace TwitchLib.Api.Sections
             }
             #endregion
             #region CheckUserConnectionToViewerHeartbeatService
-            public async Task<Models.v5.ViewerHeartbeatService.VHSConnectionCheck> CheckUserConnectionToViewerHeartbeatServiceAsync(string authToken = null)
+            public Task<Models.v5.ViewerHeartbeatService.VHSConnectionCheck> CheckUserConnectionToViewerHeartbeatServiceAsync(string authToken = null)
             {
                 Api.Settings.DynamicScopeValidation(AuthScopes.User_Read, authToken);
-                return await Api.TwitchGetGenericAsync<Models.v5.ViewerHeartbeatService.VHSConnectionCheck>("/user/vhs", ApiVersion.v5, accessToken: authToken).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.ViewerHeartbeatService.VHSConnectionCheck>("/user/vhs", ApiVersion.v5, accessToken: authToken);
             }
             #endregion
             #region DeleteUserConnectionToViewerHeartbeatService
@@ -195,7 +195,7 @@ namespace TwitchLib.Api.Sections
             {
             }
 
-            public async Task<Models.Helix.Users.GetUsers.GetUsersResponse> GetUsersAsync(List<string> ids = null, List<string> logins = null, string accessToken = null)
+            public Task<Models.Helix.Users.GetUsers.GetUsersResponse> GetUsersAsync(List<string> ids = null, List<string> logins = null, string accessToken = null)
             {
                 var getParams = new List<KeyValuePair<string, string>>();
                 if (ids != null && ids.Count > 0)
@@ -208,10 +208,10 @@ namespace TwitchLib.Api.Sections
                     foreach (var login in logins)
                         getParams.Add(new KeyValuePair<string, string>("login", login));
                 }
-                return await Api.TwitchGetGenericAsync<Models.Helix.Users.GetUsers.GetUsersResponse>("/users", ApiVersion.Helix, getParams, accessToken).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.Helix.Users.GetUsers.GetUsersResponse>("/users", ApiVersion.Helix, getParams, accessToken);
             }
 
-            public async Task<Models.Helix.Users.GetUsersFollows.GetUsersFollowsResponse> GetUsersFollowsAsync(string after = null, string before = null, int first = 20, string fromId = null, string toId = null)
+            public Task<Models.Helix.Users.GetUsersFollows.GetUsersFollowsResponse> GetUsersFollowsAsync(string after = null, string before = null, int first = 20, string fromId = null, string toId = null)
             {
                 var getParams = new List<KeyValuePair<string, string>> { new KeyValuePair<string, string>("first", first.ToString()) };
                 if (after != null)
@@ -223,7 +223,7 @@ namespace TwitchLib.Api.Sections
                 if (toId != null)
                     getParams.Add(new KeyValuePair<string, string>("to_id", toId));
                 
-                return await Api.TwitchGetGenericAsync<Models.Helix.Users.GetUsersFollows.GetUsersFollowsResponse>("/users/follows", ApiVersion.Helix, getParams).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.Helix.Users.GetUsersFollows.GetUsersFollowsResponse>("/users/follows", ApiVersion.Helix, getParams);
             }
 
             public async Task PutUsersAsync(string description, string accessToken = null)

--- a/TwitchLib.Api/Sections/Videos.cs
+++ b/TwitchLib.Api/Sections/Videos.cs
@@ -25,14 +25,14 @@ namespace TwitchLib.Api.Sections
             {
             }
             #region GetVideo
-            public async Task<Models.v5.Videos.Video> GetVideoAsync(string videoId)
+            public Task<Models.v5.Videos.Video> GetVideoAsync(string videoId)
             {
                 if (string.IsNullOrWhiteSpace(videoId)) { throw new BadParameterException("The video id is not valid. It is not allowed to be null, empty or filled with whitespaces."); }
-                return await Api.TwitchGetGenericAsync<Models.v5.Videos.Video>($"/videos/{videoId}", ApiVersion.v5).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Videos.Video>($"/videos/{videoId}", ApiVersion.v5);
             }
             #endregion
             #region GetTopVideos
-            public async Task<Models.v5.Videos.TopVideos> GetTopVideosAsync(int? limit = null, int? offset = null, string game = null, string period = null, List<string> broadcastType = null, List<string> language = null, string sort = null)
+            public Task<Models.v5.Videos.TopVideos> GetTopVideosAsync(int? limit = null, int? offset = null, string game = null, string period = null, List<string> broadcastType = null, List<string> language = null, string sort = null)
             {
                 var getParams = new List<KeyValuePair<string, string>>();
                 if (limit.HasValue)
@@ -59,11 +59,11 @@ namespace TwitchLib.Api.Sections
                 if (!string.IsNullOrWhiteSpace(sort) && (sort == "views" || sort == "time"))
                     getParams.Add(new KeyValuePair<string, string>("sort", sort));
                 
-                return await Api.TwitchGetGenericAsync<Models.v5.Videos.TopVideos>("/videos/top", ApiVersion.v5, getParams).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Videos.TopVideos>("/videos/top", ApiVersion.v5, getParams);
             }
             #endregion
             #region GetFollowedVideos
-            public async Task<Models.v5.Videos.FollowedVideos> GetFollowedVideosAsync(int? limit = null, int? offset = null, List<string> broadcastType = null, List<string> language = null, string sort = null, string authToken = null)
+            public Task<Models.v5.Videos.FollowedVideos> GetFollowedVideosAsync(int? limit = null, int? offset = null, List<string> broadcastType = null, List<string> language = null, string sort = null, string authToken = null)
             {
                 Api.Settings.DynamicScopeValidation(AuthScopes.User_Read, authToken);
                 var getParams = new List<KeyValuePair<string, string>>();
@@ -87,7 +87,7 @@ namespace TwitchLib.Api.Sections
                 if (!string.IsNullOrWhiteSpace(sort) && (sort == "views" || sort == "time"))
                     getParams.Add(new KeyValuePair<string, string>("sort", sort));
                 
-                return await Api.TwitchGetGenericAsync<Models.v5.Videos.FollowedVideos>("/videos/followed", ApiVersion.v5, getParams, authToken).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.v5.Videos.FollowedVideos>("/videos/followed", ApiVersion.v5, getParams, authToken);
             }
             #endregion
             #region UploadVideo
@@ -101,7 +101,7 @@ namespace TwitchLib.Api.Sections
             }
             #endregion
             #region UpdateVideo
-            public async Task<Models.v5.Videos.Video> UpdateVideoAsync(string videoId, string description = null, string game = null, string language = null, string tagList = null, string title = null, string authToken = null)
+            public Task<Models.v5.Videos.Video> UpdateVideoAsync(string videoId, string description = null, string game = null, string language = null, string tagList = null, string title = null, string authToken = null)
             {
                 Api.Settings.DynamicScopeValidation(AuthScopes.Channel_Editor, authToken);
                 if (string.IsNullOrWhiteSpace(videoId)) { throw new BadParameterException("The video id is not valid. It is not allowed to be null, empty or filled with whitespaces."); }
@@ -117,7 +117,7 @@ namespace TwitchLib.Api.Sections
                 if (!string.IsNullOrWhiteSpace(title))
                     getParams.Add(new KeyValuePair<string, string>("title", title));
                 
-                return await Api.TwitchPutGenericAsync<Models.v5.Videos.Video>($"/videos/{videoId}", ApiVersion.v5, null, getParams, authToken).ConfigureAwait(false);
+                return Api.TwitchPutGenericAsync<Models.v5.Videos.Video>($"/videos/{videoId}", ApiVersion.v5, null, getParams, authToken);
             }
             #endregion
             #region DeleteVideo
@@ -130,7 +130,7 @@ namespace TwitchLib.Api.Sections
             #endregion
 
 
-            private async Task<Models.v5.UploadVideo.UploadVideoListing> CreateVideoAsync(string channelId, string title, string description = null, string game = null, string language = "en", string tagList = "", Viewable viewable = Viewable.Public, DateTime? viewableAt = null, string accessToken = null)
+            private Task<Models.v5.UploadVideo.UploadVideoListing> CreateVideoAsync(string channelId, string title, string description = null, string game = null, string language = "en", string tagList = "", Viewable viewable = Viewable.Public, DateTime? viewableAt = null, string accessToken = null)
             {
                 var getParams = new List<KeyValuePair<string, string>>
                 {
@@ -152,7 +152,7 @@ namespace TwitchLib.Api.Sections
                 // Should do it?
                 if (viewableAt.HasValue)
                     getParams.Add(new KeyValuePair<string, string>("viewable_at", viewableAt.Value.ToRfc3339String()));
-                return await Api.TwitchPostGenericAsync<Models.v5.UploadVideo.UploadVideoListing>("/videos", ApiVersion.v5, null, getParams, accessToken).ConfigureAwait(false);
+                return Api.TwitchPostGenericAsync<Models.v5.UploadVideo.UploadVideoListing>("/videos", ApiVersion.v5, null, getParams, accessToken);
             }
 
             private const long MAX_VIDEO_SIZE = 10737418240;
@@ -211,7 +211,7 @@ namespace TwitchLib.Api.Sections
             public Helix(TwitchAPI api) : base(api)
             {
             }
-            public async Task<Models.Helix.Videos.GetVideos.GetVideosResponse> GetVideoAsync(List<string> videoIds = null, string userId = null, string gameId = null, string after = null, string before = null, int first = 20, string language = null, Period period = Period.All, VideoSort sort = VideoSort.Time, VideoType type = VideoType.All)
+            public Task<Models.Helix.Videos.GetVideos.GetVideosResponse> GetVideoAsync(List<string> videoIds = null, string userId = null, string gameId = null, string after = null, string before = null, int first = 20, string language = null, Period period = Period.All, VideoSort sort = VideoSort.Time, VideoType type = VideoType.All)
             {
                 if ((videoIds == null || videoIds.Count == 0) && userId == null && gameId == null)
                     throw new BadParameterException("VideoIds, userId, and gameId cannot all be null/empty.");
@@ -288,7 +288,7 @@ namespace TwitchLib.Api.Sections
                     }
                 }
 
-                return await Api.TwitchGetGenericAsync<Models.Helix.Videos.GetVideos.GetVideosResponse>("/videos", ApiVersion.Helix, getParams).ConfigureAwait(false);
+                return Api.TwitchGetGenericAsync<Models.Helix.Videos.GetVideos.GetVideosResponse>("/videos", ApiVersion.Helix, getParams);
             }
         }
     }

--- a/TwitchLib.Api/Sections/Webhooks.cs
+++ b/TwitchLib.Api/Sections/Webhooks.cs
@@ -21,31 +21,31 @@ namespace TwitchLib.Api.Sections
             {
             }
             #region UserFollowsSomeone
-            public async Task<bool> UserFollowsSomeoneAsync(string callbackUrl, Enums.WebhookCallMode mode, string userInitiatorId, TimeSpan? duration = null, string signingSecret = null)
+            public Task<bool> UserFollowsSomeoneAsync(string callbackUrl, Enums.WebhookCallMode mode, string userInitiatorId, TimeSpan? duration = null, string signingSecret = null)
             {
                 var leaseSeconds = (int)ValidateTimespan(duration).TotalSeconds;
-                return await PerformWebhookRequestAsync(mode, $"https://api.twitch.tv/helix/users/follows?first=1&from_id={userInitiatorId}", callbackUrl, leaseSeconds, signingSecret);
+                return PerformWebhookRequestAsync(mode, $"https://api.twitch.tv/helix/users/follows?first=1&from_id={userInitiatorId}", callbackUrl, leaseSeconds, signingSecret);
             }
             #endregion
             #region UserReceivesFollower
-            public async Task<bool> UserReceivesFollowerAsync(string callbackUrl, Enums.WebhookCallMode mode, string userReceiverId, TimeSpan? duration = null, string signingSecret = null)
+            public Task<bool> UserReceivesFollowerAsync(string callbackUrl, Enums.WebhookCallMode mode, string userReceiverId, TimeSpan? duration = null, string signingSecret = null)
             {
                 var leaseSeconds = (int)ValidateTimespan(duration).TotalSeconds;
-                return await PerformWebhookRequestAsync(mode, $"https://api.twitch.tv/helix/users/follows?first=1&to_id={userReceiverId}", callbackUrl, leaseSeconds, signingSecret);
+                return PerformWebhookRequestAsync(mode, $"https://api.twitch.tv/helix/users/follows?first=1&to_id={userReceiverId}", callbackUrl, leaseSeconds, signingSecret);
             }
             #endregion
             #region UserFollowsUser
-            public async Task<bool> UserFollowsUserAsync(string callbackUrl, Enums.WebhookCallMode mode, string userInitiator, string userReceiverId, TimeSpan? duration = null, string signingSecret = null)
+            public Task<bool> UserFollowsUserAsync(string callbackUrl, Enums.WebhookCallMode mode, string userInitiator, string userReceiverId, TimeSpan? duration = null, string signingSecret = null)
             {
                 var leaseSeconds = (int)ValidateTimespan(duration).TotalSeconds;
-                return await PerformWebhookRequestAsync(mode, $"https://api.twitch.tv/helix/users/follows?to_id={userReceiverId}", callbackUrl, leaseSeconds, signingSecret);
+                return PerformWebhookRequestAsync(mode, $"https://api.twitch.tv/helix/users/follows?to_id={userReceiverId}", callbackUrl, leaseSeconds, signingSecret);
             }
             #endregion
             #region StreamUpDown
-            public async Task<bool> StreamUpDownAsync(string callbackUrl, Enums.WebhookCallMode mode, string userId, TimeSpan? duration = null, string signingSecret = null)
+            public Task<bool> StreamUpDownAsync(string callbackUrl, Enums.WebhookCallMode mode, string userId, TimeSpan? duration = null, string signingSecret = null)
             {
                 var leaseSeconds = (int)ValidateTimespan(duration).TotalSeconds;
-                return await PerformWebhookRequestAsync(mode, $"https://api.twitch.tv/helix/streams?user_id={userId}", callbackUrl, leaseSeconds, signingSecret);
+                return PerformWebhookRequestAsync(mode, $"https://api.twitch.tv/helix/streams?user_id={userId}", callbackUrl, leaseSeconds, signingSecret);
             }
             #endregion
 

--- a/TwitchLib.Api/TwitchAPI.cs
+++ b/TwitchLib.Api/TwitchAPI.cs
@@ -101,63 +101,63 @@ namespace TwitchLib.Api
         #region Requests
 
         #region TwitchResources
-        internal async Task<T> TwitchGetGenericAsync<T>(string resource, ApiVersion api, List <KeyValuePair<string, string>> getParams = null, string accessToken = null, string clientId = null, string customBase = null)
+        internal Task<T> TwitchGetGenericAsync<T>(string resource, ApiVersion api, List <KeyValuePair<string, string>> getParams = null, string accessToken = null, string clientId = null, string customBase = null)
         {
             string url = ConstructResourceUrl(resource, getParams, api, customBase);
-            return await _rateLimiter.Perform(async () =>
+            return _rateLimiter.Perform(async () =>
                 JsonConvert.DeserializeObject<T>((await GeneralRequestAsync(url, HttpMethod.Get, null, accessToken, api, clientId)).Value, _twitchLibJsonDeserializer));
         }
 
-        internal async Task<string> TwitchDeleteAsync(string resource, ApiVersion api, List<KeyValuePair<string, string>> getParams = null, string accessToken = null, string clientId = null, string customBase = null)
+        internal Task<string> TwitchDeleteAsync(string resource, ApiVersion api, List<KeyValuePair<string, string>> getParams = null, string accessToken = null, string clientId = null, string customBase = null)
         {
-            return await _rateLimiter.Perform(async () =>
+            return _rateLimiter.Perform(async () =>
             {
                 string url = ConstructResourceUrl(resource, getParams, api, customBase);
                 return (await GeneralRequestAsync(url, HttpMethod.Delete, null, accessToken, api, clientId)).Value; });
         }
 
-        internal async Task<T> TwitchPostGenericAsync<T>(string resource, ApiVersion api, string payload, List<KeyValuePair<string, string>> getParams = null, string accessToken = null, string clientId = null, string customBase = null)
+        internal Task<T> TwitchPostGenericAsync<T>(string resource, ApiVersion api, string payload, List<KeyValuePair<string, string>> getParams = null, string accessToken = null, string clientId = null, string customBase = null)
         {
             string url = ConstructResourceUrl(resource, getParams, api, customBase);
-            return await _rateLimiter.Perform(async () =>
+            return _rateLimiter.Perform(async () =>
                 JsonConvert.DeserializeObject<T>((await GeneralRequestAsync(url, HttpMethod.Post, payload, accessToken, api, clientId)).Value, _twitchLibJsonDeserializer));
         }
 
-        internal async Task<T> TwitchPostGenericModelAsync<T>(string resource, ApiVersion api, Models.RequestModel model, string accessToken = null, string clientId = null, string customBase = null)
+        internal Task<T> TwitchPostGenericModelAsync<T>(string resource, ApiVersion api, Models.RequestModel model, string accessToken = null, string clientId = null, string customBase = null)
         {
             string url = ConstructResourceUrl(resource, api: api, overrideUrl: customBase);
-            return await _rateLimiter.Perform(async () => JsonConvert.DeserializeObject<T>(model != null
+            return _rateLimiter.Perform(async () => JsonConvert.DeserializeObject<T>(model != null
                 ? (await GeneralRequestAsync(url, HttpMethod.Post, _jsonSerializer.SerializeObject(model), accessToken, api, clientId)).Value
                 : (await GeneralRequestAsync(url, HttpMethod.Post, "", accessToken, api)).Value, _twitchLibJsonDeserializer));
         }
 
-        internal async Task<T> TwitchDeleteGenericAsync<T>(string resource, ApiVersion api, string accessToken = null, string clientId = null, string customBase = null)
+        internal Task<T> TwitchDeleteGenericAsync<T>(string resource, ApiVersion api, string accessToken = null, string clientId = null, string customBase = null)
         {
             string url = ConstructResourceUrl(resource, null, api, customBase);
-            return await _rateLimiter.Perform(async () =>
+            return _rateLimiter.Perform(async () =>
                 JsonConvert.DeserializeObject<T>((await GeneralRequestAsync(url, HttpMethod.Delete, null, accessToken, api, clientId)).Value, _twitchLibJsonDeserializer));
         }
 
-        internal async Task<T> TwitchPutGenericAsync<T>(string resource, ApiVersion api, string payload, List<KeyValuePair<string, string>> getParams = null, string accessToken = null, string clientId = null, string customBase = null)
+        internal Task<T> TwitchPutGenericAsync<T>(string resource, ApiVersion api, string payload, List<KeyValuePair<string, string>> getParams = null, string accessToken = null, string clientId = null, string customBase = null)
         {
             string url = ConstructResourceUrl(resource, getParams, api, customBase);
-            return await _rateLimiter.Perform(async () =>
+            return _rateLimiter.Perform(async () =>
                 JsonConvert.DeserializeObject<T>((await GeneralRequestAsync(url, HttpMethod.Put, payload, accessToken, api, clientId)).Value, _twitchLibJsonDeserializer));
         }
 
-        internal async Task<string> TwitchPutAsync(string resource, ApiVersion api, string payload, List<KeyValuePair<string, string>> getParams = null, string accessToken = null, string clientId = null, string customBase = null)
+        internal Task<string> TwitchPutAsync(string resource, ApiVersion api, string payload, List<KeyValuePair<string, string>> getParams = null, string accessToken = null, string clientId = null, string customBase = null)
         {
             string url = ConstructResourceUrl(resource, getParams, api, customBase);
-            return await _rateLimiter.Perform(async () =>
+            return _rateLimiter.Perform(async () =>
             {
                 return (await GeneralRequestAsync(url, HttpMethod.Put, payload, accessToken, api, clientId)).Value;
             });
         }
 
-        internal async Task<KeyValuePair<int, string>> TwitchPostAsync(string resource, ApiVersion api, string payload, List<KeyValuePair<string, string>> getParams = null, string accessToken = null, string clientId = null, string customBase = null)
+        internal Task<KeyValuePair<int, string>> TwitchPostAsync(string resource, ApiVersion api, string payload, List<KeyValuePair<string, string>> getParams = null, string accessToken = null, string clientId = null, string customBase = null)
         {
             string url = ConstructResourceUrl(resource, getParams, api, customBase);
-            return await _rateLimiter.Perform(async () => await GeneralRequestAsync(url, HttpMethod.Post, payload, accessToken, api, clientId));
+            return _rateLimiter.Perform(() => GeneralRequestAsync(url, HttpMethod.Post, payload, accessToken, api, clientId));
         }
 
         private string ConstructResourceUrl(string resource = null, List<KeyValuePair<string, string>> getParams = null, ApiVersion api = ApiVersion.v5, string overrideUrl = null)
@@ -199,7 +199,7 @@ namespace TwitchLib.Api
 
         #region GET
         #region GetGenericAsync
-        internal async Task<T> GetGenericAsync<T>(string url, List<KeyValuePair<string, string>> getParams = null, string accessToken = null, ApiVersion api = ApiVersion.v5, string clientId = null)
+        internal Task<T> GetGenericAsync<T>(string url, List<KeyValuePair<string, string>> getParams = null, string accessToken = null, ApiVersion api = ApiVersion.v5, string clientId = null)
         {
             if (getParams != null)
             {
@@ -211,12 +211,12 @@ namespace TwitchLib.Api
                         url += $"&{getParams[i].Key}={Uri.EscapeDataString(getParams[i].Value)}";
                 }
             }
-            return await _rateLimiter.Perform(async () =>
+            return _rateLimiter.Perform(async () =>
                 JsonConvert.DeserializeObject<T>((await GeneralRequestAsync(url, HttpMethod.Get, null, accessToken, api, clientId)).Value, _twitchLibJsonDeserializer));
         }
         #endregion
         #region GetSimpleGenericAsync
-        internal async Task<T> GetSimpleGenericAsync<T>(string url, List<KeyValuePair<string, string>> getParams = null)
+        internal Task<T> GetSimpleGenericAsync<T>(string url, List<KeyValuePair<string, string>> getParams = null)
         {
 
             if (getParams != null)
@@ -229,7 +229,7 @@ namespace TwitchLib.Api
                         url += $"&{getParams[i].Key}={Uri.EscapeDataString(getParams[i].Value)}";
                 }
             }
-            return await _rateLimiter.Perform(async () => JsonConvert.DeserializeObject<T>(await SimpleRequestAsync(url), _twitchLibJsonDeserializer));
+            return _rateLimiter.Perform(async () => JsonConvert.DeserializeObject<T>(await SimpleRequestAsync(url), _twitchLibJsonDeserializer));
         }
         #endregion
         #endregion
@@ -291,7 +291,7 @@ namespace TwitchLib.Api
         #endregion
         #region SimpleRequestAsync
         // credit: https://stackoverflow.com/questions/14290988/populate-and-return-entities-from-downloadstringcompleted-handler-in-windows-pho
-        private async Task<string> SimpleRequestAsync(string url)
+        private Task<string> SimpleRequestAsync(string url)
         {
             var tcs = new TaskCompletionSource<string>();
             var client = new WebClient();
@@ -299,7 +299,7 @@ namespace TwitchLib.Api
             client.DownloadStringCompleted += DownloadStringCompletedEventHandler;
             client.DownloadString(new Uri(url));
 
-            return await tcs.Task;
+            return tcs.Task;
 
             // local function
             void DownloadStringCompletedEventHandler(object sender, DownloadStringCompletedEventArgs args)


### PR DESCRIPTION
Hey there!

When calling an `async` task and you're just returning it, there's no reason to `await` it. We can simply proxy the task back and create no intermediate async state machine. It's far more efficient if this can be avoided, as it can in all the cases here.