### PR TITLE
Force access token for helix calls

### DIFF
--- a/TwitchLib.Api.Core/ApiBase.cs
+++ b/TwitchLib.Api.Core/ApiBase.cs
@@ -104,7 +104,7 @@ namespace TwitchLib.Api.Core
         {
             if (api != ApiVersion.Helix)
                 return;
-            if (clientId != null && accessToken != null)
+            if (!string.IsNullOrWhiteSpace(clientId) && !string.IsNullOrWhiteSpace(accessToken))
                 return;
             throw new ClientIdAndOAuthTokenRequired("As of May 1, all calls to Twitch's Helix API require Client-ID and OAuth access token be set. Example: api.Settings.AccessToken = \"twitch-oauth-access-token-here\"; api.Settings.ClientId = \"twitch-client-id-here\";");
         }

--- a/TwitchLib.Api.Core/ApiBase.cs
+++ b/TwitchLib.Api.Core/ApiBase.cs
@@ -100,13 +100,13 @@ namespace TwitchLib.Api.Core
             return null;
         }
 
-        internal void forceHelixAccessToken(string accessToken, ApiVersion api)
+        internal void ForceAccessTokenAndClientIdForHelix(string clientId, string accessToken, ApiVersion api)
         {
             if (api != ApiVersion.Helix)
                 return;
-            if (accessToken != null)
+            if (clientId != null && accessToken != null)
                 return;
-            throw new OAuthTokenRequired("As of May 1, all calls to Twitch's Helix API require OAuth access token be set. Example: api.Settings.AccessToken = \"twitch-oauth-access-token-here\"");
+            throw new ClientIdAndOAuthTokenRequired("As of May 1, all calls to Twitch's Helix API require Client-ID and OAuth access token be set. Example: api.Settings.AccessToken = \"twitch-oauth-access-token-here\"; api.Settings.ClientId = \"twitch-client-id-here\";");
         }
 
         protected Task<T> TwitchGetGenericAsync<T>(string resource, ApiVersion api, List<KeyValuePair<string, string>> getParams = null, string accessToken = null, string clientId = null, string customBase = null)
@@ -117,7 +117,7 @@ namespace TwitchLib.Api.Core
                 clientId = Settings.ClientId;
 
             accessToken = GetAccessToken(accessToken);
-            forceHelixAccessToken(accessToken, api);
+            ForceAccessTokenAndClientIdForHelix(clientId, accessToken, api);
 
             return _rateLimiter.Perform(async () => await Task.Run(() => JsonConvert.DeserializeObject<T>(_http.GeneralRequest(url, "GET", null, api, clientId, accessToken).Value, _twitchLibJsonDeserializer)).ConfigureAwait(false));
         }
@@ -130,7 +130,7 @@ namespace TwitchLib.Api.Core
                 clientId = Settings.ClientId;
 
             accessToken = GetAccessToken(accessToken);
-            forceHelixAccessToken(accessToken, api);
+            ForceAccessTokenAndClientIdForHelix(clientId, accessToken, api);
 
             return _rateLimiter.Perform(async () => await Task.Run(() => _http.GeneralRequest(url, "DELETE", null, api, clientId, accessToken).Value).ConfigureAwait(false));
         }
@@ -143,7 +143,7 @@ namespace TwitchLib.Api.Core
                 clientId = Settings.ClientId;
 
             accessToken = GetAccessToken(accessToken);
-            forceHelixAccessToken(accessToken, api);
+            ForceAccessTokenAndClientIdForHelix(clientId, accessToken, api);
 
             return _rateLimiter.Perform(async () => await Task.Run(() => JsonConvert.DeserializeObject<T>(_http.GeneralRequest(url, "POST", payload, api, clientId, accessToken).Value, _twitchLibJsonDeserializer)).ConfigureAwait(false));
         }
@@ -156,7 +156,7 @@ namespace TwitchLib.Api.Core
                 clientId = Settings.ClientId;
 
             accessToken = GetAccessToken(accessToken);
-            forceHelixAccessToken(accessToken, api);
+            ForceAccessTokenAndClientIdForHelix(clientId, accessToken, api);
 
             return _rateLimiter.Perform(async () => await Task.Run(() => JsonConvert.DeserializeObject<T>(_http.GeneralRequest(url, "POST", model != null ? _jsonSerializer.SerializeObject(model) : "", api, clientId, accessToken).Value, _twitchLibJsonDeserializer)).ConfigureAwait(false));
         }
@@ -169,7 +169,7 @@ namespace TwitchLib.Api.Core
                 clientId = Settings.ClientId;
 
             accessToken = GetAccessToken(accessToken);
