### PR TITLE
support for Moderation/GetAutoModStatus, Moderation/GetBannedEvents, Moderation/GetBannedUsers, Moderation/GetModerators, Moderation/GetModeratorEvents

### DIFF
--- a/TwitchLib.Api.Core.Enums/AuthScopesEnum.cs
+++ b/TwitchLib.Api.Core.Enums/AuthScopesEnum.cs
@@ -31,6 +31,7 @@
         Helix_User_Edit_Broadcast,
         Helix_User_Read_Broadcast,
         Helix_Channel_Read_Subscriptions,
+        Helix_Moderation_Read,
         None
     }
 }

--- a/TwitchLib.Api.Core/ApiBase.cs
+++ b/TwitchLib.Api.Core/ApiBase.cs
@@ -413,6 +413,9 @@ namespace TwitchLib.Api.Core
                     case "channel:read:subscriptions":
                         scopes.Add(AuthScopes.Helix_Channel_Read_Subscriptions);
                         break;
+                    case "moderation:read":
+                        scopes.Add(AuthScopes.Helix_Moderation_Read);
+                        break;
                 }
             }
 

--- a/TwitchLib.Api.Helix.Models/Moderation/CheckAutoModStatus/AutoModResult.cs
+++ b/TwitchLib.Api.Helix.Models/Moderation/CheckAutoModStatus/AutoModResult.cs
@@ -1,0 +1,15 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.Api.Helix.Models.Moderation.CheckAutoModStatus
+{
+    public class AutoModResult
+    {
+        [JsonProperty(PropertyName = "msg_id")]
+        public string MsgId { get; protected set; }
+        [JsonProperty(PropertyName = "is_permitted")]
+        public bool IsPermitted { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Moderation/CheckAutoModStatus/CheckAutoModStatusResponse.cs
+++ b/TwitchLib.Api.Helix.Models/Moderation/CheckAutoModStatus/CheckAutoModStatusResponse.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.Api.Helix.Models.Moderation.CheckAutoModStatus
+{
+    public class CheckAutoModStatusResponse
+    {
+        [JsonProperty(PropertyName = "data")]
+        public AutoModResult[] Data { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Moderation/CheckAutoModStatus/Request/Message.cs
+++ b/TwitchLib.Api.Helix.Models/Moderation/CheckAutoModStatus/Request/Message.cs
@@ -1,0 +1,17 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.Api.Helix.Models.Moderation.CheckAutoModStatus
+{
+    public class Message
+    {
+        [JsonProperty(PropertyName = "msg_id")]
+        public string MsgId { get; set; }
+        [JsonProperty(PropertyName = "msg_text")]
+        public bool MsgText { get; set; }
+        [JsonProperty(PropertyName = "user_id")]
+        public string UserId { get; set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Moderation/CheckAutoModStatus/Request/MessageRequest.cs
+++ b/TwitchLib.Api.Helix.Models/Moderation/CheckAutoModStatus/Request/MessageRequest.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.Api.Helix.Models.Moderation.CheckAutoModStatus.Request
+{
+    public class MessageRequest
+    {
+        [JsonProperty(PropertyName = "data")]
+        public Message[] Messages { get; set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Moderation/GetBannedEvents/BannedEvent.cs
+++ b/TwitchLib.Api.Helix.Models/Moderation/GetBannedEvents/BannedEvent.cs
@@ -1,0 +1,21 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.Api.Helix.Models.Moderation.GetBannedEvents
+{
+    public class BannedEvent
+    {
+        [JsonProperty(PropertyName = "id")]
+        public string Id { get; protected set; }
+        [JsonProperty(PropertyName = "event_type")]
+        public string EventType { get; protected set; }
+        [JsonProperty(PropertyName = "event_timestamp")]
+        public DateTime EventTimestamp { get; protected set; }
+        [JsonProperty(PropertyName = "version")]
+        public string Version { get; protected set; }
+        [JsonProperty(PropertyName = "event_data")]
+        public EventData EventData { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Moderation/GetBannedEvents/EventData.cs
+++ b/TwitchLib.Api.Helix.Models/Moderation/GetBannedEvents/EventData.cs
@@ -1,0 +1,21 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.Api.Helix.Models.Moderation.GetBannedEvents
+{
+    public class EventData
+    {
+        [JsonProperty(PropertyName = "broadcaster_id")]
+        public string BroadcasterId { get; protected set; }
+        [JsonProperty(PropertyName = "broadcaster_name")]
+        public string BroadcasterName { get; protected set; }
+        [JsonProperty(PropertyName = "user_id")]
+        public string UserId { get; protected set; }
+        [JsonProperty(PropertyName = "user_name")]
+        public string UserName { get; protected set; }
+        [JsonProperty(PropertyName = "expires_at")]
+        public DateTime? ExpiresAt { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Moderation/GetBannedEvents/GetBannedEventsResponse.cs
+++ b/TwitchLib.Api.Helix.Models/Moderation/GetBannedEvents/GetBannedEventsResponse.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using TwitchLib.Api.Helix.Models.Common;
+
+namespace TwitchLib.Api.Helix.Models.Moderation.GetBannedEvents
+{
+    public class GetBannedEventsResponse
+    {
+        [JsonProperty(PropertyName = "data")]
+        public BannedEvent[] Data { get; protected set; }
+        [JsonProperty(PropertyName = "pagination")]
+        public Pagination Pagination { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Moderation/GetBannedUsers/BannedUserEvent.cs
+++ b/TwitchLib.Api.Helix.Models/Moderation/GetBannedUsers/BannedUserEvent.cs
@@ -1,0 +1,17 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.Api.Helix.Models.Moderation.GetBannedUsers
+{
+    public class BannedUserEvent
+    {
+        [JsonProperty(PropertyName = "user_id")]
+        public string UserId { get; protected set; }
+        [JsonProperty(PropertyName = "user_name")]
+        public string UserName { get; protected set; }
+        [JsonProperty(PropertyName = "ExpiresAt")]
+        public DateTime? ExpiresAt { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Moderation/GetBannedUsers/GetBannedUsersResponse.cs
+++ b/TwitchLib.Api.Helix.Models/Moderation/GetBannedUsers/GetBannedUsersResponse.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using TwitchLib.Api.Helix.Models.Common;
+
+namespace TwitchLib.Api.Helix.Models.Moderation.GetBannedUsers
+{
+    public class GetBannedUsersResponse
+    {
+        [JsonProperty(PropertyName = "data")]
+        public BannedUserEvent[] Data { get; protected set; }
+        [JsonProperty(PropertyName = "pagination")]
+        public Pagination Pagination { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Moderation/GetModeratorEvents/EventData.cs
+++ b/TwitchLib.Api.Helix.Models/Moderation/GetModeratorEvents/EventData.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.Api.Helix.Models.Moderation.GetModeratorEvents
+{
+    public class EventData
+    {
+        [JsonProperty(PropertyName = "broadcaster_id")]
+        public string BroadcasterId { get; protected set; }
+        [JsonProperty(PropertyName = "broadcaster_name")]
+        public string BroadcasterName { get; protected set; }
+        [JsonProperty(PropertyName = "user_id")]
+        public string UserId { get; protected set; }
+        [JsonProperty(PropertyName = "user_name")]
+        public string UserName { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Moderation/GetModeratorEvents/GetModeratorEventsResponse.cs
+++ b/TwitchLib.Api.Helix.Models/Moderation/GetModeratorEvents/GetModeratorEventsResponse.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using TwitchLib.Api.Helix.Models.Common;
+
+namespace TwitchLib.Api.Helix.Models.Moderation.GetModeratorEvents
+{
+    public class GetModeratorEventsResponse
+    {
+        [JsonProperty(PropertyName = "data")]
+        public ModeratorEvent[] Data { get; protected set; }
+        [JsonProperty(PropertyName = "pagination")]
+        public Pagination Pagination { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Moderation/GetModeratorEvents/ModeratorEvent.cs
+++ b/TwitchLib.Api.Helix.Models/Moderation/GetModeratorEvents/ModeratorEvent.cs
@@ -1,0 +1,21 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.Api.Helix.Models.Moderation.GetModeratorEvents
+{
+    public class ModeratorEvent
+    {
+        [JsonProperty(PropertyName = "id")]
+        public string Id { get; protected set; }
+        [JsonProperty(PropertyName = "event_type")]
+        public string EventType { get; protected set; }
+        [JsonProperty(PropertyName = "event_timestamp")]
+        public DateTime EventTimestamp { get; protected set; }
+        [JsonProperty(PropertyName = "version")]
+        public string Version { get; protected set; }
+        [JsonProperty(PropertyName = "event_data")]
+        public EventData EventData { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Moderation/GetModerators/GetModeratorsResponse.cs
+++ b/TwitchLib.Api.Helix.Models/Moderation/GetModerators/GetModeratorsResponse.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using TwitchLib.Api.Helix.Models.Common;
+
+namespace TwitchLib.Api.Helix.Models.Moderation.GetModerators
+{
+    public class GetModeratorsResponse
+    {
+        [JsonProperty(PropertyName = "data")]
+        public Moderator[] Data { get; protected set; }
+        [JsonProperty(PropertyName = "pagination")]
+        public Pagination Pagination { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Moderation/GetModerators/Moderator.cs
+++ b/TwitchLib.Api.Helix.Models/Moderation/GetModerators/Moderator.cs
@@ -1,0 +1,15 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.Api.Helix.Models.Moderation.GetModerators
+{
+    public class Moderator
+    {
+        [JsonProperty(PropertyName = "user_id")]
+        public string UserId { get; protected set; }
+        [JsonProperty(PropertyName = "user_name")]
+        public string UserName { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix/Helix.cs
+++ b/TwitchLib.Api.Helix/Helix.cs
@@ -16,6 +16,7 @@ namespace TwitchLib.Api.Helix
         public Clips Clips { get; }
         public Entitlements Entitlements { get; }
         public Games Games { get; }
+        public Moderation Moderation { get; }
         public Subscriptions Subscriptions { get; }
         public Streams Streams { get; }
         public Tags Tags { get; }
@@ -43,6 +44,7 @@ namespace TwitchLib.Api.Helix
             Clips = new Clips(Settings, rateLimiter, http);
             Entitlements = new Entitlements(Settings, rateLimiter, http);
             Games = new Games(Settings, rateLimiter, http);
+            Moderation = new Moderation(Settings, rateLimiter, http);
             Streams = new Streams(Settings, rateLimiter, http);
             Subscriptions = new Subscriptions(Settings, rateLimiter, http);
             Tags = new Tags(Settings, rateLimiter, http);

--- a/TwitchLib.Api.Helix/Moderation.cs
+++ b/TwitchLib.Api.Helix/Moderation.cs
@@ -1,0 +1,149 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using TwitchLib.Api.Core;
+using TwitchLib.Api.Core.Enums;
+using TwitchLib.Api.Core.Exceptions;
+using TwitchLib.Api.Core.Interfaces;
+using TwitchLib.Api.Helix.Models.Moderation.CheckAutoModStatus;
+using TwitchLib.Api.Helix.Models.Moderation.CheckAutoModStatus.Request;
+using TwitchLib.Api.Helix.Models.Moderation.GetBannedEvents;
+using TwitchLib.Api.Helix.Models.Moderation.GetBannedUsers;
+using TwitchLib.Api.Helix.Models.Moderation.GetModeratorEvents;
+using TwitchLib.Api.Helix.Models.Moderation.GetModerators;
+
+namespace TwitchLib.Api.Helix
+{
+    public class Moderation : ApiBase
+    {
+        public Moderation(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http)
+        {
+        }
+
+        #region CheckAutoModeStatus
+
+        public Task<CheckAutoModStatusResponse> CheckAutoModStatusAsync(List<Message> messages, string broadcasterId, string accessToken = null)
+        {
+            if (messages == null || messages.Count == 0)
+                throw new BadParameterException("messages cannot be null and must be greater than 0 length");
+
+            if (broadcasterId == null || broadcasterId.Length == 0)
+                throw new BadParameterException("broadcasterId cannot be null and must be greater than 0 length");
+
+            var getParams = new List<KeyValuePair<string, string>>()
+            {
+                new KeyValuePair<string, string>("broacaster_id", broadcasterId)
+            };
+
+            MessageRequest request = new MessageRequest()
+            {
+                Messages = messages.ToArray()
+            };
+
+            return TwitchPostGenericAsync<CheckAutoModStatusResponse>("/moderation/enforcements/status", ApiVersion.Helix, JsonConvert.SerializeObject(request), getParams, accessToken);
+        }
+
+        #endregion
+
+        #region GetBannedEvents
+
+        public Task<GetBannedEventsResponse> GetBannedEventsAsync(string broadcasterId, List<string> userIds = null, string after = null, string first = null, string accessToken = null)
+        {
+            if (broadcasterId == null || broadcasterId.Length == 0)
+                throw new BadParameterException("broadcasterId cannot be null and must be greater than 0 length");
+
+            var getParams = new List<KeyValuePair<string, string>>()
+            {
+                new KeyValuePair<string, string>("broadcaster_id", broadcasterId)
+            };
+
+            if (userIds != null && userIds.Count > 0)
+                foreach (var userId in userIds)
+                    getParams.Add(new KeyValuePair<string, string>("user_id", userId));
+
+            if (after != null)
+                getParams.Add(new KeyValuePair<string, string>("after", after));
+
+            if (first != null)
+                getParams.Add(new KeyValuePair<string, string>("first", first));
+
+            return TwitchGetGenericAsync<GetBannedEventsResponse>("/moderation/banned/events", ApiVersion.Helix, getParams, accessToken);
+        }
+
+        #endregion
+
+        #region GetBannedUsers
+
+        public Task<GetBannedUsersResponse> GetBannedUsersAsync(string broadcasterId, List<string> userIds = null, string after = null, string before = null, string accessToken = null)
+        {
+            if (broadcasterId == null || broadcasterId.Length == 0)
+                throw new BadParameterException("broadcasterId cannot be null and must be greater than 0 length");
+
+            var getParams = new List<KeyValuePair<string, string>>()
+            {
+                new KeyValuePair<string, string>("broadcaster_id", broadcasterId)
+            };
+
+            if (userIds != null && userIds.Count > 0)
+                foreach (var userId in userIds)
+                    getParams.Add(new KeyValuePair<string, string>("user_id", userId));
+
+            if (after != null)
+                getParams.Add(new KeyValuePair<string, string>("after", after));
+
+            if (before != null)
+                getParams.Add(new KeyValuePair<string, string>("before", before));
+
+            return TwitchGetGenericAsync<GetBannedUsersResponse>("/moderation/banned", ApiVersion.Helix, getParams, accessToken);
+        }
+
+        #endregion
+
+        #region GetModerators
+
+        public Task<GetModeratorsResponse> GetModeratorsAsync(string broadcasterId, List<string> userIds = null, string after = null, string accessToken = null)
+        {
+            if (broadcasterId == null || broadcasterId.Length == 0)
+                throw new BadParameterException("broadcasterId cannot be null and must be greater than 0 length");
+
+            var getParams = new List<KeyValuePair<string, string>>()
+            {
+                new KeyValuePair<string, string>("broadcaster_id", broadcasterId)
+            };
+
+            if (userIds != null && userIds.Count > 0)
+                foreach (var userId in userIds)
+                    getParams.Add(new KeyValuePair<string, string>("user_id", userId));
+
+            if (after != null)
+                getParams.Add(new KeyValuePair<string, string>("after", after));
+
+            return TwitchGetGenericAsync<GetModeratorsResponse>("/moderation/moderators", ApiVersion.Helix, getParams, accessToken);
+        }
+
+        #endregion
+
+        #region GetModeratorEvents
+
+        public Task<GetModeratorEventsResponse> GetModeratorEventsAsync(string broadcasterId, List<string> userIds = null, string accessToken = null)
+        {
+            if (broadcasterId == null || broadcasterId.Length == 0)
+                throw new BadParameterException("broadcasterId cannot be null and must be greater than 0 length");
+
+            var getParams = new List<KeyValuePair<string, string>>()
+            {
+                new KeyValuePair<string, string>("broadcaster_id", broadcasterId)
+            };
+
+            if (userIds != null && userIds.Count > 0)
+                foreach (var userId in userIds)
+                    getParams.Add(new KeyValuePair<string, string>("user_id", userId));
+
+            return TwitchGetGenericAsync<GetModeratorEventsResponse>("/moderation/moderators/events", ApiVersion.Helix, getParams, accessToken);
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Adds support for all Helix Moderation endpoints:
 - `Moderation/GetAutoModStats`
 - `Moderation/GetBannedEvents`
 - `Moderation/GetBannedUsers`
 - `Moderation/GetModerators`
 - `Moderation/GetModeratorEvents`

I have not tested these yet. I will test them when I get some more freetime and prior to merging. I wanted to get this out so people could review it if they want.