### PR TITLE
support for Entitlements/GetCodeStatus, Entitlements/RedeemCode, and code cleanup

### DIFF
--- a/TwitchLib.Api.Core.Enums/CodeStatusEnum.cs
+++ b/TwitchLib.Api.Core.Enums/CodeStatusEnum.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.Api.Core.Enums
+{
+    public enum CodeStatusEnum
+    {
+        SUCCESSFULLY_REDEEMED,
+        ALREADY_CLAIMED,
+        EXPIRED,
+        USER_NOT_ELIGIBLE,
+        NOT_FOUND,
+        INACTIVE,
+        UNUSED,
+        INCORRECT_FORMAT,
+        INTERNAL_ERROR
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Entitlements/CreateEntitlementGrantsUploadURL/CreateEntitlementGrantsUploadURLResponse.cs
+++ b/TwitchLib.Api.Helix.Models/Entitlements/CreateEntitlementGrantsUploadURL/CreateEntitlementGrantsUploadURLResponse.cs
@@ -1,6 +1,6 @@
 ﻿using Newtonsoft.Json;
 
-namespace TwitchLib.Api.Helix.Models.Entitlements
+namespace TwitchLib.Api.Helix.Models.Entitlements.CreateEntitlementGrantsUploadURL
 {
     public class CreateEntitlementGrantsUploadUrlResponse
     {

--- a/TwitchLib.Api.Helix.Models/Entitlements/CreateEntitlementGrantsUploadURL/UploadURL.cs
+++ b/TwitchLib.Api.Helix.Models/Entitlements/CreateEntitlementGrantsUploadURL/UploadURL.cs
@@ -1,6 +1,6 @@
 ﻿using Newtonsoft.Json;
 
-namespace TwitchLib.Api.Helix.Models.Entitlements
+namespace TwitchLib.Api.Helix.Models.Entitlements.CreateEntitlementGrantsUploadURL
 {
     public class UploadUrl
     {

--- a/TwitchLib.Api.Helix.Models/Entitlements/GetCodeStatus/GetCodeStatusResponse.cs
+++ b/TwitchLib.Api.Helix.Models/Entitlements/GetCodeStatus/GetCodeStatusResponse.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.Api.Helix.Models.Entitlements.GetCodeStatus
+{
+    public class GetCodeStatusResponse
+    {
+        [JsonProperty(PropertyName = "data")]
+        public Status[] Data { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Entitlements/RedeemCode/RedeemCodeResponse.cs
+++ b/TwitchLib.Api.Helix.Models/Entitlements/RedeemCode/RedeemCodeResponse.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.Api.Helix.Models.Entitlements.RedeemCode
+{
+    public class RedeemCodeResponse
+    {
+        [JsonProperty(PropertyName = "data")]
+        public Status[] Data { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Entitlements/Status.cs
+++ b/TwitchLib.Api.Helix.Models/Entitlements/Status.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using TwitchLib.Api.Core.Enums;
+
+namespace TwitchLib.Api.Helix.Models.Entitlements
+{
+    public class Status
+    {
+        [JsonProperty(PropertyName = "code")]
+        public string Code { get; protected set; }
+        [JsonProperty(PropertyName = "status")]
+        public CodeStatusEnum StatusEnum { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix/Entitlements.cs
+++ b/TwitchLib.Api.Helix/Entitlements.cs
@@ -4,7 +4,9 @@ using TwitchLib.Api.Core;
 using TwitchLib.Api.Core.Enums;
 using TwitchLib.Api.Core.Exceptions;
 using TwitchLib.Api.Core.Interfaces;
-using TwitchLib.Api.Helix.Models.Entitlements;
+using TwitchLib.Api.Helix.Models.Entitlements.CreateEntitlementGrantsUploadURL;
+using TwitchLib.Api.Helix.Models.Entitlements.GetCodeStatus;
+using TwitchLib.Api.Helix.Models.Entitlements.RedeemCode;
 
 namespace TwitchLib.Api.Helix
 {
@@ -16,15 +18,15 @@ namespace TwitchLib.Api.Helix
 
         #region CreateEntitlementGrantsUploadURL
 
-        public Task<CreateEntitlementGrantsUploadUrlResponse> CreateEntitlementGrantsUploadUrl(string manifestId, EntitleGrantType type, string url = null, string applicationAccessToken = null)
+        public Task<CreateEntitlementGrantsUploadUrlResponse> CreateEntitlementGrantsUploadUrlAsync(string manifestId, EntitleGrantType type, string url = null, string applicationAccessToken = null)
         {
             if (manifestId == null)
                 throw new BadParameterException("manifestId cannot be null");
 
-            var getParams = new List<KeyValuePair<string, string>>
-                {
-                    new KeyValuePair<string, string>("manifest_id", manifestId)
-                };
+            var getParams = new List<KeyValuePair<string, string>>()
+            {
+                new KeyValuePair<string, string>("manifest_id", manifestId)
+            };
 
             switch (type)
             {
@@ -35,9 +37,45 @@ namespace TwitchLib.Api.Helix
                     throw new BadParameterException("Unknown entitlement grant type");
             }
 
-            return TwitchGetGenericAsync<CreateEntitlementGrantsUploadUrlResponse>("/entitlements/upload", ApiVersion.Helix, getParams);
+            return TwitchGetGenericAsync<CreateEntitlementGrantsUploadUrlResponse>("/entitlements/upload", ApiVersion.Helix, getParams, applicationAccessToken);
         }
 
+        #endregion
+
+        #region GetCodeStatus
+        public Task<GetCodeStatusResponse> GetCodeStatusAsync(List<string> codes, string userId, string accessToken = null)
+        {
+            if (codes == null || codes.Count == 0 || codes.Count > 20)
+                throw new BadParameterException("codes cannot be null and must ahve between 1 and 20 items");
+
+            if (userId == null)
+                throw new BadParameterException("userId cannot be null");
+
+            var getParams = new List<KeyValuePair<string, string>>()
+            {
+                new KeyValuePair<string, string>("user_id", userId)
+            };
+
+            foreach (var code in codes)
+                getParams.Add(new KeyValuePair<string, string>("code", code));
+
+            return TwitchPostGenericAsync<GetCodeStatusResponse>("/entitlements/codes", ApiVersion.Helix, null, getParams, accessToken);
+        }
+        #endregion
+
+        #region RedeemCode
+        public Task<RedeemCodeResponse> RedeemCodeAsync(List<string> codes, string accessToken = null)
+        {
+            if (codes == null || codes.Count == 0 || codes.Count > 20)
+                throw new BadParameterException("codes cannot be null and must ahve between 1 and 20 items");
+
+            var getParams = new List<KeyValuePair<string, string>>();
+
+            foreach (var code in codes)
+                getParams.Add(new KeyValuePair<string, string>("code", code));
+
+            return TwitchPostGenericAsync<RedeemCodeResponse>("/entitlements/codes", ApiVersion.Helix, null, getParams, accessToken);
+        }
         #endregion
 
     }


### PR DESCRIPTION
Support for `Entitlements/GetCodeStatus` and `Entitlements/RedeemCode`. Some cleanup as well.

I'm not sure if we have anyone that can effectively test these endpoints as they require using an application access token that has entitlements. So I guess just review the code and make sure it looks/makes sense.