-            forceHelixAccessToken(accessToken, api);
+            ForceAccessTokenAndClientIdForHelix(clientId, accessToken, api);
 
             return _rateLimiter.Perform(async () => await Task.Run(() => JsonConvert.DeserializeObject<T>(_http.GeneralRequest(url, "DELETE", null, api, clientId, accessToken).Value, _twitchLibJsonDeserializer)).ConfigureAwait(false));
         }
@@ -182,7 +182,7 @@ namespace TwitchLib.Api.Core
                 clientId = Settings.ClientId;
 
             accessToken = GetAccessToken(accessToken);
-            forceHelixAccessToken(accessToken, api);
+            ForceAccessTokenAndClientIdForHelix(clientId, accessToken, api);
 
             return _rateLimiter.Perform(async () => await Task.Run(() => JsonConvert.DeserializeObject<T>(_http.GeneralRequest(url, "PUT", payload, api, clientId, accessToken).Value, _twitchLibJsonDeserializer)).ConfigureAwait(false));
         }
@@ -195,7 +195,7 @@ namespace TwitchLib.Api.Core
                 clientId = Settings.ClientId;
 
             accessToken = GetAccessToken(accessToken);
-            forceHelixAccessToken(accessToken, api);
+            ForceAccessTokenAndClientIdForHelix(clientId, accessToken, api);
 
             return _rateLimiter.Perform(async () => await Task.Run(() => _http.GeneralRequest(url, "PUT", payload, api, clientId, accessToken).Value).ConfigureAwait(false));
         }
@@ -208,7 +208,7 @@ namespace TwitchLib.Api.Core
                 clientId = Settings.ClientId;
 
             accessToken = GetAccessToken(accessToken);
-            forceHelixAccessToken(accessToken, api);
+            ForceAccessTokenAndClientIdForHelix(clientId, accessToken, api);
 
             return _rateLimiter.Perform(async () => await Task.Run(() => _http.GeneralRequest(url, "POST", payload, api, clientId, accessToken)).ConfigureAwait(false));
         }
@@ -241,7 +241,7 @@ namespace TwitchLib.Api.Core
                 clientId = Settings.ClientId;
 
             accessToken = GetAccessToken(accessToken);
-            forceHelixAccessToken(accessToken, api);
+            ForceAccessTokenAndClientIdForHelix(clientId, accessToken, api);
 
             return _rateLimiter.Perform(async () => await Task.Run(() => JsonConvert.DeserializeObject<T>(_http.GeneralRequest(url, "GET", null, api, clientId, accessToken).Value, _twitchLibJsonDeserializer)).ConfigureAwait(false));
         }

--- a/TwitchLib.Api.Core/ApiBase.cs
+++ b/TwitchLib.Api.Core/ApiBase.cs
@@ -100,6 +100,15 @@ namespace TwitchLib.Api.Core
             return null;
         }
 
+        internal void forceHelixAccessToken(string accessToken, ApiVersion api)
+        {
+            if (api != ApiVersion.Helix)
+                return;
+            if (accessToken != null)
+                return;
+            throw new OAuthTokenRequired("As of May 1, all calls to Twitch's Helix API require OAuth access token be set. Example: api.Settings.AccessToken = \"twitch-oauth-access-token-here\"");
+        }
+
         protected Task<T> TwitchGetGenericAsync<T>(string resource, ApiVersion api, List<KeyValuePair<string, string>> getParams = null, string accessToken = null, string clientId = null, string customBase = null)
         {
             var url = ConstructResourceUrl(resource, getParams, api, customBase);
@@ -108,6 +117,7 @@ namespace TwitchLib.Api.Core
                 clientId = Settings.ClientId;
 
             accessToken = GetAccessToken(accessToken);
+            forceHelixAccessToken(accessToken, api);
 
             return _rateLimiter.Perform(async () => await Task.Run(() => JsonConvert.DeserializeObject<T>(_http.GeneralRequest(url, "GET", null, api, clientId, accessToken).Value, _twitchLibJsonDeserializer)).ConfigureAwait(false));
         }
@@ -120,6 +130,7 @@ namespace TwitchLib.Api.Core
                 clientId = Settings.ClientId;
 
             accessToken = GetAccessToken(accessToken);
+            forceHelixAccessToken(accessToken, api);
 
             return _rateLimiter.Perform(async () => await Task.Run(() => _http.GeneralRequest(url, "DELETE", null, api, clientId, accessToken).Value).ConfigureAwait(false));
         }
@@ -132,6 +143,7 @@ namespace TwitchLib.Api.Core
                 clientId = Settings.ClientId;
 
             accessToken = GetAccessToken(accessToken);
