### PR TITLE
Fixed parsing game id for v5 api.

### DIFF
--- a/TwitchLib.Api.V5.Models/Games/Game.cs
+++ b/TwitchLib.Api.V5.Models/Games/Game.cs
@@ -5,7 +5,7 @@ namespace TwitchLib.Api.V5.Models.Games
     public class Game
     {
         #region Id
-        [JsonProperty(PropertyName = "id")]
+        [JsonProperty(PropertyName = "_id")]
         public int Id { get; protected set; }
         #endregion
         #region Viewers


### PR DESCRIPTION
The game id should be prefixed with an underscore otherwise it will fall back to default(int) (a.k.a. 0)