### PR TITLE
bubble the exceptions on the LiveMonitor and FollowMonitor

### DIFF
--- a/TwitchLib.Api/Services/Core/ServiceTimer.cs
+++ b/TwitchLib.Api/Services/Core/ServiceTimer.cs
@@ -16,7 +16,7 @@ namespace TwitchLib.Api.Services.Core
             _serviceTimerTickAsyncCallback = serviceTimerTickAsyncCallback;
             Interval = intervalInSeconds * 1000;
             IntervalInSeconds = intervalInSeconds;
-            Elapsed += TimerElapsedAsync;
+            Elapsed += async ( sender, e ) => await TimerElapsedAsync();
         }
 
         private async void TimerElapsedAsync(object sender, ElapsedEventArgs e)

--- a/TwitchLib.Api/Services/Core/ServiceTimer.cs
+++ b/TwitchLib.Api/Services/Core/ServiceTimer.cs
@@ -16,10 +16,10 @@ namespace TwitchLib.Api.Services.Core
             _serviceTimerTickAsyncCallback = serviceTimerTickAsyncCallback;
             Interval = intervalInSeconds * 1000;
             IntervalInSeconds = intervalInSeconds;
-            Elapsed += async ( sender, e ) => await TimerElapsedAsync();
+            Elapsed += async ( sender, e ) => await TimerElapsedAsync(sender, e);
         }
 
-        private async void TimerElapsedAsync(object sender, ElapsedEventArgs e)
+        private async Task TimerElapsedAsync(object sender, ElapsedEventArgs e)
         {
             await _serviceTimerTickAsyncCallback();
         }


### PR DESCRIPTION
According to this article/doc

[ARTICLE/DOC](https://docs.microsoft.com/en-us/dotnet/api/system.timers.timer?view=netcore-2.0)

All we should need is 

`Elapsed += async ( sender, e ) => await TimerElapsedAsync();`