### PR TITLE
Implemented missing request parameters in Helix Clips class

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,79 @@
 API component of TwitchLib.
 
 For a general overview and example, refer to https://github.com/TwitchLib/TwitchLib/blob/master/README.md
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using TwitchLib.Api;
+using TwitchLib.Api.Services;
+using TwitchLib.Api.Services.Events;
+using TwitchLib.Api.Services.Events.LiveStreamMonitor;
+
+namespace Example
+{
+    public class LiveMonitor
+    { 
+        private LiveStreamMonitorService Monitor;
+        private TwitchAPI API;
+
+        public LiveMonitor()
+        {
+            Task.Run(() => ConfigLiveMonitorAsync());
+        }
+
+        private async Task ConfigLiveMonitorAsync()
+        {
+            API = new TwitchAPI();                
+                
+            API.Settings.ClientId = "";
+            API.Settings.AccessToken = "";               
+
+            Monitor = new LiveStreamMonitorService(API, 60);
+            
+            List<string> lst = new List<string>{ "ID1", "ID2" };
+            Monitor.SetChannelsById(lst);            
+
+            Monitor.OnStreamOnline += Monitor_OnStreamOnline;
+            Monitor.OnStreamOffline += Monitor_OnStreamOffline;
+            Monitor.OnStreamUpdate += Monitor_OnStreamUpdate;
+
+            Monitor.OnServiceStarted += Monitor_OnServiceStarted;
+            Monitor.OnChannelsSet += Monitor_OnChannelsSet;
+
+
+            Monitor.Start(); //Keep at the end!
+
+            await Task.Delay(-1);
+
+        }
+
+        private void Monitor_OnStreamOnline(object sender, OnStreamOnlineArgs e)
+        {
+            throw new NotImplementedException();
+        }
+
+        private void Monitor_OnStreamUpdate(object sender, OnStreamUpdateArgs e)
+        {
+            throw new NotImplementedException();
+        }
+
+        private void Monitor_OnStreamOffline(object sender, OnStreamOfflineArgs e)
+        {
+            throw new NotImplementedException();
+        }
+
+        private void Monitor_OnChannelsSet(object sender, OnChannelsSetArgs e)       
+        {
+            throw new NotImplementedException();
+        }
+
+        private void Monitor_OnServiceStarted(object sender, OnServiceStartedArgs e)
+        {
+            throw new NotImplementedException();
+        }        
+    }
+}
+```

--- a/TwitchLib.Api.Core.Interfaces/Clips/IVOD.cs
+++ b/TwitchLib.Api.Core.Interfaces/Clips/IVOD.cs
@@ -4,5 +4,7 @@
     {
          string Id { get; }
          string Url { get; }
+         int Offset { get; }
+         string PreviewImageUrl { get; }
     }
 }

--- a/TwitchLib.Api.Helix/Clips.cs
+++ b/TwitchLib.Api.Helix/Clips.cs
@@ -1,8 +1,11 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
 using System.Threading.Tasks;
 using TwitchLib.Api.Core;
 using TwitchLib.Api.Core.Enums;
 using TwitchLib.Api.Core.Exceptions;
+using TwitchLib.Api.Core.Extensions.System;
 using TwitchLib.Api.Core.Interfaces;
 using TwitchLib.Api.Helix.Models.Clips.CreateClip;
 using TwitchLib.Api.Helix.Models.Clips.GetClip;
@@ -16,7 +19,7 @@ namespace TwitchLib.Api.Helix
 
         #region GetClip
 
-        public Task<GetClipResponse> GetClipAsync(string clipId = null, string gameId = null, string broadcasterId = null, string startedAt = null, string endedAt = null, string before = null, string after = null, int first = 20)
+        public Task<GetClipResponse> GetClipAsync(string clipId = null, string gameId = null, string broadcasterId = null, string before = null, string after = null, DateTime? startedAt = null, DateTime? endedAt = null, int first = 20)
         {
             if (first < 0 || first > 100)
                 throw new BadParameterException("'first' must between 0 (inclusive) and 100 (inclusive).");
@@ -32,10 +35,13 @@ namespace TwitchLib.Api.Helix
             if (getParams.Count != 1)
                 throw new BadParameterException("One of the following parameters must be set: clipId, gameId, broadcasterId. Only one is allowed to be set.");
 
+            if (startedAt == null && endedAt != null)
+                throw new BadParameterException("The ended_at parameter cannot be used without the started_at parameter. Please include both parameters!");
+
             if (startedAt != null)
-                getParams.Add(new KeyValuePair<string, string>("started_at", startedAt));
+                getParams.Add(new KeyValuePair<string, string>("started_at", startedAt.Value.ToRfc3339String()));
             if (endedAt != null)
-                getParams.Add(new KeyValuePair<string, string>("ended_at", endedAt));
+                getParams.Add(new KeyValuePair<string, string>("ended_at", endedAt.Value.ToRfc3339String()));
             if (before != null)
                 getParams.Add(new KeyValuePair<string, string>("before", before));
             if (after != null)

--- a/TwitchLib.Api.Helix/Clips.cs
+++ b/TwitchLib.Api.Helix/Clips.cs
@@ -16,7 +16,7 @@ namespace TwitchLib.Api.Helix
 
         #region GetClip
 
-        public Task<GetClipResponse> GetClipAsync(string clipId = null, string gameId = null, string broadcasterId = null, string before = null, string after = null, int first = 20)
+        public Task<GetClipResponse> GetClipAsync(string clipId = null, string gameId = null, string broadcasterId = null, string startedAt = null, string endedAt = null, string before = null, string after = null, int first = 20)
         {
             if (first < 0 || first > 100)
                 throw new BadParameterException("'first' must between 0 (inclusive) and 100 (inclusive).");
@@ -32,6 +32,10 @@ namespace TwitchLib.Api.Helix
             if (getParams.Count != 1)
                 throw new BadParameterException("One of the following parameters must be set: clipId, gameId, broadcasterId. Only one is allowed to be set.");
 
+            if (startedAt != null)
+                getParams.Add(new KeyValuePair<string, string>("started_at", startedAt));
+            if (endedAt != null)
+                getParams.Add(new KeyValuePair<string, string>("ended_at", endedAt));
             if (before != null)
                 getParams.Add(new KeyValuePair<string, string>("before", before));
             if (after != null)

--- a/TwitchLib.Api.V5.Models/Clips/Clip.cs
+++ b/TwitchLib.Api.V5.Models/Clips/Clip.cs
@@ -4,7 +4,7 @@ using TwitchLib.Api.Core.Interfaces.Clips;
 
 namespace TwitchLib.Api.V5.Models.Clips
 {
-    public class Clip : IClip
+    public class Clip
     {
         [JsonProperty(PropertyName = "broadcaster")]
         public Broadcaster Broadcaster { get; protected set; }
@@ -33,6 +33,6 @@ namespace TwitchLib.Api.V5.Models.Clips
         [JsonProperty(PropertyName = "views")]
         public int Views { get; protected set; }
         [JsonProperty(PropertyName = "vod")]
-        public IVOD VOD { get; protected set; }
+        public VOD VOD { get; protected set; }
     }
 }

--- a/TwitchLib.Api.V5.Models/Clips/VOD.cs
+++ b/TwitchLib.Api.V5.Models/Clips/VOD.cs
@@ -9,5 +9,9 @@ namespace TwitchLib.Api.V5.Models.Clips
         public string Id { get; protected set; }
         [JsonProperty(PropertyName = "url")]
         public string Url { get; protected set; }
+        [JsonProperty(PropertyName = "offset")]
+        public int Offset { get; protected set; }
+        [JsonProperty(PropertyName = "preview_image_url")]
+        public string PreviewImageUrl { get; protected set; }
     }
 }

--- a/TwitchLib.Api.V5.Models/Games/Game.cs
+++ b/TwitchLib.Api.V5.Models/Games/Game.cs
@@ -5,7 +5,7 @@ namespace TwitchLib.Api.V5.Models.Games
     public class Game
     {
         #region Id
-        [JsonProperty(PropertyName = "id")]
+        [JsonProperty(PropertyName = "_id")]
         public int Id { get; protected set; }
         #endregion
         #region Viewers


### PR DESCRIPTION
- Added missing GET clip query parameters (started_at, ended_at)

Official documentation states there extra parameters "started_at" and "ended_at" which are not currently integrated in the TwitchLib.Api.Helix.Clips class.

Proof can be found on the [official documentation clip section.](https://dev.twitch.tv/docs/api/reference/#get-clips)

I have tested this implementation within my own code, and the "started_at" and "ended_at" parameters both function properly.