### PR TITLE
Handle Exceptions in Follower and Stream Monitor Services

### DIFF
--- a/TwitchLib.Api/Services/ApiService.cs
+++ b/TwitchLib.Api/Services/ApiService.cs
@@ -39,6 +39,10 @@ namespace TwitchLib.Api.Services
         /// </summary>
         public event EventHandler<OnServiceTickArgs> OnServiceTick;
         /// <summary>
+        /// Event invoked when the service encounters an exception.
+        /// </summary>
+        public event EventHandler<OnServiceExceptionArgs> OnServiceException;
+        /// <summary>
         /// Event invoked when the channels have been set.
         /// </summary>
         public event EventHandler<OnChannelsSetArgs> OnChannelsSet;
@@ -92,6 +96,11 @@ namespace TwitchLib.Api.Services
             _serviceTimer.Stop();
 
             OnServiceStopped?.Invoke(this, new OnServiceStoppedArgs());
+        }
+
+        internal virtual void HandleException(Exception ex)
+        {
+            OnServiceException?.Invoke(this, new OnServiceExceptionArgs { Exception = ex });
         }
 
         /// <summary>

--- a/TwitchLib.Api/Services/Events/OnServiceExceptionArgs.cs
+++ b/TwitchLib.Api/Services/Events/OnServiceExceptionArgs.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.Api.Services.Events
+{
+    public class OnServiceExceptionArgs : EventArgs
+    {
+        public Exception Exception;
+    }
+}

--- a/TwitchLib.Api/Services/FollowerService.cs
+++ b/TwitchLib.Api/Services/FollowerService.cs
@@ -166,7 +166,13 @@ namespace TwitchLib.Api.Services
         protected override async Task OnServiceTimerTick()
         {
             await base.OnServiceTimerTick();
-            await UpdateLatestFollowersAsync();
+            try
+            {
+                await UpdateLatestFollowersAsync();
+            } catch(Exception ex)
+            {
+                base.HandleException(ex);
+            }
         }
 
         private async Task<List<Follow>> GetLatestFollowersAsync(string channel)

--- a/TwitchLib.Api/Services/LiveStreamMonitorService.cs
+++ b/TwitchLib.Api/Services/LiveStreamMonitorService.cs
@@ -104,7 +104,13 @@ namespace TwitchLib.Api.Services
         protected override async Task OnServiceTimerTick()
         {
             await base.OnServiceTimerTick();
-            await UpdateLiveStreamersAsync();
+            try
+            {
+                await UpdateLiveStreamersAsync();
+            } catch(Exception ex)
+            {
+                base.HandleException(ex);
+            }
         }
 
         private void HandleLiveStreamUpdate(string channel, Stream liveStream, bool callEvents)


### PR DESCRIPTION
This is one (simple) way to solve this problem. Basically we're catching any exception being thrown in the tick event and passing that exception to a new event that can be listened to. This should prevent exceptions from causing problems internally, and also allow the end programmer to get access to the exceptions.

Thoughts?