### PR TITLE
Add two more fields...the Helix follow API returns

### DIFF
--- a/TwitchLib.Api.Helix.Models/Users/Follow.cs
+++ b/TwitchLib.Api.Helix.Models/Users/Follow.cs
@@ -8,11 +8,11 @@ namespace TwitchLib.Api.Helix.Models.Users
         [JsonProperty(PropertyName = "from_id")]
         public string FromUserId { get; protected set; }
         [JsonProperty(PropertyName = "from_name")]
-        public string FromName { get; protected set; }
+        public string FromUserName { get; protected set; }
         [JsonProperty(PropertyName = "to_id")]
         public string ToUserId { get; protected set; }
         [JsonProperty(PropertyName = "to_name")]
-        public string ToName { get; protected set; }
+        public string ToUserName { get; protected set; }
         [JsonProperty(PropertyName = "followed_at")]
         public DateTime FollowedAt { get; protected set; }
     }

--- a/TwitchLib.Api.Helix.Models/Users/Follow.cs
+++ b/TwitchLib.Api.Helix.Models/Users/Follow.cs
@@ -7,8 +7,12 @@ namespace TwitchLib.Api.Helix.Models.Users
     {
         [JsonProperty(PropertyName = "from_id")]
         public string FromUserId { get; protected set; }
+        [JsonProperty(PropertyName = "from_name")]
+        public string FromName { get; protected set; }
         [JsonProperty(PropertyName = "to_id")]
         public string ToUserId { get; protected set; }
+        [JsonProperty(PropertyName = "to_name")]
+        public string ToName { get; protected set; }
         [JsonProperty(PropertyName = "followed_at")]
         public DateTime FollowedAt { get; protected set; }
     }


### PR DESCRIPTION
Adding FromName and ToName because it's free and the helix api returns them.   Why spend another API call to look these IDs up when we get both anyway...  for free.  The model only captures and exposes only the Id.
example;
{"total":2,"data":[         {"from_id":"x","from_name":"mycooltwitchNamemonkaS","to_id":"999995","to_name":"RebootTech","followed_at":"2019-04-20T00:41:59Z"},{"from_id":"myothercooltwitchNamemonkaS","from_name":"99999996","to_id":"x","to_name":"RebootTech","followed_at":"2019-04-18T00:39:55Z"}
],"pagination":{"cursor":"cursorhash_blablah"}}