### PR TITLE
Implemented missing request parameters in Helix Clips class

### DIFF
--- a/TwitchLib.Api.Helix/Clips.cs
+++ b/TwitchLib.Api.Helix/Clips.cs
@@ -16,7 +16,7 @@ namespace TwitchLib.Api.Helix
 
         #region GetClip
 
-        public Task<GetClipResponse> GetClipAsync(string clipId = null, string gameId = null, string broadcasterId = null, string before = null, string after = null, int first = 20)
+        public Task<GetClipResponse> GetClipAsync(string clipId = null, string gameId = null, string broadcasterId = null, string startedAt = null, string endedAt = null, string before = null, string after = null, int first = 20)
         {
             if (first < 0 || first > 100)
                 throw new BadParameterException("'first' must between 0 (inclusive) and 100 (inclusive).");
@@ -32,6 +32,10 @@ namespace TwitchLib.Api.Helix
             if (getParams.Count != 1)
                 throw new BadParameterException("One of the following parameters must be set: clipId, gameId, broadcasterId. Only one is allowed to be set.");
 
+            if (startedAt != null)
+                getParams.Add(new KeyValuePair<string, string>("started_at", startedAt));
+            if (endedAt != null)
+                getParams.Add(new KeyValuePair<string, string>("ended_at", endedAt));
             if (before != null)
                 getParams.Add(new KeyValuePair<string, string>("before", before));
             if (after != null)


### PR DESCRIPTION
- Added missing GET clip query parameters (started_at, ended_at)

Official documentation states there extra parameters "started_at" and "ended_at" which are not currently integrated in the TwitchLib.Api.Helix.Clips class. 

Proof can be found on the [official documentation clip section.](https://dev.twitch.tv/docs/api/reference/#get-clips)

I have tested this implementation within my own code, and the "started_at" and "ended_at" parameters both function properly. 