+            forceHelixAccessToken(accessToken, api);
 
             return _rateLimiter.Perform(async () => await Task.Run(() => JsonConvert.DeserializeObject<T>(_http.GeneralRequest(url, "POST", payload, api, clientId, accessToken).Value, _twitchLibJsonDeserializer)).ConfigureAwait(false));
         }
@@ -144,6 +156,7 @@ namespace TwitchLib.Api.Core
                 clientId = Settings.ClientId;
 
             accessToken = GetAccessToken(accessToken);
+            forceHelixAccessToken(accessToken, api);
 
             return _rateLimiter.Perform(async () => await Task.Run(() => JsonConvert.DeserializeObject<T>(_http.GeneralRequest(url, "POST", model != null ? _jsonSerializer.SerializeObject(model) : "", api, clientId, accessToken).Value, _twitchLibJsonDeserializer)).ConfigureAwait(false));
         }
@@ -156,6 +169,7 @@ namespace TwitchLib.Api.Core
                 clientId = Settings.ClientId;
 
             accessToken = GetAccessToken(accessToken);
+            forceHelixAccessToken(accessToken, api);
 
             return _rateLimiter.Perform(async () => await Task.Run(() => JsonConvert.DeserializeObject<T>(_http.GeneralRequest(url, "DELETE", null, api, clientId, accessToken).Value, _twitchLibJsonDeserializer)).ConfigureAwait(false));
         }
@@ -168,6 +182,7 @@ namespace TwitchLib.Api.Core
                 clientId = Settings.ClientId;
 
             accessToken = GetAccessToken(accessToken);
+            forceHelixAccessToken(accessToken, api);
 
             return _rateLimiter.Perform(async () => await Task.Run(() => JsonConvert.DeserializeObject<T>(_http.GeneralRequest(url, "PUT", payload, api, clientId, accessToken).Value, _twitchLibJsonDeserializer)).ConfigureAwait(false));
         }
@@ -180,6 +195,7 @@ namespace TwitchLib.Api.Core
                 clientId = Settings.ClientId;
 
             accessToken = GetAccessToken(accessToken);
+            forceHelixAccessToken(accessToken, api);
 
             return _rateLimiter.Perform(async () => await Task.Run(() => _http.GeneralRequest(url, "PUT", payload, api, clientId, accessToken).Value).ConfigureAwait(false));
         }
@@ -192,6 +208,7 @@ namespace TwitchLib.Api.Core
                 clientId = Settings.ClientId;
 
             accessToken = GetAccessToken(accessToken);
+            forceHelixAccessToken(accessToken, api);
 
             return _rateLimiter.Perform(async () => await Task.Run(() => _http.GeneralRequest(url, "POST", payload, api, clientId, accessToken)).ConfigureAwait(false));
         }
@@ -224,6 +241,7 @@ namespace TwitchLib.Api.Core
                 clientId = Settings.ClientId;
 
             accessToken = GetAccessToken(accessToken);
+            forceHelixAccessToken(accessToken, api);
 
             return _rateLimiter.Perform(async () => await Task.Run(() => JsonConvert.DeserializeObject<T>(_http.GeneralRequest(url, "GET", null, api, clientId, accessToken).Value, _twitchLibJsonDeserializer)).ConfigureAwait(false));
         }

--- a/TwitchLib.Api.Core/Exceptions/ClientIdAndOAuthTokenRequiredException.cs
+++ b/TwitchLib.Api.Core/Exceptions/ClientIdAndOAuthTokenRequiredException.cs
@@ -6,11 +6,11 @@ namespace TwitchLib.Api.Core.Exceptions
 {
     /// <inheritdoc />
     /// <summary>Exception representing a Helix request sent without an OAuth access token</summary>
-    public class OAuthTokenRequired : Exception
+    public class ClientIdAndOAuthTokenRequired : Exception
     {
         /// <inheritdoc />
         /// <summary>Exception constructor</summary>
-        public OAuthTokenRequired(string explanation)
+        public ClientIdAndOAuthTokenRequired(string explanation)
             : base(explanation)
         {
         }

--- a/TwitchLib.Api.Core/Exceptions/OAuthTokenRequiredException.cs
+++ b/TwitchLib.Api.Core/Exceptions/OAuthTokenRequiredException.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.Api.Core.Exceptions
+{
+    /// <inheritdoc />
+    /// <summary>Exception representing a Helix request sent without an OAuth access token</summary>
+    public class OAuthTokenRequired : Exception
+    {
+        /// <inheritdoc />
+        /// <summary>Exception constructor</summary>
+        public OAuthTokenRequired(string explanation)
+            : base(explanation)
+        {
+        }
+    }
+}


### PR DESCRIPTION
As per: https://discuss.dev.twitch.tv/t/requiring-oauth-for-helix-twitch-api-endpoints/23916

Helix calls MUST have client-id and oauth access token.