### PR TITLE
Convert code to true async

### DIFF
--- a/TwitchLib.Api.Core.Interfaces/IHttpCallHandler.cs
+++ b/TwitchLib.Api.Core.Interfaces/IHttpCallHandler.cs
@@ -1,12 +1,13 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using TwitchLib.Api.Core.Enums;
 
 namespace TwitchLib.Api.Core.Interfaces
 {
     public interface IHttpCallHandler
     {
-        KeyValuePair<int, string> GeneralRequest(string url, string method, string payload = null, ApiVersion api = ApiVersion.V5, string clientId = null, string accessToken = null);
-        void PutBytes(string url, byte[] payload);
-        int RequestReturnResponseCode(string url, string method, List<KeyValuePair<string, string>> getParams = null);
+        Task<KeyValuePair<int, string>> GeneralRequest(string url, string method, string payload = null, ApiVersion api = ApiVersion.V5, string clientId = null, string accessToken = null);
+        Task PutBytes(string url, byte[] payload);
+        Task<int> RequestReturnResponseCode(string url, string method, List<KeyValuePair<string, string>> getParams = null);
     }
 }

--- a/TwitchLib.Api.Core.Interfaces/IHttpCallHandler.cs
+++ b/TwitchLib.Api.Core.Interfaces/IHttpCallHandler.cs
@@ -6,8 +6,8 @@ namespace TwitchLib.Api.Core.Interfaces
 {
     public interface IHttpCallHandler
     {
-        Task<KeyValuePair<int, string>> GeneralRequest(string url, string method, string payload = null, ApiVersion api = ApiVersion.V5, string clientId = null, string accessToken = null);
-        Task PutBytes(string url, byte[] payload);
-        Task<int> RequestReturnResponseCode(string url, string method, List<KeyValuePair<string, string>> getParams = null);
+        Task<KeyValuePair<int, string>> GeneralRequestAsync(string url, string method, string payload = null, ApiVersion api = ApiVersion.V5, string clientId = null, string accessToken = null);
+        Task PutBytesAsync(string url, byte[] payload);
+        Task<int> RequestReturnResponseCodeAsync(string url, string method, List<KeyValuePair<string, string>> getParams = null);
     }
 }

--- a/TwitchLib.Api.Core.Interfaces/IRateLimiter.cs
+++ b/TwitchLib.Api.Core.Interfaces/IRateLimiter.cs
@@ -6,20 +6,20 @@ namespace TwitchLib.Api.Core.Interfaces
 {
     public interface IRateLimiter
     {
-        Task Perform(Func<Task> perform, CancellationToken cancellationToken);
+        Task PerformAsync(Func<Task> perform, CancellationToken cancellationToken);
 
-        Task Perform(Func<Task> perform);
+        Task PerformAsync(Func<Task> perform);
 
-        Task<T> Perform<T>(Func<Task<T>> perform);
+        Task<T> PerformAsync<T>(Func<Task<T>> perform);
 
-        Task<T> Perform<T>(Func<Task<T>> perform, CancellationToken cancellationToken);
+        Task<T> PerformAsync<T>(Func<Task<T>> perform, CancellationToken cancellationToken);
 
-        Task Perform(Action perform, CancellationToken cancellationToken);
+        Task PerformAsync(Action perform, CancellationToken cancellationToken);
 
-        Task Perform(Action perform);
+        Task PerformAsync(Action perform);
 
-        Task<T> Perform<T>(Func<T> perform);
+        Task<T> PerformAsync<T>(Func<T> perform);
 
-        Task<T> Perform<T>(Func<T> perform, CancellationToken cancellationToken);
+        Task<T> PerformAsync<T>(Func<T> perform, CancellationToken cancellationToken);
     }
 }

--- a/TwitchLib.Api.Core/ApiBase.cs
+++ b/TwitchLib.Api.Core/ApiBase.cs
@@ -4,7 +4,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
 using TwitchLib.Api.Core.Enums;
 using TwitchLib.Api.Core.Exceptions;
 using TwitchLib.Api.Core.Interfaces;
@@ -19,6 +21,9 @@ namespace TwitchLib.Api.Core
         protected readonly IApiSettings Settings;
         private readonly IRateLimiter _rateLimiter;
         private readonly IHttpCallHandler _http;
+        private readonly SemaphoreSlim _lock = new SemaphoreSlim(1, 1);
+        private string _serverToken;
+        private DateTime _expires = DateTime.MinValue;
 
         internal const string BaseV5 = "https://api.twitch.tv/kraken";
         internal const string BaseHelix = "https://api.twitch.tv/helix";
@@ -36,33 +41,33 @@ namespace TwitchLib.Api.Core
         /// Checks the ClientId and AccessToken against the Twitch Api Endpoints 
         /// </summary>
         /// <returns>CredentialCheckResponseModel with a success boolean and message</returns>
-        public Task<CredentialCheckResponseModel> CheckCredentialsAsync()
+        public async Task<CredentialCheckResponseModel> CheckCredentialsAsync()
         {
             var message = "Check successful";
             var failMessage = "";
             var result = true;
-            if (!string.IsNullOrWhiteSpace(Settings.ClientId) && !ValidClientId(Settings.ClientId))
+            if (!string.IsNullOrWhiteSpace(Settings.ClientId) && !(await ValidClientId(Settings.ClientId).ConfigureAwait(false)))
             {
                 result = false;
                 failMessage = "The passed Client Id was not valid. To get a valid Client Id, register an application here: https://www.twitch.tv/kraken/oauth2/clients/new";
             }
 
-            if (!string.IsNullOrWhiteSpace(Settings.AccessToken) && ValidAccessToken(Settings.AccessToken) == null)
+            if (!string.IsNullOrWhiteSpace(Settings.AccessToken) && (await ValidAccessToken(Settings.AccessToken).ConfigureAwait(false)) == null)
             {
                 result = false;
                 failMessage += "The passed Access Token was not valid. To get an access token, go here:  https://twitchtokengenerator.com/";
             }
 
-            return Task.FromResult(new CredentialCheckResponseModel { Result = result, ResultMessage = result ? message : failMessage });
+            return new CredentialCheckResponseModel { Result = result, ResultMessage = result ? message : failMessage };
         }
 
-        public void DynamicScopeValidation(AuthScopes requiredScope, string accessToken = null)
+        public async Task DynamicScopeValidationAsync(AuthScopes requiredScope, string accessToken = null)
         {
             //Skip validation if skip is set or access token is null
             if (Settings.SkipDynamicScopeValidation || string.IsNullOrWhiteSpace(accessToken)) return;
 
             //set the scopes based on access token
-            Settings.Scopes = ValidAccessToken(accessToken);
+            Settings.Scopes = await ValidAccessToken(accessToken).ConfigureAwait(false);
             //skip if no scopes
             if (Settings.Scopes == null)
                 throw new InvalidCredentialException($"The current access token does not support this call. Missing required scope: {requiredScope.ToString().ToLower()}. You can skip this check by using: IApiSettings.SkipDynamicScopeValidation = true . You can also generate a new token with this scope here: https://twitchtokengenerator.com");
@@ -76,26 +81,42 @@ namespace TwitchLib.Api.Core
             return TwitchGetGenericAsync<Models.Root.Root>("", ApiVersion.V5, accessToken: authToken, clientId: clientId);
         }
 
-        public string GetAccessToken(string accessToken = null)
+        public async Task<string> GetAccessTokenAsync(string accessToken = null)
         {
             if (!string.IsNullOrEmpty(accessToken))
                 return accessToken;
             if (!string.IsNullOrEmpty(Settings.AccessToken))
                 return Settings.AccessToken;
-            if (!string.IsNullOrEmpty(Settings.Secret) && !string.IsNullOrEmpty(Settings.ClientId) && !Settings.SkipAutoServerTokenGeneration)
-                return GenerateServerBasedAccessToken();
+
+            await _lock.WaitAsync();
+
+            try
+            {
+                if (!string.IsNullOrEmpty(Settings.Secret) && !string.IsNullOrEmpty(Settings.ClientId) &&
+                    !Settings.SkipAutoServerTokenGeneration)
+                    return await GenerateServerBasedAccessTokenAsync();
+            }
+            finally
+            {
+                _lock.Release();
+            }
 
             return null;
         }
 
-        internal string GenerateServerBasedAccessToken()
+        internal async Task<string> GenerateServerBasedAccessTokenAsync()
         {
-            var result = _http.GeneralRequest($"{BaseOauthToken}?client_id={Settings.ClientId}&client_secret={Settings.Secret}&grant_type=client_credentials", "POST", null, ApiVersion.Helix, Settings.ClientId, null);
+            if (_serverToken != null && DateTime.UtcNow < _expires)
+                return _serverToken;
+
+            var result = await _http.GeneralRequest($"{BaseOauthToken}?client_id={Settings.ClientId}&client_secret={Settings.Secret}&grant_type=client_credentials", "POST", null, ApiVersion.Helix, Settings.ClientId, null).ConfigureAwait(false);
             if (result.Key == 200)
             {
-                var user = JsonConvert.DeserializeObject<dynamic>(result.Value);
-                var offset = (int)user.expires_in;
-                return (string)user.access_token;
+                var user = JsonConvert.DeserializeObject<JObject>(result.Value);
+
+                _serverToken = user.Value<string>("access_token");
+                _expires = DateTime.UtcNow.AddSeconds(user.Value<int>("expires_in") - 5);
+                return _serverToken;
             }
             return null;
         }
@@ -109,108 +130,137 @@ namespace TwitchLib.Api.Core
             throw new ClientIdAndOAuthTokenRequired("As of May 1, all calls to Twitch's Helix API require Client-ID and OAuth access token be set. Example: api.Settings.AccessToken = \"twitch-oauth-access-token-here\"; api.Settings.ClientId = \"twitch-client-id-here\";");
         }
 
-        protected Task<T> TwitchGetGenericAsync<T>(string resource, ApiVersion api, List<KeyValuePair<string, string>> getParams = null, string accessToken = null, string clientId = null, string customBase = null)
+        protected async Task<T> TwitchGetGenericAsync<T>(string resource, ApiVersion api, List<KeyValuePair<string, string>> getParams = null, string accessToken = null, string clientId = null, string customBase = null)
         {
             var url = ConstructResourceUrl(resource, getParams, api, customBase);
 
             if (string.IsNullOrEmpty(clientId) && !string.IsNullOrEmpty(Settings.ClientId))
                 clientId = Settings.ClientId;
 
-            accessToken = GetAccessToken(accessToken);
+            accessToken = await GetAccessTokenAsync(accessToken).ConfigureAwait(false);
             ForceAccessTokenAndClientIdForHelix(clientId, accessToken, api);
 
-            return _rateLimiter.Perform(async () => await Task.Run(() => JsonConvert.DeserializeObject<T>(_http.GeneralRequest(url, "GET", null, api, clientId, accessToken).Value, _twitchLibJsonDeserializer)).ConfigureAwait(false));
+            return await _rateLimiter.Perform(async () =>
+            {
+                var req = await _http.GeneralRequest(url, "GET", null, api, clientId, accessToken).ConfigureAwait(false);
+                return JsonConvert.DeserializeObject<T>(req.Value, _twitchLibJsonDeserializer);
+            }).ConfigureAwait(false);
         }
 
-        protected Task<string> TwitchDeleteAsync(string resource, ApiVersion api, List<KeyValuePair<string, string>> getParams = null, string accessToken = null, string clientId = null, string customBase = null)
+        protected async Task<string> TwitchDeleteAsync(string resource, ApiVersion api, List<KeyValuePair<string, string>> getParams = null, string accessToken = null, string clientId = null, string customBase = null)
         {
             var url = ConstructResourceUrl(resource, getParams, api, customBase);
 
             if (string.IsNullOrEmpty(clientId) && !string.IsNullOrEmpty(Settings.ClientId))
                 clientId = Settings.ClientId;
 
-            accessToken = GetAccessToken(accessToken);
+            accessToken = await GetAccessTokenAsync(accessToken).ConfigureAwait(false);
             ForceAccessTokenAndClientIdForHelix(clientId, accessToken, api);
 
-            return _rateLimiter.Perform(async () => await Task.Run(() => _http.GeneralRequest(url, "DELETE", null, api, clientId, accessToken).Value).ConfigureAwait(false));
+            return await _rateLimiter.Perform(async () =>
+            {
+                var req = await _http.GeneralRequest(url, "GET", null, api, clientId, accessToken).ConfigureAwait(false);
+                return req.Value;
+            }).ConfigureAwait(false);
         }
 
-        protected Task<T> TwitchPostGenericAsync<T>(string resource, ApiVersion api, string payload, List<KeyValuePair<string, string>> getParams = null, string accessToken = null, string clientId = null, string customBase = null)
+        protected async Task<T> TwitchPostGenericAsync<T>(string resource, ApiVersion api, string payload, List<KeyValuePair<string, string>> getParams = null, string accessToken = null, string clientId = null, string customBase = null)
         {
             var url = ConstructResourceUrl(resource, getParams, api, customBase);
 
             if (string.IsNullOrEmpty(clientId) && !string.IsNullOrEmpty(Settings.ClientId))
                 clientId = Settings.ClientId;
 
-            accessToken = GetAccessToken(accessToken);
+            accessToken = await GetAccessTokenAsync(accessToken).ConfigureAwait(false);
             ForceAccessTokenAndClientIdForHelix(clientId, accessToken, api);
 
-            return _rateLimiter.Perform(async () => await Task.Run(() => JsonConvert.DeserializeObject<T>(_http.GeneralRequest(url, "POST", payload, api, clientId, accessToken).Value, _twitchLibJsonDeserializer)).ConfigureAwait(false));
+            return await _rateLimiter.Perform(async () =>
+            {
+                var req = await _http.GeneralRequest(url, "POST", payload, api, clientId, accessToken).ConfigureAwait(false);
+                return JsonConvert.DeserializeObject<T>(req.Value, _twitchLibJsonDeserializer);
+            }).ConfigureAwait(false);
         }
 
-        protected Task<T> TwitchPostGenericModelAsync<T>(string resource, ApiVersion api, RequestModel model, string accessToken = null, string clientId = null, string customBase = null)
+        protected async Task<T> TwitchPostGenericModelAsync<T>(string resource, ApiVersion api, RequestModel model, string accessToken = null, string clientId = null, string customBase = null)
         {
             var url = ConstructResourceUrl(resource, api: api, overrideUrl: customBase);
 
             if (string.IsNullOrEmpty(clientId) && !string.IsNullOrEmpty(Settings.ClientId))
                 clientId = Settings.ClientId;
 
-            accessToken = GetAccessToken(accessToken);
+            accessToken = await GetAccessTokenAsync(accessToken).ConfigureAwait(false);
             ForceAccessTokenAndClientIdForHelix(clientId, accessToken, api);
 
-            return _rateLimiter.Perform(async () => await Task.Run(() => JsonConvert.DeserializeObject<T>(_http.GeneralRequest(url, "POST", model != null ? _jsonSerializer.SerializeObject(model) : "", api, clientId, accessToken).Value, _twitchLibJsonDeserializer)).ConfigureAwait(false));
+            return await _rateLimiter.Perform(async () =>
+            {
+                var req = await _http.GeneralRequest(url, "POST", model != null ? _jsonSerializer.SerializeObject(model) : "", api, clientId, accessToken).ConfigureAwait(false);
+                return JsonConvert.DeserializeObject<T>(req.Value, _twitchLibJsonDeserializer);
+            }).ConfigureAwait(false);
         }
 
-        protected Task<T> TwitchDeleteGenericAsync<T>(string resource, ApiVersion api, string accessToken = null, string clientId = null, string customBase = null)
+        protected async Task<T> TwitchDeleteGenericAsync<T>(string resource, ApiVersion api, string accessToken = null, string clientId = null, string customBase = null)
         {
             var url = ConstructResourceUrl(resource, null, api, customBase);
 
             if (string.IsNullOrEmpty(clientId) && !string.IsNullOrEmpty(Settings.ClientId))
                 clientId = Settings.ClientId;
 
-            accessToken = GetAccessToken(accessToken);
+            accessToken = await GetAccessTokenAsync(accessToken).ConfigureAwait(false);
             ForceAccessTokenAndClientIdForHelix(clientId, accessToken, api);
 
-            return _rateLimiter.Perform(async () => await Task.Run(() => JsonConvert.DeserializeObject<T>(_http.GeneralRequest(url, "DELETE", null, api, clientId, accessToken).Value, _twitchLibJsonDeserializer)).ConfigureAwait(false));
+
+            return await _rateLimiter.Perform(async () =>
+            {
+                var req = await _http.GeneralRequest(url, "DELETE", null, api, clientId, accessToken).ConfigureAwait(false);
+                return JsonConvert.DeserializeObject<T>(req.Value, _twitchLibJsonDeserializer);
+            }).ConfigureAwait(false);
         }
 
-        protected Task<T> TwitchPutGenericAsync<T>(string resource, ApiVersion api, string payload, List<KeyValuePair<string, string>> getParams = null, string accessToken = null, string clientId = null, string customBase = null)
+        protected async Task<T> TwitchPutGenericAsync<T>(string resource, ApiVersion api, string payload, List<KeyValuePair<string, string>> getParams = null, string accessToken = null, string clientId = null, string customBase = null)
         {
             var url = ConstructResourceUrl(resource, getParams, api, customBase);
 
             if (string.IsNullOrEmpty(clientId) && !string.IsNullOrEmpty(Settings.ClientId))
                 clientId = Settings.ClientId;
 
-            accessToken = GetAccessToken(accessToken);
+            accessToken = await GetAccessTokenAsync(accessToken).ConfigureAwait(false);
             ForceAccessTokenAndClientIdForHelix(clientId, accessToken, api);
 
-            return _rateLimiter.Perform(async () => await Task.Run(() => JsonConvert.DeserializeObject<T>(_http.GeneralRequest(url, "PUT", payload, api, clientId, accessToken).Value, _twitchLibJsonDeserializer)).ConfigureAwait(false));
+            return await _rateLimiter.Perform(async () =>
+            {
+                var req = await _http.GeneralRequest(url, "PUT", payload, api, clientId, accessToken);
+                return JsonConvert.DeserializeObject<T>(req.Value, _twitchLibJsonDeserializer);
+            }).ConfigureAwait(false);
         }
 
-        protected Task<string> TwitchPutAsync(string resource, ApiVersion api, string payload, List<KeyValuePair<string, string>> getParams = null, string accessToken = null, string clientId = null, string customBase = null)
+        protected async Task<string> TwitchPutAsync(string resource, ApiVersion api, string payload, List<KeyValuePair<string, string>> getParams = null, string accessToken = null, string clientId = null, string customBase = null)
         {
             var url = ConstructResourceUrl(resource, getParams, api, customBase);
 
             if (string.IsNullOrEmpty(clientId) && !string.IsNullOrEmpty(Settings.ClientId))
                 clientId = Settings.ClientId;
 
-            accessToken = GetAccessToken(accessToken);
+            accessToken = await GetAccessTokenAsync(accessToken).ConfigureAwait(false);
             ForceAccessTokenAndClientIdForHelix(clientId, accessToken, api);
 
-            return _rateLimiter.Perform(async () => await Task.Run(() => _http.GeneralRequest(url, "PUT", payload, api, clientId, accessToken).Value).ConfigureAwait(false));
+            return await _rateLimiter.Perform(async () =>
+            {
+                var req = await _http.GeneralRequest(url, "PUT", payload, api, clientId, accessToken).ConfigureAwait(false);
+                return req.Value;
+            }).ConfigureAwait(false);
         }
 
-        protected Task<KeyValuePair<int, string>> TwitchPostAsync(string resource, ApiVersion api, string payload, List<KeyValuePair<string, string>> getParams = null, string accessToken = null, string clientId = null, string customBase = null)
+        protected async Task<KeyValuePair<int, string>> TwitchPostAsync(string resource, ApiVersion api, string payload, List<KeyValuePair<string, string>> getParams = null, string accessToken = null, string clientId = null, string customBase = null)
         {
             var url = ConstructResourceUrl(resource, getParams, api, customBase);
 
             if (string.IsNullOrEmpty(clientId) && !string.IsNullOrEmpty(Settings.ClientId))
                 clientId = Settings.ClientId;
 
-            accessToken = GetAccessToken(accessToken);
+            accessToken = await GetAccessTokenAsync(accessToken).ConfigureAwait(false);
             ForceAccessTokenAndClientIdForHelix(clientId, accessToken, api);
 
-            return _rateLimiter.Perform(async () => await Task.Run(() => _http.GeneralRequest(url, "POST", payload, api, clientId, accessToken)).ConfigureAwait(false));
+            return await _rateLimiter.Perform(() => _http.GeneralRequest(url, "POST", payload, api, clientId, accessToken)).ConfigureAwait(false);
         }
 
 
@@ -219,12 +269,12 @@ namespace TwitchLib.Api.Core
             _http.PutBytes(url, payload);
         }
 
-        internal int RequestReturnResponseCode(string url, string method, List<KeyValuePair<string, string>> getParams = null)
+        internal Task<int> RequestReturnResponseCodeAsync(string url, string method, List<KeyValuePair<string, string>> getParams = null)
         {
             return _http.RequestReturnResponseCode(url, method, getParams);
         }
 
-        protected Task<T> GetGenericAsync<T>(string url, List<KeyValuePair<string, string>> getParams = null, string accessToken = null, ApiVersion api = ApiVersion.V5, string clientId = null)
+        protected async Task<T> GetGenericAsync<T>(string url, List<KeyValuePair<string, string>> getParams = null, string accessToken = null, ApiVersion api = ApiVersion.V5, string clientId = null)
         {
             if (getParams != null)
             {
@@ -240,10 +290,16 @@ namespace TwitchLib.Api.Core
             if (string.IsNullOrEmpty(clientId) && !string.IsNullOrEmpty(Settings.ClientId))
                 clientId = Settings.ClientId;
 
-            accessToken = GetAccessToken(accessToken);
+            accessToken = await GetAccessTokenAsync(accessToken);
             ForceAccessTokenAndClientIdForHelix(clientId, accessToken, api);
 
-            return _rateLimiter.Perform(async () => await Task.Run(() => JsonConvert.DeserializeObject<T>(_http.GeneralRequest(url, "GET", null, api, clientId, accessToken).Value, _twitchLibJsonDeserializer)).ConfigureAwait(false));
+            return await _rateLimiter.Perform(async () =>
+            {
+                var req = await _http.GeneralRequest(url, "GET", null, api, clientId, accessToken).ConfigureAwait(false);
+                return JsonConvert.DeserializeObject<T>(
+                    req.Value,
+                    _twitchLibJsonDeserializer);
+            }).ConfigureAwait(false);
         }
 
         internal Task<T> GetSimpleGenericAsync<T>(string url, List<KeyValuePair<string, string>> getParams = null)
@@ -310,11 +366,11 @@ namespace TwitchLib.Api.Core
             }
         }
 
-        private bool ValidClientId(string clientId)
+        private async Task<bool> ValidClientId(string clientId)
         {
             try
             {
-                var result = GetRootAsync(null, clientId).GetAwaiter().GetResult();
+                var result = await GetRootAsync(null, clientId).ConfigureAwait(false);
                 return result.Token != null;
             }
             catch (BadRequestException)
@@ -323,11 +379,11 @@ namespace TwitchLib.Api.Core
             }
         }
 
-        private List<AuthScopes> ValidAccessToken(string accessToken)
+        private async Task<List<AuthScopes>> ValidAccessToken(string accessToken)
         {
             try
             {
-                var resp = GetRootAsync(accessToken).GetAwaiter().GetResult();
+                var resp = await GetRootAsync(accessToken).ConfigureAwait(false);
                 if (resp.Token == null) return null;
 
                 return BuildScopesList(resp.Token);

--- a/TwitchLib.Api.Core/ApiBase.cs
+++ b/TwitchLib.Api.Core/ApiBase.cs
@@ -264,9 +264,9 @@ namespace TwitchLib.Api.Core
         }
 
 
-        protected void PutBytes(string url, byte[] payload)
+        protected Task PutBytesAsync(string url, byte[] payload)
         {
-            _http.PutBytes(url, payload);
+            return _http.PutBytes(url, payload);
         }
 
         internal Task<int> RequestReturnResponseCodeAsync(string url, string method, List<KeyValuePair<string, string>> getParams = null)

--- a/TwitchLib.Api.Core/ApiBase.cs
+++ b/TwitchLib.Api.Core/ApiBase.cs
@@ -88,13 +88,13 @@ namespace TwitchLib.Api.Core
             if (!string.IsNullOrEmpty(Settings.AccessToken))
                 return Settings.AccessToken;
 
-            await _lock.WaitAsync();
+            await _lock.WaitAsync().ConfigureAwait(false);
 
             try
             {
                 if (!string.IsNullOrEmpty(Settings.Secret) && !string.IsNullOrEmpty(Settings.ClientId) &&
                     !Settings.SkipAutoServerTokenGeneration)
-                    return await GenerateServerBasedAccessTokenAsync();
+                    return await GenerateServerBasedAccessTokenAsync().ConfigureAwait(false);
             }
             finally
             {
@@ -109,7 +109,7 @@ namespace TwitchLib.Api.Core
             if (_serverToken != null && DateTime.UtcNow < _expires)
                 return _serverToken;
 
-            var result = await _http.GeneralRequest($"{BaseOauthToken}?client_id={Settings.ClientId}&client_secret={Settings.Secret}&grant_type=client_credentials", "POST", null, ApiVersion.Helix, Settings.ClientId, null).ConfigureAwait(false);
+            var result = await _http.GeneralRequestAsync($"{BaseOauthToken}?client_id={Settings.ClientId}&client_secret={Settings.Secret}&grant_type=client_credentials", "POST", null, ApiVersion.Helix, Settings.ClientId, null).ConfigureAwait(false);
             if (result.Key == 200)
             {
                 var user = JsonConvert.DeserializeObject<JObject>(result.Value);
@@ -140,9 +140,9 @@ namespace TwitchLib.Api.Core
             accessToken = await GetAccessTokenAsync(accessToken).ConfigureAwait(false);
             ForceAccessTokenAndClientIdForHelix(clientId, accessToken, api);
 
-            return await _rateLimiter.Perform(async () =>
+            return await _rateLimiter.PerformAsync(async () =>
             {
-                var req = await _http.GeneralRequest(url, "GET", null, api, clientId, accessToken).ConfigureAwait(false);
+                var req = await _http.GeneralRequestAsync(url, "GET", null, api, clientId, accessToken).ConfigureAwait(false);
                 return JsonConvert.DeserializeObject<T>(req.Value, _twitchLibJsonDeserializer);
             }).ConfigureAwait(false);
         }
@@ -157,9 +157,9 @@ namespace TwitchLib.Api.Core
             accessToken = await GetAccessTokenAsync(accessToken).ConfigureAwait(false);
             ForceAccessTokenAndClientIdForHelix(clientId, accessToken, api);
 
-            return await _rateLimiter.Perform(async () =>
+            return await _rateLimiter.PerformAsync(async () =>
             {
-                var req = await _http.GeneralRequest(url, "GET", null, api, clientId, accessToken).ConfigureAwait(false);
+                var req = await _http.GeneralRequestAsync(url, "GET", null, api, clientId, accessToken).ConfigureAwait(false);
                 return req.Value;
             }).ConfigureAwait(false);
         }
@@ -174,9 +174,9 @@ namespace TwitchLib.Api.Core
             accessToken = await GetAccessTokenAsync(accessToken).ConfigureAwait(false);
             ForceAccessTokenAndClientIdForHelix(clientId, accessToken, api);
 
-            return await _rateLimiter.Perform(async () =>
+            return await _rateLimiter.PerformAsync(async () =>
             {
-                var req = await _http.GeneralRequest(url, "POST", payload, api, clientId, accessToken).ConfigureAwait(false);
+                var req = await _http.GeneralRequestAsync(url, "POST", payload, api, clientId, accessToken).ConfigureAwait(false);
                 return JsonConvert.DeserializeObject<T>(req.Value, _twitchLibJsonDeserializer);
             }).ConfigureAwait(false);
         }
@@ -191,9 +191,9 @@ namespace TwitchLib.Api.Core
             accessToken = await GetAccessTokenAsync(accessToken).ConfigureAwait(false);
             ForceAccessTokenAndClientIdForHelix(clientId, accessToken, api);
 
-            return await _rateLimiter.Perform(async () =>
+            return await _rateLimiter.PerformAsync(async () =>
             {
-                var req = await _http.GeneralRequest(url, "POST", model != null ? _jsonSerializer.SerializeObject(model) : "", api, clientId, accessToken).ConfigureAwait(false);
+                var req = await _http.GeneralRequestAsync(url, "POST", model != null ? _jsonSerializer.SerializeObject(model) : "", api, clientId, accessToken).ConfigureAwait(false);
                 return JsonConvert.DeserializeObject<T>(req.Value, _twitchLibJsonDeserializer);
             }).ConfigureAwait(false);
         }
@@ -209,9 +209,9 @@ namespace TwitchLib.Api.Core
             ForceAccessTokenAndClientIdForHelix(clientId, accessToken, api);
 
 
-            return await _rateLimiter.Perform(async () =>
+            return await _rateLimiter.PerformAsync(async () =>
             {
-                var req = await _http.GeneralRequest(url, "DELETE", null, api, clientId, accessToken).ConfigureAwait(false);
+                var req = await _http.GeneralRequestAsync(url, "DELETE", null, api, clientId, accessToken).ConfigureAwait(false);
                 return JsonConvert.DeserializeObject<T>(req.Value, _twitchLibJsonDeserializer);
             }).ConfigureAwait(false);
         }
@@ -226,9 +226,9 @@ namespace TwitchLib.Api.Core
             accessToken = await GetAccessTokenAsync(accessToken).ConfigureAwait(false);
             ForceAccessTokenAndClientIdForHelix(clientId, accessToken, api);
 
-            return await _rateLimiter.Perform(async () =>
+            return await _rateLimiter.PerformAsync(async () =>
             {
-                var req = await _http.GeneralRequest(url, "PUT", payload, api, clientId, accessToken);
+                var req = await _http.GeneralRequestAsync(url, "PUT", payload, api, clientId, accessToken).ConfigureAwait(false);
                 return JsonConvert.DeserializeObject<T>(req.Value, _twitchLibJsonDeserializer);
             }).ConfigureAwait(false);
         }
@@ -243,9 +243,9 @@ namespace TwitchLib.Api.Core
             accessToken = await GetAccessTokenAsync(accessToken).ConfigureAwait(false);
             ForceAccessTokenAndClientIdForHelix(clientId, accessToken, api);
 
-            return await _rateLimiter.Perform(async () =>
+            return await _rateLimiter.PerformAsync(async () =>
             {
-                var req = await _http.GeneralRequest(url, "PUT", payload, api, clientId, accessToken).ConfigureAwait(false);
+                var req = await _http.GeneralRequestAsync(url, "PUT", payload, api, clientId, accessToken).ConfigureAwait(false);
                 return req.Value;
             }).ConfigureAwait(false);
         }
@@ -260,18 +260,18 @@ namespace TwitchLib.Api.Core
             accessToken = await GetAccessTokenAsync(accessToken).ConfigureAwait(false);
             ForceAccessTokenAndClientIdForHelix(clientId, accessToken, api);
 
-            return await _rateLimiter.Perform(() => _http.GeneralRequest(url, "POST", payload, api, clientId, accessToken)).ConfigureAwait(false);
+            return await _rateLimiter.PerformAsync(() => _http.GeneralRequestAsync(url, "POST", payload, api, clientId, accessToken)).ConfigureAwait(false);
         }
 
 
         protected Task PutBytesAsync(string url, byte[] payload)
         {
-            return _http.PutBytes(url, payload);
+            return _http.PutBytesAsync(url, payload);
         }
 
         internal Task<int> RequestReturnResponseCodeAsync(string url, string method, List<KeyValuePair<string, string>> getParams = null)
         {
-            return _http.RequestReturnResponseCode(url, method, getParams);
+            return _http.RequestReturnResponseCodeAsync(url, method, getParams);
         }
 
         protected async Task<T> GetGenericAsync<T>(string url, List<KeyValuePair<string, string>> getParams = null, string accessToken = null, ApiVersion api = ApiVersion.V5, string clientId = null)
@@ -290,12 +290,12 @@ namespace TwitchLib.Api.Core
             if (string.IsNullOrEmpty(clientId) && !string.IsNullOrEmpty(Settings.ClientId))
                 clientId = Settings.ClientId;
 
-            accessToken = await GetAccessTokenAsync(accessToken);
+            accessToken = await GetAccessTokenAsync(accessToken).ConfigureAwait(false);
             ForceAccessTokenAndClientIdForHelix(clientId, accessToken, api);
 
-            return await _rateLimiter.Perform(async () =>
+            return await _rateLimiter.PerformAsync(async () =>
             {
-                var req = await _http.GeneralRequest(url, "GET", null, api, clientId, accessToken).ConfigureAwait(false);
+                var req = await _http.GeneralRequestAsync(url, "GET", null, api, clientId, accessToken).ConfigureAwait(false);
                 return JsonConvert.DeserializeObject<T>(
                     req.Value,
                     _twitchLibJsonDeserializer);
@@ -314,7 +314,7 @@ namespace TwitchLib.Api.Core
                         url += $"&{getParams[i].Key}={Uri.EscapeDataString(getParams[i].Value)}";
                 }
             }
-            return _rateLimiter.Perform(async () => JsonConvert.DeserializeObject<T>(await SimpleRequestAsync(url), _twitchLibJsonDeserializer));
+            return _rateLimiter.PerformAsync(async () => JsonConvert.DeserializeObject<T>(await SimpleRequestAsync(url).ConfigureAwait(false), _twitchLibJsonDeserializer));
         }
 
         // credit: https://stackoverflow.com/questions/14290988/populate-and-return-entities-from-downloadstringcompleted-handler-in-windows-pho

--- a/TwitchLib.Api.Core/HttpCallHandlers/TwitchHttpClient.cs
+++ b/TwitchLib.Api.Core/HttpCallHandlers/TwitchHttpClient.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;
+using System.Threading.Tasks;
 using TwitchLib.Api.Core.Enums;
 using TwitchLib.Api.Core.Exceptions;
 using TwitchLib.Api.Core.Interfaces;
@@ -28,15 +29,15 @@ namespace TwitchLib.Api.Core.HttpCallHandlers
         }
 
 
-        public void PutBytes(string url, byte[] payload)
+        public async Task PutBytes(string url, byte[] payload)
         {
-            var response = _http.PutAsync(new Uri(url), new ByteArrayContent(payload)).GetAwaiter().GetResult();
+            var response = await _http.PutAsync(new Uri(url), new ByteArrayContent(payload)).ConfigureAwait(false);
 
             if (!response.IsSuccessStatusCode)
                 HandleWebException(response);
         }
 
-        public KeyValuePair<int, string> GeneralRequest(string url, string method, string payload = null, ApiVersion api = ApiVersion.V5, string clientId = null, string accessToken = null)
+        public async Task<KeyValuePair<int, string>> GeneralRequest(string url, string method, string payload = null, ApiVersion api = ApiVersion.V5, string clientId = null, string accessToken = null)
         {
             var request = new HttpRequestMessage
             {
@@ -69,10 +70,10 @@ namespace TwitchLib.Api.Core.HttpCallHandlers
                 request.Content = new StringContent(payload, Encoding.UTF8, "application/json");
 
 
-            var response = _http.SendAsync(request).GetAwaiter().GetResult();
+            var response = await _http.SendAsync(request).ConfigureAwait(false);
             if (response.IsSuccessStatusCode)
             {
-                var respStr =  response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+                var respStr = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new KeyValuePair<int, string>((int)response.StatusCode, respStr);
             }
 
@@ -80,7 +81,7 @@ namespace TwitchLib.Api.Core.HttpCallHandlers
             return new KeyValuePair<int, string>(0, null);
         }
 
-        public int RequestReturnResponseCode(string url, string method, List<KeyValuePair<string, string>> getParams = null)
+        public async Task<int> RequestReturnResponseCode(string url, string method, List<KeyValuePair<string, string>> getParams = null)
         {
             if (getParams != null)
             {
@@ -98,7 +99,7 @@ namespace TwitchLib.Api.Core.HttpCallHandlers
                 RequestUri = new Uri(url),
                 Method = new HttpMethod(method)
             };
-            var response = _http.SendAsync(request).GetAwaiter().GetResult();
+            var response = await _http.SendAsync(request);
             return (int)response.StatusCode;
         }
 

--- a/TwitchLib.Api.Core/HttpCallHandlers/TwitchHttpClient.cs
+++ b/TwitchLib.Api.Core/HttpCallHandlers/TwitchHttpClient.cs
@@ -29,7 +29,7 @@ namespace TwitchLib.Api.Core.HttpCallHandlers
         }
 
 
-        public async Task PutBytes(string url, byte[] payload)
+        public async Task PutBytesAsync(string url, byte[] payload)
         {
             var response = await _http.PutAsync(new Uri(url), new ByteArrayContent(payload)).ConfigureAwait(false);
 
@@ -37,7 +37,7 @@ namespace TwitchLib.Api.Core.HttpCallHandlers
                 HandleWebException(response);
         }
 
-        public async Task<KeyValuePair<int, string>> GeneralRequest(string url, string method, string payload = null, ApiVersion api = ApiVersion.V5, string clientId = null, string accessToken = null)
+        public async Task<KeyValuePair<int, string>> GeneralRequestAsync(string url, string method, string payload = null, ApiVersion api = ApiVersion.V5, string clientId = null, string accessToken = null)
         {
             var request = new HttpRequestMessage
             {
@@ -81,7 +81,7 @@ namespace TwitchLib.Api.Core.HttpCallHandlers
             return new KeyValuePair<int, string>(0, null);
         }
 
-        public async Task<int> RequestReturnResponseCode(string url, string method, List<KeyValuePair<string, string>> getParams = null)
+        public async Task<int> RequestReturnResponseCodeAsync(string url, string method, List<KeyValuePair<string, string>> getParams = null)
         {
             if (getParams != null)
             {
@@ -99,7 +99,7 @@ namespace TwitchLib.Api.Core.HttpCallHandlers
                 RequestUri = new Uri(url),
                 Method = new HttpMethod(method)
             };
-            var response = await _http.SendAsync(request);
+            var response = await _http.SendAsync(request).ConfigureAwait(false);
             return (int)response.StatusCode;
         }
 

--- a/TwitchLib.Api.Core/HttpCallHandlers/TwitchWebRequest.cs
+++ b/TwitchLib.Api.Core/HttpCallHandlers/TwitchWebRequest.cs
@@ -24,17 +24,17 @@ namespace TwitchLib.Api.Core.HttpCallHandlers
         }
     
     
-        public async Task PutBytes(string url, byte[] payload)
+        public async Task PutBytesAsync(string url, byte[] payload)
         {
             try
             {
                 using (var client = new WebClient())
-                    await client.UploadDataTaskAsync(new Uri(url), "PUT", payload);
+                    await client.UploadDataTaskAsync(new Uri(url), "PUT", payload).ConfigureAwait(false);
             }
             catch (WebException ex) { HandleWebException(ex); }
         }
     
-        public async Task<KeyValuePair<int, string>> GeneralRequest(string url, string method, string payload = null, ApiVersion api = ApiVersion.V5, string clientId = null, string accessToken = null)
+        public async Task<KeyValuePair<int, string>> GeneralRequestAsync(string url, string method, string payload = null, ApiVersion api = ApiVersion.V5, string clientId = null, string accessToken = null)
         {
             var request = WebRequest.CreateHttp(url);
             if (string.IsNullOrEmpty(clientId) && string.IsNullOrEmpty(accessToken))
@@ -71,11 +71,11 @@ namespace TwitchLib.Api.Core.HttpCallHandlers
     
             try
             {
-                var response = (HttpWebResponse)await Task.Factory.FromAsync(request.BeginGetResponse, request.EndGetResponse, null);
+                var response = (HttpWebResponse)await Task.Factory.FromAsync(request.BeginGetResponse, request.EndGetResponse, null).ConfigureAwait(false);
     
                 using (var reader = new StreamReader(response.GetResponseStream() ?? throw new InvalidOperationException()))
                 {
-                    var data = await reader.ReadToEndAsync();
+                    var data = await reader.ReadToEndAsync().ConfigureAwait(false);
                     return new KeyValuePair<int, string>((int)response.StatusCode, data);
                 }
             }
@@ -84,7 +84,7 @@ namespace TwitchLib.Api.Core.HttpCallHandlers
             return new KeyValuePair<int, string>(0, null);
         }
     
-        public async Task<int> RequestReturnResponseCode(string url, string method, List<KeyValuePair<string, string>> getParams = null)
+        public async Task<int> RequestReturnResponseCodeAsync(string url, string method, List<KeyValuePair<string, string>> getParams = null)
         {
             if (getParams != null)
             {
@@ -100,7 +100,7 @@ namespace TwitchLib.Api.Core.HttpCallHandlers
             var req = WebRequest.CreateHttp(url);
             req.Method = method;
 
-            var response = (HttpWebResponse) await Task.Factory.FromAsync(req.BeginGetResponse, req.EndGetResponse, null);
+            var response = (HttpWebResponse) await Task.Factory.FromAsync(req.BeginGetResponse, req.EndGetResponse, null).ConfigureAwait(false);
             return (int)response.StatusCode;
         }
     

--- a/TwitchLib.Api.Core/Internal/TwitchLibCustomHttpMessageHandler.cs
+++ b/TwitchLib.Api.Core/Internal/TwitchLibCustomHttpMessageHandler.cs
@@ -21,20 +21,20 @@ namespace TwitchLib.Api.Core.Internal
         {
             if (request.Content != null)
                 _logger?.LogInformation("Timestamp: {timestamp} Type: {type} Method: {method} Resource: {url} Content: {content}",
-                    DateTime.Now, "Request", request.Method.ToString(), request.RequestUri.ToString(), await request.Content.ReadAsStringAsync());
+                    DateTime.Now, "Request", request.Method.ToString(), request.RequestUri.ToString(), await request.Content.ReadAsStringAsync().ConfigureAwait(false));
             else
                 _logger?.LogInformation("Timestamp: {timestamp} Type: {type} Method: {method} Resource: {url}",
                     DateTime.Now, "Request", request.Method.ToString(), request.RequestUri.ToString());
 
             var stopwatch = Stopwatch.StartNew();
-            var response = await base.SendAsync(request, cancellationToken);
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
             stopwatch.Stop();
 
             if (response.IsSuccessStatusCode)
             {
                 if (response.Content != null)
                     _logger?.LogInformation("Timestamp: {timestamp} Type: {type} Resource: {url} Statuscode: {statuscode} Elapsed: {elapsed} ms Content: {content}",
-                        DateTime.Now, "Response", response.RequestMessage.RequestUri, (int)response.StatusCode, stopwatch.ElapsedMilliseconds, await response.Content.ReadAsStringAsync());
+                        DateTime.Now, "Response", response.RequestMessage.RequestUri, (int)response.StatusCode, stopwatch.ElapsedMilliseconds, await response.Content.ReadAsStringAsync().ConfigureAwait(false));
                 else
                     _logger?.LogInformation("Timestamp: {timestamp} Type: {type} Resource: {url} Statuscode: {statuscode} Elapsed: {elapsed} ms",
                         DateTime.Now, "Response", response.RequestMessage.RequestUri, (int)response.StatusCode, stopwatch.ElapsedMilliseconds);
@@ -43,7 +43,7 @@ namespace TwitchLib.Api.Core.Internal
             {
                 if (response.Content != null)
                     _logger?.LogError("Timestamp: {timestamp} Type: {type} Resource: {url} Statuscode: {statuscode} Elapsed: {elapsed} ms Content: {content}",
-                        DateTime.Now, "Response", response.RequestMessage.RequestUri, (int)response.StatusCode, stopwatch.ElapsedMilliseconds, await response.Content.ReadAsStringAsync());
+                        DateTime.Now, "Response", response.RequestMessage.RequestUri, (int)response.StatusCode, stopwatch.ElapsedMilliseconds, await response.Content.ReadAsStringAsync().ConfigureAwait(false));
                 else
                     _logger?.LogError("Timestamp: {timestamp} Type: {type} Resource: {url} Statuscode: {statuscode} Elapsed: {elapsed} ms",
                         DateTime.Now, "Response", response.RequestMessage.RequestUri, (int)response.StatusCode, stopwatch.ElapsedMilliseconds);

--- a/TwitchLib.Api.Core/RateLimiter/BypassLimiter.cs
+++ b/TwitchLib.Api.Core/RateLimiter/BypassLimiter.cs
@@ -7,23 +7,23 @@ namespace TwitchLib.Api.Core.RateLimiter
 {
     public class BypassLimiter : IRateLimiter
     {
-        public Task Perform(Func<Task> perform)
+        public Task PerformAsync(Func<Task> perform)
         {
-            return Perform(perform, CancellationToken.None);
+            return PerformAsync(perform, CancellationToken.None);
         }
 
-        public Task<T> Perform<T>(Func<Task<T>> perform)
+        public Task<T> PerformAsync<T>(Func<Task<T>> perform)
         {
-            return Perform(perform, CancellationToken.None);
+            return PerformAsync(perform, CancellationToken.None);
         }
 
-        public Task Perform(Func<Task> perform, CancellationToken cancellationToken)
+        public Task PerformAsync(Func<Task> perform, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             return perform();
         }
 
-        public Task<T> Perform<T>(Func<Task<T>> perform, CancellationToken cancellationToken)
+        public Task<T> PerformAsync<T>(Func<Task<T>> perform, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             return perform();
@@ -39,28 +39,28 @@ namespace TwitchLib.Api.Core.RateLimiter
             return () => Task.FromResult(compute());
         }
 
-        public Task Perform(Action perform, CancellationToken cancellationToken)
+        public Task PerformAsync(Action perform, CancellationToken cancellationToken)
         {
             var transformed = Transform(perform);
-            return Perform(transformed, cancellationToken);
+            return PerformAsync(transformed, cancellationToken);
         }
 
-        public Task Perform(Action perform)
+        public Task PerformAsync(Action perform)
         {
             var transformed = Transform(perform);
-            return Perform(transformed);
+            return PerformAsync(transformed);
         }
 
-        public Task<T> Perform<T>(Func<T> perform)
+        public Task<T> PerformAsync<T>(Func<T> perform)
         {
             var transformed = Transform(perform);
-            return Perform(transformed);
+            return PerformAsync(transformed);
         }
 
-        public Task<T> Perform<T>(Func<T> perform, CancellationToken cancellationToken)
+        public Task<T> PerformAsync<T>(Func<T> perform, CancellationToken cancellationToken)
         {
             var transformed = Transform(perform);
-            return Perform(transformed, cancellationToken);
+            return PerformAsync(transformed, cancellationToken);
         }
 
         public static BypassLimiter CreateLimiterBypassInstance()

--- a/TwitchLib.Api.Core/RateLimiter/ComposedAwaitableConstraint.cs
+++ b/TwitchLib.Api.Core/RateLimiter/ComposedAwaitableConstraint.cs
@@ -23,7 +23,7 @@ namespace TwitchLib.Api.Core.RateLimiter
             IDisposable[] diposables;
             try 
             {
-                diposables = await Task.WhenAll(_ac1.WaitForReadiness(cancellationToken), _ac2.WaitForReadiness(cancellationToken));
+                diposables = await Task.WhenAll(_ac1.WaitForReadiness(cancellationToken), _ac2.WaitForReadiness(cancellationToken)).ConfigureAwait(false);
             }
             catch (Exception) 
             {

--- a/TwitchLib.Api.Core/RateLimiter/ComposedAwaitableConstraint.cs
+++ b/TwitchLib.Api.Core/RateLimiter/ComposedAwaitableConstraint.cs
@@ -19,7 +19,7 @@ namespace TwitchLib.Api.Core.RateLimiter
 
         public async Task<IDisposable> WaitForReadiness(CancellationToken cancellationToken)
         {
-            await _semafore.WaitAsync(cancellationToken);
+            await _semafore.WaitAsync(cancellationToken).ConfigureAwait(false);
             IDisposable[] diposables;
             try 
             {
@@ -32,11 +32,17 @@ namespace TwitchLib.Api.Core.RateLimiter
             } 
             return new DisposeAction(() => 
             {
-                foreach (var diposable in diposables)
+                try
                 {
-                    diposable.Dispose();
+                    foreach (var disposable in diposables)
+                    {
+                        disposable.Dispose();
+                    }
                 }
-                _semafore.Release();
+                finally
+                {
+                    _semafore.Release();
+                }
             });
         }
     }

--- a/TwitchLib.Api.Core/RateLimiter/CountByIntervalAwaitableConstraint.cs
+++ b/TwitchLib.Api.Core/RateLimiter/CountByIntervalAwaitableConstraint.cs
@@ -34,7 +34,7 @@ namespace TwitchLib.Api.Core.RateLimiter
 
         public async Task<IDisposable> WaitForReadiness(CancellationToken cancellationToken)
         {
-            await _semafore.WaitAsync(cancellationToken);
+            await _semafore.WaitAsync(cancellationToken).ConfigureAwait(false);
             var count = 0;
             var now = _time.GetTimeNow();
             var target = now - _timeSpan;
@@ -52,7 +52,7 @@ namespace TwitchLib.Api.Core.RateLimiter
             var timetoWait = last.Value.Add(_timeSpan) - now;
             try 
             {
-                await _time.GetDelay(timetoWait, cancellationToken);
+                await _time.GetDelay(timetoWait, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception) 
             {

--- a/TwitchLib.Api.Core/RateLimiter/TimeLimiter.cs
+++ b/TwitchLib.Api.Core/RateLimiter/TimeLimiter.cs
@@ -29,18 +29,18 @@ namespace TwitchLib.Api.Core.RateLimiter
         public async Task Perform(Func<Task> perform, CancellationToken cancellationToken) 
         {
             cancellationToken.ThrowIfCancellationRequested();
-            using (await _ac.WaitForReadiness(cancellationToken)) 
+            using (await _ac.WaitForReadiness(cancellationToken).ConfigureAwait(false)) 
             {
-                await perform();
+                await perform().ConfigureAwait(false);
             }
         }
 
         public async Task<T> Perform<T>(Func<Task<T>> perform, CancellationToken cancellationToken) 
         {
             cancellationToken.ThrowIfCancellationRequested();
-            using (await _ac.WaitForReadiness(cancellationToken)) 
+            using (await _ac.WaitForReadiness(cancellationToken).ConfigureAwait(false)) 
             {
-                return await perform();
+                return await perform().ConfigureAwait(false);
             }
         }
 

--- a/TwitchLib.Api.Core/RateLimiter/TimeLimiter.cs
+++ b/TwitchLib.Api.Core/RateLimiter/TimeLimiter.cs
@@ -16,17 +16,17 @@ namespace TwitchLib.Api.Core.RateLimiter
             _ac = ac;
         }
 
-        public Task Perform(Func<Task> perform) 
+        public Task PerformAsync(Func<Task> perform) 
         {
-            return Perform(perform, CancellationToken.None);
+            return PerformAsync(perform, CancellationToken.None);
         }
 
-        public Task<T> Perform<T>(Func<Task<T>> perform) 
+        public Task<T> PerformAsync<T>(Func<Task<T>> perform) 
         {
-            return Perform(perform, CancellationToken.None);
+            return PerformAsync(perform, CancellationToken.None);
         }
 
-        public async Task Perform(Func<Task> perform, CancellationToken cancellationToken) 
+        public async Task PerformAsync(Func<Task> perform, CancellationToken cancellationToken) 
         {
             cancellationToken.ThrowIfCancellationRequested();
             using (await _ac.WaitForReadiness(cancellationToken).ConfigureAwait(false)) 
@@ -35,7 +35,7 @@ namespace TwitchLib.Api.Core.RateLimiter
             }
         }
 
-        public async Task<T> Perform<T>(Func<Task<T>> perform, CancellationToken cancellationToken) 
+        public async Task<T> PerformAsync<T>(Func<Task<T>> perform, CancellationToken cancellationToken) 
         {
             cancellationToken.ThrowIfCancellationRequested();
             using (await _ac.WaitForReadiness(cancellationToken).ConfigureAwait(false)) 
@@ -54,28 +54,28 @@ namespace TwitchLib.Api.Core.RateLimiter
             return () =>  Task.FromResult(compute()); 
         }
 
-        public Task Perform(Action perform, CancellationToken cancellationToken) 
+        public Task PerformAsync(Action perform, CancellationToken cancellationToken) 
         {
            var transformed = Transform(perform);
-           return Perform(transformed, cancellationToken);
+           return PerformAsync(transformed, cancellationToken);
         }
 
-        public Task Perform(Action perform) 
+        public Task PerformAsync(Action perform) 
         {
             var transformed = Transform(perform);
-            return Perform(transformed);
+            return PerformAsync(transformed);
         }
 
-        public Task<T> Perform<T>(Func<T> perform) 
+        public Task<T> PerformAsync<T>(Func<T> perform) 
         {
             var transformed = Transform(perform);
-            return Perform(transformed);
+            return PerformAsync(transformed);
         }
 
-        public Task<T> Perform<T>(Func<T> perform, CancellationToken cancellationToken) 
+        public Task<T> PerformAsync<T>(Func<T> perform, CancellationToken cancellationToken) 
         {
             var transformed = Transform(perform);
-            return Perform(transformed, cancellationToken);
+            return PerformAsync(transformed, cancellationToken);
         }
 
         public static TimeLimiter GetFromMaxCountByInterval(int maxCount, TimeSpan timeSpan)

--- a/TwitchLib.Api.Core/Undocumented/Undocumented.cs
+++ b/TwitchLib.Api.Core/Undocumented/Undocumented.cs
@@ -186,16 +186,16 @@ namespace TwitchLib.Api.Core.Undocumented
 
         #region IsUsernameAvailable
 
-        public Task<bool> IsUsernameAvailableAsync(string username)
+        public async Task<bool> IsUsernameAvailableAsync(string username)
         {
             var getParams = new List<KeyValuePair<string, string>> {new KeyValuePair<string, string>("users_service", "true")};
-            var resp = RequestReturnResponseCode($"https://passport.twitch.tv/usernames/{username}", "HEAD", getParams);
+            var resp = await RequestReturnResponseCodeAsync($"https://passport.twitch.tv/usernames/{username}", "HEAD", getParams).ConfigureAwait(false);
             switch (resp)
             {
                 case 200:
-                    return Task.FromResult(false);
+                    return false;
                 case 204:
-                    return Task.FromResult(true);
+                    return true;
                 default:
                     throw new BadResourceException("Unexpected response from resource. Expecting response code 200 or 204, received: " + resp);
             }

--- a/TwitchLib.Api.Core/Undocumented/Undocumented.cs
+++ b/TwitchLib.Api.Core/Undocumented/Undocumented.cs
@@ -146,7 +146,7 @@ namespace TwitchLib.Api.Core.Undocumented
 
         public async Task<List<ChatterFormatted>> GetChattersAsync(string channelName)
         {
-            var resp = await GetGenericAsync<ChattersResponse>($"https://tmi.twitch.tv/group/user/{channelName.ToLower()}/chatters");
+            var resp = await GetGenericAsync<ChattersResponse>($"https://tmi.twitch.tv/group/user/{channelName.ToLower()}/chatters").ConfigureAwait(false);
 
             var chatters = resp.Chatters.Staff.Select(chatter => new ChatterFormatted(chatter, UserType.Staff)).ToList();
             chatters.AddRange(resp.Chatters.Admins.Select(chatter => new ChatterFormatted(chatter, UserType.Admin)));
@@ -229,8 +229,8 @@ namespace TwitchLib.Api.Core.Undocumented
 
         public async Task<List<CommentsPage>> GetAllCommentsAsync(string videoId)
         {
-            var pages = new List<CommentsPage> {await GetCommentsPageAsync(videoId)};
-            while (pages.Last().Next != null) pages.Add(await GetCommentsPageAsync(videoId, null, pages.Last().Next));
+            var pages = new List<CommentsPage> {await GetCommentsPageAsync(videoId).ConfigureAwait(false)};
+            while (pages.Last().Next != null) pages.Add(await GetCommentsPageAsync(videoId, null, pages.Last().Next).ConfigureAwait(false));
 
             return pages;
         }

--- a/TwitchLib.Api.Helix/Analytics.cs
+++ b/TwitchLib.Api.Helix/Analytics.cs
@@ -17,7 +17,7 @@ namespace TwitchLib.Api.Helix
 
         public Task<GetGameAnalyticsResponse> GetGameAnalyticsAsync(string gameId = null, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.Helix_Analytics_Read_Games, authToken);
+            DynamicScopeValidationAsync(AuthScopes.Helix_Analytics_Read_Games, authToken);
             var getParams = new List<KeyValuePair<string, string>>();
             if (gameId != null)
                 getParams.Add(new KeyValuePair<string, string>("game_id", gameId));
@@ -31,7 +31,7 @@ namespace TwitchLib.Api.Helix
 
         public Task<GetExtensionAnalyticsResponse> GetExtensionAnalyticsAsync(string extensionId, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.Helix_Analytics_Read_Extensions, authToken);
+            DynamicScopeValidationAsync(AuthScopes.Helix_Analytics_Read_Extensions, authToken);
             var getParams = new List<KeyValuePair<string, string>>();
             if (extensionId != null)
                 getParams.Add(new KeyValuePair<string, string>("extension_id", extensionId));

--- a/TwitchLib.Api.Helix/Analytics.cs
+++ b/TwitchLib.Api.Helix/Analytics.cs
@@ -15,28 +15,28 @@ namespace TwitchLib.Api.Helix
 
         #region GetGameAnalytics
 
-        public Task<GetGameAnalyticsResponse> GetGameAnalyticsAsync(string gameId = null, string authToken = null)
+        public async Task<GetGameAnalyticsResponse> GetGameAnalyticsAsync(string gameId = null, string authToken = null)
         {
-            DynamicScopeValidationAsync(AuthScopes.Helix_Analytics_Read_Games, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.Helix_Analytics_Read_Games, authToken).ConfigureAwait(false);
             var getParams = new List<KeyValuePair<string, string>>();
             if (gameId != null)
                 getParams.Add(new KeyValuePair<string, string>("game_id", gameId));
 
-            return TwitchGetGenericAsync<GetGameAnalyticsResponse>("/analytics/games", ApiVersion.Helix, getParams, authToken);
+            return await TwitchGetGenericAsync<GetGameAnalyticsResponse>("/analytics/games", ApiVersion.Helix, getParams, authToken).ConfigureAwait(false);
         }
 
         #endregion
 
         #region GetExtensionAnalytics
 
-        public Task<GetExtensionAnalyticsResponse> GetExtensionAnalyticsAsync(string extensionId, string authToken = null)
+        public async Task<GetExtensionAnalyticsResponse> GetExtensionAnalyticsAsync(string extensionId, string authToken = null)
         {
-            DynamicScopeValidationAsync(AuthScopes.Helix_Analytics_Read_Extensions, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.Helix_Analytics_Read_Extensions, authToken).ConfigureAwait(false);
             var getParams = new List<KeyValuePair<string, string>>();
             if (extensionId != null)
                 getParams.Add(new KeyValuePair<string, string>("extension_id", extensionId));
 
-            return TwitchGetGenericAsync<GetExtensionAnalyticsResponse>("/analytics/extensions", ApiVersion.Helix, getParams, authToken);
+            return await TwitchGetGenericAsync<GetExtensionAnalyticsResponse>("/analytics/extensions", ApiVersion.Helix, getParams, authToken).ConfigureAwait(false);
         }
 
         #endregion

--- a/TwitchLib.Api.Helix/Bits.cs
+++ b/TwitchLib.Api.Helix/Bits.cs
@@ -17,9 +17,9 @@ namespace TwitchLib.Api.Helix
 
         #region GetBitsLeaderboard
 
-        public Task<GetBitsLeaderboardResponse> GetBitsLeaderboardAsync(int count = 10, BitsLeaderboardPeriodEnum period = BitsLeaderboardPeriodEnum.All, DateTime? startedAt = null, string userid = null, string accessToken = null)
+        public async Task<GetBitsLeaderboardResponse> GetBitsLeaderboardAsync(int count = 10, BitsLeaderboardPeriodEnum period = BitsLeaderboardPeriodEnum.All, DateTime? startedAt = null, string userid = null, string accessToken = null)
         {
-            DynamicScopeValidation(AuthScopes.Helix_Bits_Read, accessToken);
+            await DynamicScopeValidationAsync(AuthScopes.Helix_Bits_Read, accessToken).ConfigureAwait(false);
 
             var getParams = new List<KeyValuePair<string, string>>
                     {
@@ -50,7 +50,7 @@ namespace TwitchLib.Api.Helix
             if (userid != null)
                 getParams.Add(new KeyValuePair<string, string>("user_id", userid));
 
-            return TwitchGetGenericAsync<GetBitsLeaderboardResponse>("/bits/leaderboard", ApiVersion.Helix, getParams);
+            return await TwitchGetGenericAsync<GetBitsLeaderboardResponse>("/bits/leaderboard", ApiVersion.Helix, getParams).ConfigureAwait(false);
         }
 
         #endregion

--- a/TwitchLib.Api.Helix/Clips.cs
+++ b/TwitchLib.Api.Helix/Clips.cs
@@ -57,7 +57,7 @@ namespace TwitchLib.Api.Helix
 
         public Task<CreatedClipResponse> CreateClipAsync(string broadcasterId, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.Helix_Clips_Edit);
+            DynamicScopeValidationAsync(AuthScopes.Helix_Clips_Edit);
             var getParams = new List<KeyValuePair<string, string>>
                 {
                     new KeyValuePair<string, string>("broadcaster_id", broadcasterId)

--- a/TwitchLib.Api.Helix/Clips.cs
+++ b/TwitchLib.Api.Helix/Clips.cs
@@ -55,14 +55,14 @@ namespace TwitchLib.Api.Helix
 
         #region CreateClip
 
-        public Task<CreatedClipResponse> CreateClipAsync(string broadcasterId, string authToken = null)
+        public async Task<CreatedClipResponse> CreateClipAsync(string broadcasterId, string authToken = null)
         {
-            DynamicScopeValidationAsync(AuthScopes.Helix_Clips_Edit);
+            await DynamicScopeValidationAsync(AuthScopes.Helix_Clips_Edit).ConfigureAwait(false);
             var getParams = new List<KeyValuePair<string, string>>
                 {
                     new KeyValuePair<string, string>("broadcaster_id", broadcasterId)
                 };
-            return TwitchPostGenericAsync<CreatedClipResponse>("/clips", ApiVersion.Helix, null, getParams, authToken);
+            return await TwitchPostGenericAsync<CreatedClipResponse>("/clips", ApiVersion.Helix, null, getParams, authToken).ConfigureAwait(false);
         }
 
         #endregion

--- a/TwitchLib.Api.Helix/Streams.cs
+++ b/TwitchLib.Api.Helix/Streams.cs
@@ -116,7 +116,7 @@ namespace TwitchLib.Api.Helix
 
         public Task ReplaceStreamTags(string broadcasterId, List<string> tagIds = null, string accessToken = null)
         {
-            DynamicScopeValidation(AuthScopes.Helix_User_Edit_Broadcast, accessToken);
+            DynamicScopeValidationAsync(AuthScopes.Helix_User_Edit_Broadcast, accessToken);
 
             var getParams = new List<KeyValuePair<string, string>>();
             getParams.Add(new KeyValuePair<string, string>("broadcaster_id", broadcasterId));

--- a/TwitchLib.Api.Helix/Streams.cs
+++ b/TwitchLib.Api.Helix/Streams.cs
@@ -114,9 +114,9 @@ namespace TwitchLib.Api.Helix
             return TwitchGetGenericAsync<GetStreamTagsResponse>("/streams/tags", ApiVersion.Helix, getParams, accessToken);
         }
 
-        public Task ReplaceStreamTags(string broadcasterId, List<string> tagIds = null, string accessToken = null)
+        public async Task ReplaceStreamTags(string broadcasterId, List<string> tagIds = null, string accessToken = null)
         {
-            DynamicScopeValidationAsync(AuthScopes.Helix_User_Edit_Broadcast, accessToken);
+            await DynamicScopeValidationAsync(AuthScopes.Helix_User_Edit_Broadcast, accessToken).ConfigureAwait(false);
 
             var getParams = new List<KeyValuePair<string, string>>();
             getParams.Add(new KeyValuePair<string, string>("broadcaster_id", broadcasterId));
@@ -129,7 +129,7 @@ namespace TwitchLib.Api.Helix
                 payload = dynamicPayload.ToString();
             }
 
-            return TwitchPutAsync("/streams/tags", ApiVersion.Helix, payload, getParams, accessToken);
+            await TwitchPutAsync("/streams/tags", ApiVersion.Helix, payload, getParams, accessToken).ConfigureAwait(false);
         }
     }
 

--- a/TwitchLib.Api.Helix/Users.cs
+++ b/TwitchLib.Api.Helix/Users.cs
@@ -76,9 +76,9 @@ namespace TwitchLib.Api.Helix
             return TwitchGetGenericAsync<GetUserActiveExtensionsResponse>("/users/extensions", ApiVersion.Helix, getParams, accessToken: authToken);
         }
 
-        public Task<GetUserActiveExtensionsResponse> UpdateUserExtensionsAsync(IEnumerable<ExtensionSlot> userExtensionStates, string authToken = null)
+        public async Task<GetUserActiveExtensionsResponse> UpdateUserExtensionsAsync(IEnumerable<ExtensionSlot> userExtensionStates, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.Channel_Editor, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.Channel_Editor, authToken).ConfigureAwait(false);
 
             var panels = new Dictionary<string, UserExtensionState>();
             var overlays = new Dictionary<string, UserExtensionState>();
@@ -115,7 +115,7 @@ namespace TwitchLib.Api.Helix
             json.Add(new JProperty("data", JObject.FromObject(p)));
             var payload = json.ToString();
 
-            return TwitchPutGenericAsync<GetUserActiveExtensionsResponse>("/users/extensions", ApiVersion.Helix, payload, accessToken: authToken);
+            return await TwitchPutGenericAsync<GetUserActiveExtensionsResponse>("/users/extensions", ApiVersion.Helix, payload, accessToken: authToken).ConfigureAwait(false);
         }
     }
 }

--- a/TwitchLib.Api.Helix/Webhooks.cs
+++ b/TwitchLib.Api.Helix/Webhooks.cs
@@ -16,7 +16,7 @@ namespace TwitchLib.Api.Helix
         }
 
         #region GetWebhookSubscriptions
-        public Task<GetWebhookSubscriptionsResponse> GetWebhookSubscriptionsAsync(string after = null, int first = 20, string accessToken = null)
+        public async Task<GetWebhookSubscriptionsResponse> GetWebhookSubscriptionsAsync(string after = null, int first = 20, string accessToken = null)
         {
             if (first < 1 || first > 100)
                 throw new BadParameterException("'first' must between 1 (inclusive) and 100 (inclusive).");
@@ -29,12 +29,12 @@ namespace TwitchLib.Api.Helix
                 getParams.Add(new KeyValuePair<string, string>("after", after));
 
 
-            accessToken = GetAccessToken(accessToken);
+            accessToken = await GetAccessTokenAsync(accessToken).ConfigureAwait(false);
 
             if (string.IsNullOrEmpty(accessToken))
                 throw new BadParameterException("'accessToken' be supplied, set AccessToken in settings or ClientId and Secret in settings");
 
-            return TwitchGetGenericAsync<GetWebhookSubscriptionsResponse>("/webhooks/subscriptions", ApiVersion.Helix, getParams, accessToken);
+            return await TwitchGetGenericAsync<GetWebhookSubscriptionsResponse>("/webhooks/subscriptions", ApiVersion.Helix, getParams, accessToken).ConfigureAwait(false);
         }
 
         #endregion
@@ -98,7 +98,7 @@ namespace TwitchLib.Api.Helix
 
         public Task<bool> GameAnalyticsAsync(string callbackUrl, WebhookCallMode mode, string gameId, TimeSpan? duration = null, string signingSecret = null, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.Helix_Analytics_Read_Games, authToken);
+            DynamicScopeValidationAsync(AuthScopes.Helix_Analytics_Read_Games, authToken);
             var leaseSeconds = (int)ValidateTimespan(duration).TotalSeconds;
 
             return PerformWebhookRequestAsync(mode, $"https://api.twitch.tv/helix/analytics/games?game_id={gameId}", callbackUrl, leaseSeconds, signingSecret);

--- a/TwitchLib.Api.Helix/Webhooks.cs
+++ b/TwitchLib.Api.Helix/Webhooks.cs
@@ -96,12 +96,12 @@ namespace TwitchLib.Api.Helix
 
         #region GameAnalytics
 
-        public Task<bool> GameAnalyticsAsync(string callbackUrl, WebhookCallMode mode, string gameId, TimeSpan? duration = null, string signingSecret = null, string authToken = null)
+        public async Task<bool> GameAnalyticsAsync(string callbackUrl, WebhookCallMode mode, string gameId, TimeSpan? duration = null, string signingSecret = null, string authToken = null)
         {
-            DynamicScopeValidationAsync(AuthScopes.Helix_Analytics_Read_Games, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.Helix_Analytics_Read_Games, authToken).ConfigureAwait(false);
             var leaseSeconds = (int)ValidateTimespan(duration).TotalSeconds;
 
-            return PerformWebhookRequestAsync(mode, $"https://api.twitch.tv/helix/analytics/games?game_id={gameId}", callbackUrl, leaseSeconds, signingSecret);
+            return await PerformWebhookRequestAsync(mode, $"https://api.twitch.tv/helix/analytics/games?game_id={gameId}", callbackUrl, leaseSeconds, signingSecret).ConfigureAwait(false);
         }
 
         #endregion

--- a/TwitchLib.Api.Test/HelixVideos.cs
+++ b/TwitchLib.Api.Test/HelixVideos.cs
@@ -19,7 +19,7 @@ namespace TwitchLib.Api.Test
                 .Returns(new System.Collections.Generic.KeyValuePair<int, string>(200, GetGameAnalyticsResponse));
             var api = new TwitchAPI(http: mockHandler.Object);
 
-           var result= await api.Analytics.Helix.GetGameAnalyticsAsync("493057", "RandomTokenThatDoesntMatter");
+            var result= await api.Analytics.Helix.GetGameAnalyticsAsync("493057", "RandomTokenThatDoesntMatter");
 
             Assert.True(result.Data[0].Type == "overview_v2");
             Assert.True(result.Data[0].GameId == "493057");

--- a/TwitchLib.Api.Test/Helpers/TwitchLibMock.cs
+++ b/TwitchLib.Api.Test/Helpers/TwitchLibMock.cs
@@ -27,7 +27,7 @@ namespace TwitchLib.Api.Test.Helpers
             foreach (var (url, response) in urlResponses)
             {
                 mockHandler
-                    .Setup(x => x.GeneralRequest(It.Is<string>(y => new Uri(y).GetLeftPart(UriPartial.Path) == url), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Core.Enums.ApiVersion>(), It.IsAny<string>(), It.IsAny<string>()))
+                    .Setup(x => x.GeneralRequestAsync(It.Is<string>(y => new Uri(y).GetLeftPart(UriPartial.Path) == url), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Core.Enums.ApiVersion>(), It.IsAny<string>(), It.IsAny<string>()))
                     .Returns(Task.FromResult(new KeyValuePair<int, string>(200, response)));
             }
         }
@@ -39,7 +39,7 @@ namespace TwitchLib.Api.Test.Helpers
             foreach (var (url, response) in urlResponses)
             {
                 mockHandler
-                    .Setup(x => x.GeneralRequest(It.Is<string>(y => new Uri(y).GetLeftPart(UriPartial.Path) == url), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Core.Enums.ApiVersion>(), It.IsAny<string>(), It.IsAny<string>()))
+                    .Setup(x => x.GeneralRequestAsync(It.Is<string>(y => new Uri(y).GetLeftPart(UriPartial.Path) == url), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Core.Enums.ApiVersion>(), It.IsAny<string>(), It.IsAny<string>()))
                     .Returns(Task.FromResult(new KeyValuePair<int, string>(200, response)));
             }
             

--- a/TwitchLib.Api.Test/Helpers/TwitchLibMock.cs
+++ b/TwitchLib.Api.Test/Helpers/TwitchLibMock.cs
@@ -1,6 +1,7 @@
 ﻿using Moq;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using TwitchLib.Api.Core.Interfaces;
 
 namespace TwitchLib.Api.Test.Helpers
@@ -27,7 +28,7 @@ namespace TwitchLib.Api.Test.Helpers
             {
                 mockHandler
                     .Setup(x => x.GeneralRequest(It.Is<string>(y => new Uri(y).GetLeftPart(UriPartial.Path) == url), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Core.Enums.ApiVersion>(), It.IsAny<string>(), It.IsAny<string>()))
-                    .Returns(new KeyValuePair<int, string>(200, response));
+                    .Returns(Task.FromResult(new KeyValuePair<int, string>(200, response)));
             }
         }
 
@@ -39,7 +40,7 @@ namespace TwitchLib.Api.Test.Helpers
             {
                 mockHandler
                     .Setup(x => x.GeneralRequest(It.Is<string>(y => new Uri(y).GetLeftPart(UriPartial.Path) == url), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Core.Enums.ApiVersion>(), It.IsAny<string>(), It.IsAny<string>()))
-                    .Returns(new KeyValuePair<int, string>(200, response));
+                    .Returns(Task.FromResult(new KeyValuePair<int, string>(200, response)));
             }
             
             return mockHandler;

--- a/TwitchLib.Api.Test/Integration/V5/V5Setup.cs
+++ b/TwitchLib.Api.Test/Integration/V5/V5Setup.cs
@@ -14,10 +14,10 @@ namespace TwitchLib.Api.Test.Integration.V5
         {
             var mockHandler = new Mock<IHttpCallHandler>();
             mockHandler
-                .Setup(x => x.GeneralRequest(It.Is<string>(y => y == V5Root), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Core.Enums.ApiVersion>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Setup(x => x.GeneralRequestAsync(It.Is<string>(y => y == V5Root), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Core.Enums.ApiVersion>(), It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(Task.FromResult(new KeyValuePair<int, string>(200, GetRootScopesResponse)));
             mockHandler
-                .Setup(x => x.GeneralRequest(It.IsNotIn(V5Root), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Core.Enums.ApiVersion>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Setup(x => x.GeneralRequestAsync(It.IsNotIn(V5Root), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Core.Enums.ApiVersion>(), It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(Task.FromResult(new KeyValuePair<int, string>(200, response)));
 
             return mockHandler;

--- a/TwitchLib.Api.Test/Integration/V5/V5Setup.cs
+++ b/TwitchLib.Api.Test/Integration/V5/V5Setup.cs
@@ -1,5 +1,6 @@
 ﻿using Moq;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using TwitchLib.Api.Core.Interfaces;
 
 namespace TwitchLib.Api.Test.Integration.V5
@@ -14,10 +15,10 @@ namespace TwitchLib.Api.Test.Integration.V5
             var mockHandler = new Mock<IHttpCallHandler>();
             mockHandler
                 .Setup(x => x.GeneralRequest(It.Is<string>(y => y == V5Root), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Core.Enums.ApiVersion>(), It.IsAny<string>(), It.IsAny<string>()))
-                .Returns(new KeyValuePair<int, string>(200, GetRootScopesResponse));
+                .Returns(Task.FromResult(new KeyValuePair<int, string>(200, GetRootScopesResponse)));
             mockHandler
                 .Setup(x => x.GeneralRequest(It.IsNotIn(V5Root), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Core.Enums.ApiVersion>(), It.IsAny<string>(), It.IsAny<string>()))
-                .Returns(new KeyValuePair<int, string>(200, response));
+                .Returns(Task.FromResult(new KeyValuePair<int, string>(200, response)));
 
             return mockHandler;
         }

--- a/TwitchLib.Api.Test/Services/FollowerServiceTests.cs
+++ b/TwitchLib.Api.Test/Services/FollowerServiceTests.cs
@@ -223,7 +223,7 @@ namespace TwitchLib.Api.Test.Services
                 var mockHandler = new Mock<IHttpCallHandler>();
 
                 mockHandler
-                    .Setup(x => x.GeneralRequest(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Core.Enums.ApiVersion>(), It.IsAny<string>(), It.IsAny<string>()))
+                    .Setup(x => x.GeneralRequestAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Core.Enums.ApiVersion>(), It.IsAny<string>(), It.IsAny<string>()))
                     .Returns(Task.FromResult(new KeyValuePair<int, string>(200, usersFollowsResponseFirstUserJson)));
 
                 _api = TwitchLibMock.TwitchApi(mockHandler);
@@ -246,7 +246,7 @@ namespace TwitchLib.Api.Test.Services
                 mockHandler.Reset();
 
                 mockHandler
-                    .Setup(x => x.GeneralRequest(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Core.Enums.ApiVersion>(), It.IsAny<string>(), It.IsAny<string>()))
+                    .Setup(x => x.GeneralRequestAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Core.Enums.ApiVersion>(), It.IsAny<string>(), It.IsAny<string>()))
                     .Returns(Task.FromResult(new KeyValuePair<int, string>(200, usersFollowsResponseSecondUserJson)));
 
                 await _followerService.UpdateLatestFollowersAsync();

--- a/TwitchLib.Api.Test/Services/FollowerServiceTests.cs
+++ b/TwitchLib.Api.Test/Services/FollowerServiceTests.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using TwitchLib.Api.Core.Interfaces;
 using TwitchLib.Api.Helix.Models.Users;
 using TwitchLib.Api.Services;
@@ -223,7 +224,7 @@ namespace TwitchLib.Api.Test.Services
 
                 mockHandler
                     .Setup(x => x.GeneralRequest(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Core.Enums.ApiVersion>(), It.IsAny<string>(), It.IsAny<string>()))
-                    .Returns(new KeyValuePair<int, string>(200, usersFollowsResponseFirstUserJson));
+                    .Returns(Task.FromResult(new KeyValuePair<int, string>(200, usersFollowsResponseFirstUserJson)));
 
                 _api = TwitchLibMock.TwitchApi(mockHandler);
 
@@ -246,7 +247,7 @@ namespace TwitchLib.Api.Test.Services
 
                 mockHandler
                     .Setup(x => x.GeneralRequest(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Core.Enums.ApiVersion>(), It.IsAny<string>(), It.IsAny<string>()))
-                    .Returns(new KeyValuePair<int, string>(200, usersFollowsResponseSecondUserJson));
+                    .Returns(Task.FromResult(new KeyValuePair<int, string>(200, usersFollowsResponseSecondUserJson)));
 
                 await _followerService.UpdateLatestFollowersAsync();
 

--- a/TwitchLib.Api.Test/Unit/Helix/HelixSetup.cs
+++ b/TwitchLib.Api.Test/Unit/Helix/HelixSetup.cs
@@ -1,5 +1,6 @@
 ﻿using Moq;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using TwitchLib.Api.Core.Interfaces;
 
 namespace TwitchLib.Api.Test.Unit.Helix
@@ -14,10 +15,10 @@ namespace TwitchLib.Api.Test.Unit.Helix
             var mockHandler = new Mock<IHttpCallHandler>();
             mockHandler
                 .Setup(x => x.GeneralRequest(It.Is<string>(y => y == V5Root), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Core.Enums.ApiVersion>(), It.IsAny<string>(), It.IsAny<string>()))
-                .Returns(new KeyValuePair<int, string>(200, GetRootScopesResponse));
+                .Returns(Task.FromResult(new KeyValuePair<int, string>(200, GetRootScopesResponse)));
             mockHandler
                 .Setup(x => x.GeneralRequest(It.IsNotIn(V5Root), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Core.Enums.ApiVersion>(), It.IsAny<string>(), It.IsAny<string>()))
-                .Returns(new KeyValuePair<int, string>(200, response));
+                .Returns(Task.FromResult(new KeyValuePair<int, string>(200, response)));
 
             return mockHandler;
         }

--- a/TwitchLib.Api.Test/Unit/Helix/HelixSetup.cs
+++ b/TwitchLib.Api.Test/Unit/Helix/HelixSetup.cs
@@ -14,10 +14,10 @@ namespace TwitchLib.Api.Test.Unit.Helix
         {
             var mockHandler = new Mock<IHttpCallHandler>();
             mockHandler
-                .Setup(x => x.GeneralRequest(It.Is<string>(y => y == V5Root), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Core.Enums.ApiVersion>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Setup(x => x.GeneralRequestAsync(It.Is<string>(y => y == V5Root), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Core.Enums.ApiVersion>(), It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(Task.FromResult(new KeyValuePair<int, string>(200, GetRootScopesResponse)));
             mockHandler
-                .Setup(x => x.GeneralRequest(It.IsNotIn(V5Root), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Core.Enums.ApiVersion>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Setup(x => x.GeneralRequestAsync(It.IsNotIn(V5Root), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Core.Enums.ApiVersion>(), It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(Task.FromResult(new KeyValuePair<int, string>(200, response)));
 
             return mockHandler;

--- a/TwitchLib.Api.Test/Unit/V5/V5Setup.cs
+++ b/TwitchLib.Api.Test/Unit/V5/V5Setup.cs
@@ -1,5 +1,6 @@
 ﻿using Moq;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using TwitchLib.Api.Core.Interfaces;
 
 namespace TwitchLib.Api.Test.Unit.V5
@@ -14,10 +15,10 @@ namespace TwitchLib.Api.Test.Unit.V5
             var mockHandler = new Mock<IHttpCallHandler>();
             mockHandler
                 .Setup(x => x.GeneralRequest(It.Is<string>(y => y == V5Root), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Core.Enums.ApiVersion>(), It.IsAny<string>(), It.IsAny<string>()))
-                .Returns(new KeyValuePair<int, string>(200, GetRootScopesResponse));
+                .Returns(Task.FromResult(new KeyValuePair<int, string>(200, GetRootScopesResponse)));
             mockHandler
                 .Setup(x => x.GeneralRequest(It.IsNotIn(V5Root), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Core.Enums.ApiVersion>(), It.IsAny<string>(), It.IsAny<string>()))
-                .Returns(new KeyValuePair<int, string>(200, response));
+                .Returns(Task.FromResult(new KeyValuePair<int, string>(200, response)));
 
             return mockHandler;
         }

--- a/TwitchLib.Api.Test/Unit/V5/V5Setup.cs
+++ b/TwitchLib.Api.Test/Unit/V5/V5Setup.cs
@@ -14,10 +14,10 @@ namespace TwitchLib.Api.Test.Unit.V5
         {
             var mockHandler = new Mock<IHttpCallHandler>();
             mockHandler
-                .Setup(x => x.GeneralRequest(It.Is<string>(y => y == V5Root), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Core.Enums.ApiVersion>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Setup(x => x.GeneralRequestAsync(It.Is<string>(y => y == V5Root), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Core.Enums.ApiVersion>(), It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(Task.FromResult(new KeyValuePair<int, string>(200, GetRootScopesResponse)));
             mockHandler
-                .Setup(x => x.GeneralRequest(It.IsNotIn(V5Root), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Core.Enums.ApiVersion>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Setup(x => x.GeneralRequestAsync(It.IsNotIn(V5Root), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Core.Enums.ApiVersion>(), It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(Task.FromResult(new KeyValuePair<int, string>(200, response)));
 
             return mockHandler;

--- a/TwitchLib.Api.V5/Channels.cs
+++ b/TwitchLib.Api.V5/Channels.cs
@@ -189,7 +189,7 @@ namespace TwitchLib.Api.V5
             var leftOverFollowers = (totalFollowers - amount) % 100;
             var requiredRequests = (totalFollowers - amount - leftOverFollowers) / 100;
 
-            await Task.Delay(1000);
+            await Task.Delay(1000).ConfigureAwait(false);
             for (var i = 0; i < requiredRequests; i++)
             {
                 var requestedFollowers = await GetChannelFollowersAsync(channelId, 100, cursor: cursor).ConfigureAwait(false);
@@ -197,7 +197,7 @@ namespace TwitchLib.Api.V5
                 followers.AddRange(requestedFollowers.Follows.OfType<ChannelFollow>().ToList());
 
                 // we should wait a second before performing another request per Twitch requirements
-                await Task.Delay(1000);
+                await Task.Delay(1000).ConfigureAwait(false);
             }
 
             // get leftover subs
@@ -271,7 +271,7 @@ namespace TwitchLib.Api.V5
             await DynamicScopeValidationAsync(AuthScopes.Channel_Subscriptions, accessToken).ConfigureAwait(false);
             // initial stuffs
             var allSubs = new List<Subscription>();
-            var firstBatch = await GetChannelSubscribersAsync(channelId, 100, 0, "asc", accessToken);
+            var firstBatch = await GetChannelSubscribersAsync(channelId, 100, 0, "asc", accessToken).ConfigureAwait(false);
             var totalSubs = firstBatch.Total;
             allSubs.AddRange(firstBatch.Subscriptions);
 
@@ -282,7 +282,7 @@ namespace TwitchLib.Api.V5
 
             // perform required requests after initial delay
             var currentOffset = amount;
-            await Task.Delay(1000);
+            await Task.Delay(1000).ConfigureAwait(false);
             for (var i = 0; i < requiredRequests; i++)
             {
                 var requestedSubs = await GetChannelSubscribersAsync(channelId, 100, currentOffset, "asc", accessToken).ConfigureAwait(false);
@@ -290,7 +290,7 @@ namespace TwitchLib.Api.V5
                 currentOffset += requestedSubs.Subscriptions.Length;
 
                 // We should wait a second before performing another request per Twitch requirements
-                await Task.Delay(1000);
+                await Task.Delay(1000).ConfigureAwait(false);
             }
 
             // get leftover subs

--- a/TwitchLib.Api.V5/Channels.cs
+++ b/TwitchLib.Api.V5/Channels.cs
@@ -77,9 +77,9 @@ namespace TwitchLib.Api.V5
         /// </param>
         /// <param name="authToken"></param>
         /// <returns>A Channel object with the newly changed properties.</returns>
-        public Task<Channel> UpdateChannelAsync(string channelId, string status = null, string game = null, string delay = null, bool? channelFeedEnabled = null, string authToken = null)
+        public async Task<Channel> UpdateChannelAsync(string channelId, string status = null, string game = null, string delay = null, bool? channelFeedEnabled = null, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.Helix_User_Edit_Broadcast, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.Helix_User_Edit_Broadcast, authToken).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(channelId))
                 throw new BadParameterException("The channel id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -109,7 +109,7 @@ namespace TwitchLib.Api.V5
 
             payload = "{ \"channel\": {" + payload + "} }";
 
-            return TwitchPutGenericAsync<Channel>($"/channels/{channelId}", ApiVersion.V5, payload, accessToken: authToken);
+            return await TwitchPutGenericAsync<Channel>($"/channels/{channelId}", ApiVersion.V5, payload, accessToken: authToken).ConfigureAwait(false);
         }
 
         #endregion
@@ -125,7 +125,7 @@ namespace TwitchLib.Api.V5
         /// <returns>A ChannelEditors object that contains an array of the Users which are Editor of the channel.</returns>
         public Task<ChannelEditors> GetChannelEditorsAsync(string channelId, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.Channel_Read, authToken);
+            DynamicScopeValidationAsync(AuthScopes.Channel_Read, authToken);
             if (string.IsNullOrWhiteSpace(channelId))
                 throw new BadParameterException("The channel id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -240,7 +240,7 @@ namespace TwitchLib.Api.V5
         /// <returns></returns>
         public Task<ChannelSubscribers> GetChannelSubscribersAsync(string channelId, int? limit = null, int? offset = null, string direction = null, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.Channel_Subscriptions, authToken);
+            DynamicScopeValidationAsync(AuthScopes.Channel_Subscriptions, authToken);
             if (string.IsNullOrWhiteSpace(channelId))
                 throw new BadParameterException("The channel id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -268,7 +268,7 @@ namespace TwitchLib.Api.V5
         /// <returns></returns>
         public async Task<List<Subscription>> GetAllSubscribersAsync(string channelId, string accessToken = null)
         {
-            DynamicScopeValidation(AuthScopes.Channel_Subscriptions, accessToken);
+            DynamicScopeValidationAsync(AuthScopes.Channel_Subscriptions, accessToken);
             // initial stuffs
             var allSubs = new List<Subscription>();
             var firstBatch = await GetChannelSubscribersAsync(channelId, 100, 0, "asc", accessToken);
@@ -321,7 +321,7 @@ namespace TwitchLib.Api.V5
         /// <returns>Returns a subscription object or null if not subscribed.</returns>
         public Task<Subscription> CheckChannelSubscriptionByUserAsync(string channelId, string userId, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.Channel_Check_Subscription, authToken);
+            DynamicScopeValidationAsync(AuthScopes.Channel_Check_Subscription, authToken);
             if (string.IsNullOrWhiteSpace(channelId))
                 throw new BadParameterException("The channel id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -375,7 +375,7 @@ namespace TwitchLib.Api.V5
 
         public Task<ChannelCommercial> StartChannelCommercialAsync(string channelId, CommercialLength duration, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.Channel_Commercial, authToken);
+            DynamicScopeValidationAsync(AuthScopes.Channel_Commercial, authToken);
             if (string.IsNullOrWhiteSpace(channelId))
                 throw new BadParameterException("The channel id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -406,7 +406,7 @@ namespace TwitchLib.Api.V5
         /// </returns>
         public Task<ChannelAuthed> ResetChannelStreamKeyAsync(string channelId, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.Channel_Stream, authToken);
+            DynamicScopeValidationAsync(AuthScopes.Channel_Stream, authToken);
             if (string.IsNullOrWhiteSpace(channelId))
                 throw new BadParameterException("The channel id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -459,7 +459,7 @@ namespace TwitchLib.Api.V5
         /// <param name="authToken"></param>
         public Task SetChannelCommunitiesAsync(string channelId, List<string> communityIds, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.Channel_Editor, authToken);
+            DynamicScopeValidationAsync(AuthScopes.Channel_Editor, authToken);
             if (string.IsNullOrWhiteSpace(channelId))
                 throw new BadParameterException("The channel id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 

--- a/TwitchLib.Api.V5/Channels.cs
+++ b/TwitchLib.Api.V5/Channels.cs
@@ -123,13 +123,13 @@ namespace TwitchLib.Api.V5
         /// <param name="channelId">The specified channelId of the channel to get the information from.</param>
         /// <param name="authToken"></param>
         /// <returns>A ChannelEditors object that contains an array of the Users which are Editor of the channel.</returns>
-        public Task<ChannelEditors> GetChannelEditorsAsync(string channelId, string authToken = null)
+        public async Task<ChannelEditors> GetChannelEditorsAsync(string channelId, string authToken = null)
         {
-            DynamicScopeValidationAsync(AuthScopes.Channel_Read, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.Channel_Read, authToken).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(channelId))
                 throw new BadParameterException("The channel id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
-            return TwitchGetGenericAsync<ChannelEditors>($"/channels/{channelId}/editors", ApiVersion.V5, accessToken: authToken);
+            return await TwitchGetGenericAsync<ChannelEditors>($"/channels/{channelId}/editors", ApiVersion.V5, accessToken: authToken).ConfigureAwait(false);
         }
 
         #endregion
@@ -238,9 +238,9 @@ namespace TwitchLib.Api.V5
         /// <param name="direction">Sorting direction. Valid values: "asc", "desc" (newest first). Default: "desc".</param>
         /// <param name="authToken">The associated auth token for this request.</param>
         /// <returns></returns>
-        public Task<ChannelSubscribers> GetChannelSubscribersAsync(string channelId, int? limit = null, int? offset = null, string direction = null, string authToken = null)
+        public async Task<ChannelSubscribers> GetChannelSubscribersAsync(string channelId, int? limit = null, int? offset = null, string direction = null, string authToken = null)
         {
-            DynamicScopeValidationAsync(AuthScopes.Channel_Subscriptions, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.Channel_Subscriptions, authToken).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(channelId))
                 throw new BadParameterException("The channel id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -252,7 +252,7 @@ namespace TwitchLib.Api.V5
             if (!string.IsNullOrEmpty(direction) && (direction == "asc" || direction == "desc"))
                 getParams.Add(new KeyValuePair<string, string>("direction", direction));
 
-            return TwitchGetGenericAsync<ChannelSubscribers>($"/channels/{channelId}/subscriptions", ApiVersion.V5, getParams, authToken);
+            return await TwitchGetGenericAsync<ChannelSubscribers>($"/channels/{channelId}/subscriptions", ApiVersion.V5, getParams, authToken).ConfigureAwait(false);
         }
 
         #endregion
@@ -268,7 +268,7 @@ namespace TwitchLib.Api.V5
         /// <returns></returns>
         public async Task<List<Subscription>> GetAllSubscribersAsync(string channelId, string accessToken = null)
         {
-            DynamicScopeValidationAsync(AuthScopes.Channel_Subscriptions, accessToken);
+            await DynamicScopeValidationAsync(AuthScopes.Channel_Subscriptions, accessToken).ConfigureAwait(false);
             // initial stuffs
             var allSubs = new List<Subscription>();
             var firstBatch = await GetChannelSubscribersAsync(channelId, 100, 0, "asc", accessToken);
@@ -319,16 +319,16 @@ namespace TwitchLib.Api.V5
         /// <param name="userId">The specified user to check for.</param>
         /// <param name="authToken"></param>
         /// <returns>Returns a subscription object or null if not subscribed.</returns>
-        public Task<Subscription> CheckChannelSubscriptionByUserAsync(string channelId, string userId, string authToken = null)
+        public async Task<Subscription> CheckChannelSubscriptionByUserAsync(string channelId, string userId, string authToken = null)
         {
-            DynamicScopeValidationAsync(AuthScopes.Channel_Check_Subscription, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.Channel_Check_Subscription, authToken).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(channelId))
                 throw new BadParameterException("The channel id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
             if (string.IsNullOrWhiteSpace(userId))
                 throw new BadParameterException("The user id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
-            return TwitchGetGenericAsync<Subscription>($"/channels/{channelId}/subscriptions/{userId}", ApiVersion.V5, accessToken: authToken);
+            return await TwitchGetGenericAsync<Subscription>($"/channels/{channelId}/subscriptions/{userId}", ApiVersion.V5, accessToken: authToken).ConfigureAwait(false);
         }
 
         #endregion
@@ -373,14 +373,14 @@ namespace TwitchLib.Api.V5
 
         #region StartChannelCommercial
 
-        public Task<ChannelCommercial> StartChannelCommercialAsync(string channelId, CommercialLength duration, string authToken = null)
+        public async Task<ChannelCommercial> StartChannelCommercialAsync(string channelId, CommercialLength duration, string authToken = null)
         {
-            DynamicScopeValidationAsync(AuthScopes.Channel_Commercial, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.Channel_Commercial, authToken).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(channelId))
                 throw new BadParameterException("The channel id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
             var payload = "{\"duration\": " + (int)duration + "}";
-            return TwitchPostGenericAsync<ChannelCommercial>($"/channels/{channelId}/commercial", ApiVersion.V5, payload, accessToken: authToken);
+            return await TwitchPostGenericAsync<ChannelCommercial>($"/channels/{channelId}/commercial", ApiVersion.V5, payload, accessToken: authToken).ConfigureAwait(false);
         }
 
         #endregion
@@ -404,13 +404,13 @@ namespace TwitchLib.Api.V5
         ///     A ChannelPrivileged object that also contains the email and stream key of the channel aside from the normal
         ///     channel values.
         /// </returns>
-        public Task<ChannelAuthed> ResetChannelStreamKeyAsync(string channelId, string authToken = null)
+        public async Task<ChannelAuthed> ResetChannelStreamKeyAsync(string channelId, string authToken = null)
         {
-            DynamicScopeValidationAsync(AuthScopes.Channel_Stream, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.Channel_Stream, authToken).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(channelId))
                 throw new BadParameterException("The channel id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
-            return TwitchDeleteGenericAsync<ChannelAuthed>($"/channels/{channelId}/stream_key", ApiVersion.V5, authToken);
+            return await TwitchDeleteGenericAsync<ChannelAuthed>($"/channels/{channelId}/stream_key", ApiVersion.V5, authToken).ConfigureAwait(false);
         }
 
         #endregion
@@ -457,9 +457,9 @@ namespace TwitchLib.Api.V5
         /// <param name="channelId">The specified channel to set the community for.</param>
         /// <param name="communityIds">The specified communities to set the channel to be a part of.</param>
         /// <param name="authToken"></param>
-        public Task SetChannelCommunitiesAsync(string channelId, List<string> communityIds, string authToken = null)
+        public async Task SetChannelCommunitiesAsync(string channelId, List<string> communityIds, string authToken = null)
         {
-            DynamicScopeValidationAsync(AuthScopes.Channel_Editor, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.Channel_Editor, authToken).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(channelId))
                 throw new BadParameterException("The channel id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -480,7 +480,7 @@ namespace TwitchLib.Api.V5
                     payload += $", \"{communityId}\"";
 
             payload = $"{{\"community_ids\": [{payload}]}}";
-            return TwitchPutAsync($"/channels/{channelId}/communities", ApiVersion.V5, payload, accessToken: authToken);
+            await TwitchPutAsync($"/channels/{channelId}/communities", ApiVersion.V5, payload, accessToken: authToken).ConfigureAwait(false);
         }
 
         #endregion

--- a/TwitchLib.Api.V5/Chat.cs
+++ b/TwitchLib.Api.V5/Chat.cs
@@ -55,10 +55,10 @@ namespace TwitchLib.Api.V5
 
         #region GetChatRoomsByChannel 
 
-        public Task<ChatRoomsByChannelResponse> GetChatRoomsByChannelAsync(string channelId, string authToken = null)
+        public async Task<ChatRoomsByChannelResponse> GetChatRoomsByChannelAsync(string channelId, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.Any, authToken);
-            return TwitchGetGenericAsync<ChatRoomsByChannelResponse>($"/chat/{channelId}/rooms", ApiVersion.V5, accessToken: authToken);
+            await DynamicScopeValidationAsync(AuthScopes.Any, authToken).ConfigureAwait(false);
+            return await TwitchGetGenericAsync<ChatRoomsByChannelResponse>($"/chat/{channelId}/rooms", ApiVersion.V5, accessToken: authToken).ConfigureAwait(false);
         }
 
         #endregion

--- a/TwitchLib.Api.V5/Clips.cs
+++ b/TwitchLib.Api.V5/Clips.cs
@@ -67,7 +67,7 @@ namespace TwitchLib.Api.V5
 
         public Task<FollowClipsResponse> GetFollowedClipsAsync(long limit = 10, string cursor = null, bool trending = false, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.User_Read, authToken);
+            DynamicScopeValidationAsync(AuthScopes.User_Read, authToken).ConfigureAwait(false);
             var getParams = new List<KeyValuePair<string, string>>
                 {
                     new KeyValuePair<string, string>("limit", limit.ToString())

--- a/TwitchLib.Api.V5/Collections.cs
+++ b/TwitchLib.Api.V5/Collections.cs
@@ -64,9 +64,9 @@ namespace TwitchLib.Api.V5
 
         #region CreateCollection
 
-        public Task<CollectionMetadata> CreateCollectionAsync(string channelId, string collectionTitle, string authToken = null)
+        public async Task<CollectionMetadata> CreateCollectionAsync(string channelId, string collectionTitle, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.Collections_Edit, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.Collections_Edit, authToken).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(channelId))
                 throw new BadParameterException("The channel id is not valid for a collection creation. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -74,7 +74,7 @@ namespace TwitchLib.Api.V5
                 throw new BadParameterException("The collection title is not valid for a collection. It is not allowed to be null, empty or filled with whitespaces.");
 
             var payload = "{\"title\": \"" + collectionTitle + "\"}";
-            return TwitchPostGenericAsync<CollectionMetadata>($"/channels/{channelId}/collections", ApiVersion.V5, payload, accessToken: authToken);
+            return await TwitchPostGenericAsync<CollectionMetadata>($"/channels/{channelId}/collections", ApiVersion.V5, payload, accessToken: authToken).ConfigureAwait(false);
         }
 
         #endregion
@@ -83,7 +83,7 @@ namespace TwitchLib.Api.V5
 
         public Task UpdateCollectionAsync(string collectionId, string newCollectionTitle, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.Collections_Edit, authToken);
+            DynamicScopeValidationAsync(AuthScopes.Collections_Edit, authToken);
             if (string.IsNullOrWhiteSpace(collectionId))
                 throw new BadParameterException("The collection id is not valid for a collection. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -100,7 +100,7 @@ namespace TwitchLib.Api.V5
 
         public Task CreateCollectionThumbnailAsync(string collectionId, string itemId, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.Collections_Edit, authToken);
+            DynamicScopeValidationAsync(AuthScopes.Collections_Edit, authToken);
             if (string.IsNullOrWhiteSpace(collectionId))
                 throw new BadParameterException("The collection id is not valid for a collection. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -117,7 +117,7 @@ namespace TwitchLib.Api.V5
 
         public Task DeleteCollectionAsync(string collectionId, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.Collections_Edit, authToken);
+            DynamicScopeValidationAsync(AuthScopes.Collections_Edit, authToken);
             if (string.IsNullOrWhiteSpace(collectionId))
                 throw new BadParameterException("The collection id is not valid for a collection. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -130,7 +130,7 @@ namespace TwitchLib.Api.V5
 
         public Task<CollectionItem> AddItemToCollectionAsync(string collectionId, string itemId, string itemType, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.Collections_Edit, authToken);
+            DynamicScopeValidationAsync(AuthScopes.Collections_Edit, authToken);
             if (string.IsNullOrWhiteSpace(collectionId))
                 throw new BadParameterException("The collection id is not valid for a collection. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -150,7 +150,7 @@ namespace TwitchLib.Api.V5
 
         public Task DeleteItemFromCollectionAsync(string collectionId, string itemId, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.Collections_Edit, authToken);
+            DynamicScopeValidationAsync(AuthScopes.Collections_Edit, authToken);
             if (string.IsNullOrWhiteSpace(collectionId))
                 throw new BadParameterException("The collection id is not valid for a collection. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -166,7 +166,7 @@ namespace TwitchLib.Api.V5
 
         public Task MoveItemWithinCollectionAsync(string collectionId, string itemId, int position, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.Collections_Edit, authToken);
+            DynamicScopeValidationAsync(AuthScopes.Collections_Edit, authToken);
             if (string.IsNullOrWhiteSpace(collectionId))
                 throw new BadParameterException("The collection id is not valid for a collection. It is not allowed to be null, empty or filled with whitespaces.");
 

--- a/TwitchLib.Api.V5/Collections.cs
+++ b/TwitchLib.Api.V5/Collections.cs
@@ -157,7 +157,7 @@ namespace TwitchLib.Api.V5
             if (string.IsNullOrWhiteSpace(itemId))
                 throw new BadParameterException("The item id is not valid for a collection. It is not allowed to be null, empty or filled with whitespaces.");
 
-            await TwitchDeleteAsync($"/collections/{collectionId}/items/{itemId}", ApiVersion.V5, accessToken: authToken);
+            await TwitchDeleteAsync($"/collections/{collectionId}/items/{itemId}", ApiVersion.V5, accessToken: authToken).ConfigureAwait(false);
         }
 
         #endregion

--- a/TwitchLib.Api.V5/Collections.cs
+++ b/TwitchLib.Api.V5/Collections.cs
@@ -81,9 +81,9 @@ namespace TwitchLib.Api.V5
 
         #region UpdateCollection
 
-        public Task UpdateCollectionAsync(string collectionId, string newCollectionTitle, string authToken = null)
+        public async Task UpdateCollectionAsync(string collectionId, string newCollectionTitle, string authToken = null)
         {
-            DynamicScopeValidationAsync(AuthScopes.Collections_Edit, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.Collections_Edit, authToken).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(collectionId))
                 throw new BadParameterException("The collection id is not valid for a collection. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -91,16 +91,16 @@ namespace TwitchLib.Api.V5
                 throw new BadParameterException("The new collection title is not valid for a collection. It is not allowed to be null, empty or filled with whitespaces.");
 
             var payload = "{\"title\": \"" + newCollectionTitle + "\"}";
-            return TwitchPutAsync($"/collections/{collectionId}", ApiVersion.V5, payload, accessToken: authToken);
+            await TwitchPutAsync($"/collections/{collectionId}", ApiVersion.V5, payload, accessToken: authToken).ConfigureAwait(false);
         }
 
         #endregion
 
         #region CreateCollectionThumbnail
 
-        public Task CreateCollectionThumbnailAsync(string collectionId, string itemId, string authToken = null)
+        public async Task CreateCollectionThumbnailAsync(string collectionId, string itemId, string authToken = null)
         {
-            DynamicScopeValidationAsync(AuthScopes.Collections_Edit, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.Collections_Edit, authToken).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(collectionId))
                 throw new BadParameterException("The collection id is not valid for a collection. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -108,29 +108,29 @@ namespace TwitchLib.Api.V5
                 throw new BadParameterException("The item id is not valid for a collection. It is not allowed to be null, empty or filled with whitespaces.");
 
             var payload = "{\"item_id\": \"" + itemId + "\"}";
-            return TwitchPutAsync($"/collections/{collectionId}/thumbnail", ApiVersion.V5, payload, accessToken: authToken);
+            await TwitchPutAsync($"/collections/{collectionId}/thumbnail", ApiVersion.V5, payload, accessToken: authToken).ConfigureAwait(false);
         }
 
         #endregion
 
         #region DeleteCollection
 
-        public Task DeleteCollectionAsync(string collectionId, string authToken = null)
+        public async Task DeleteCollectionAsync(string collectionId, string authToken = null)
         {
-            DynamicScopeValidationAsync(AuthScopes.Collections_Edit, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.Collections_Edit, authToken).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(collectionId))
                 throw new BadParameterException("The collection id is not valid for a collection. It is not allowed to be null, empty or filled with whitespaces.");
 
-            return TwitchDeleteAsync($"/collections/{collectionId}", ApiVersion.V5, accessToken: authToken);
+            await TwitchDeleteAsync($"/collections/{collectionId}", ApiVersion.V5, accessToken: authToken).ConfigureAwait(false);
         }
 
         #endregion
 
         #region AddItemToCollection
 
-        public Task<CollectionItem> AddItemToCollectionAsync(string collectionId, string itemId, string itemType, string authToken = null)
+        public async Task<CollectionItem> AddItemToCollectionAsync(string collectionId, string itemId, string itemType, string authToken = null)
         {
-            DynamicScopeValidationAsync(AuthScopes.Collections_Edit, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.Collections_Edit, authToken).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(collectionId))
                 throw new BadParameterException("The collection id is not valid for a collection. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -141,32 +141,32 @@ namespace TwitchLib.Api.V5
                 throw new BadParameterException($"The item_type {itemType} is not valid for a collection. Item type MUST be \"video\".");
 
             var payload = "{\"id\": \"" + itemId + "\", \"type\": \"" + itemType + "\"}";
-            return TwitchPostGenericAsync<CollectionItem>($"/collections/{collectionId}/items", ApiVersion.V5, payload, accessToken: authToken);
+            return await TwitchPostGenericAsync<CollectionItem>($"/collections/{collectionId}/items", ApiVersion.V5, payload, accessToken: authToken).ConfigureAwait(false);
         }
 
         #endregion
 
         #region DeleteItemFromCollection
 
-        public Task DeleteItemFromCollectionAsync(string collectionId, string itemId, string authToken = null)
+        public async Task DeleteItemFromCollectionAsync(string collectionId, string itemId, string authToken = null)
         {
-            DynamicScopeValidationAsync(AuthScopes.Collections_Edit, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.Collections_Edit, authToken).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(collectionId))
                 throw new BadParameterException("The collection id is not valid for a collection. It is not allowed to be null, empty or filled with whitespaces.");
 
             if (string.IsNullOrWhiteSpace(itemId))
                 throw new BadParameterException("The item id is not valid for a collection. It is not allowed to be null, empty or filled with whitespaces.");
 
-            return TwitchDeleteAsync($"/collections/{collectionId}/items/{itemId}", ApiVersion.V5, accessToken: authToken);
+            await TwitchDeleteAsync($"/collections/{collectionId}/items/{itemId}", ApiVersion.V5, accessToken: authToken);
         }
 
         #endregion
 
         #region MoveItemWithinCollection
 
-        public Task MoveItemWithinCollectionAsync(string collectionId, string itemId, int position, string authToken = null)
+        public async Task MoveItemWithinCollectionAsync(string collectionId, string itemId, int position, string authToken = null)
         {
-            DynamicScopeValidationAsync(AuthScopes.Collections_Edit, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.Collections_Edit, authToken).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(collectionId))
                 throw new BadParameterException("The collection id is not valid for a collection. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -177,7 +177,7 @@ namespace TwitchLib.Api.V5
                 throw new BadParameterException("The position is not valid for a collection. It is not allowed to be less than 1.");
 
             var payload = "{\"position\": \"" + position + "\"}";
-            return TwitchPutAsync($"/collections/{collectionId}/items/{itemId}", ApiVersion.V5, payload, accessToken: authToken);
+            await TwitchPutAsync($"/collections/{collectionId}/items/{itemId}", ApiVersion.V5, payload, accessToken: authToken).ConfigureAwait(false);
         }
 
         #endregion

--- a/TwitchLib.Api.V5/Communities.cs
+++ b/TwitchLib.Api.V5/Communities.cs
@@ -95,9 +95,9 @@ namespace TwitchLib.Api.V5
 
         #region GetCommunityBannedUsers
 
-        public Task<BannedUsers> GetCommunityBannedUsersAsync(string communityId, long? limit = null, string cursor = null, string authToken = null)
+        public async Task<BannedUsers> GetCommunityBannedUsersAsync(string communityId, long? limit = null, string cursor = null, string authToken = null)
         {
-            DynamicScopeValidationAsync(AuthScopes.Communities_Moderate, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.Communities_Moderate, authToken).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(communityId))
                 throw new BadParameterException("The community id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -107,48 +107,48 @@ namespace TwitchLib.Api.V5
             if (!string.IsNullOrEmpty(cursor))
                 getParams.Add(new KeyValuePair<string, string>("cursor", cursor));
 
-            return TwitchGetGenericAsync<BannedUsers>($"/communities/{communityId}/bans", ApiVersion.V5, getParams, authToken);
+            return await TwitchGetGenericAsync<BannedUsers>($"/communities/{communityId}/bans", ApiVersion.V5, getParams, authToken).ConfigureAwait(false);
         }
 
         #endregion
 
         #region BanCommunityUser
 
-        public Task BanCommunityUserAsync(string communityId, string userId, string authToken = null)
+        public async Task BanCommunityUserAsync(string communityId, string userId, string authToken = null)
         {
-            DynamicScopeValidationAsync(AuthScopes.Communities_Moderate, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.Communities_Moderate, authToken).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(communityId))
                 throw new BadParameterException("The community id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
             if (string.IsNullOrWhiteSpace(userId))
                 throw new BadParameterException("The user id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
-            return TwitchPutAsync($"/communities/{communityId}/bans/{userId}", ApiVersion.V5, null, accessToken: authToken);
+            await TwitchPutAsync($"/communities/{communityId}/bans/{userId}", ApiVersion.V5, null, accessToken: authToken).ConfigureAwait(false);
         }
 
         #endregion
 
         #region UnBanCommunityUser
 
-        public Task UnBanCommunityUserAsync(string communityId, string userId, string authToken = null)
+        public async Task UnBanCommunityUserAsync(string communityId, string userId, string authToken = null)
         {
-            DynamicScopeValidationAsync(AuthScopes.Communities_Moderate, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.Communities_Moderate, authToken).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(communityId))
                 throw new BadParameterException("The community id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
             if (string.IsNullOrWhiteSpace(userId))
                 throw new BadParameterException("The user id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
-            return TwitchDeleteAsync($"/communities/{communityId}/bans/{userId}", ApiVersion.V5, accessToken: authToken);
+            await TwitchDeleteAsync($"/communities/{communityId}/bans/{userId}", ApiVersion.V5, accessToken: authToken).ConfigureAwait(false);
         }
 
         #endregion
 
         #region CreateCommunityAvatarImage
 
-        public Task CreateCommunityAvatarImageAsync(string communityId, string avatarImage, string authToken = null)
+        public async Task CreateCommunityAvatarImageAsync(string communityId, string avatarImage, string authToken = null)
         {
-            DynamicScopeValidationAsync(AuthScopes.Communities_Edit, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.Communities_Edit, authToken).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(communityId))
                 throw new BadParameterException("The community id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -156,29 +156,29 @@ namespace TwitchLib.Api.V5
                 throw new BadParameterException("The avatar image is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
             var payload = "{\"avatar_image\": \"" + avatarImage + "\"}";
-            return TwitchPostAsync($"/communities/{communityId}/images/avatar", ApiVersion.V5, payload, accessToken: authToken);
+            await TwitchPostAsync($"/communities/{communityId}/images/avatar", ApiVersion.V5, payload, accessToken: authToken).ConfigureAwait(false);
         }
 
         #endregion
 
         #region DeleteCommunityAvatarImage
 
-        public Task DeleteCommunityAvatarImageAsync(string communityId, string authToken = null)
+        public async Task DeleteCommunityAvatarImageAsync(string communityId, string authToken = null)
         {
-            DynamicScopeValidationAsync(AuthScopes.Communities_Edit, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.Communities_Edit, authToken).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(communityId))
                 throw new BadParameterException("The community id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
-            return TwitchDeleteAsync($"/communities/{communityId}/images/avatar", ApiVersion.V5, accessToken: authToken);
+            await TwitchDeleteAsync($"/communities/{communityId}/images/avatar", ApiVersion.V5, accessToken: authToken).ConfigureAwait(false);
         }
 
         #endregion
 
         #region CreateCommunityCoverImage
 
-        public Task CreateCommunityCoverImageAsync(string communityId, string coverImage, string authToken = null)
+        public async Task CreateCommunityCoverImageAsync(string communityId, string coverImage, string authToken = null)
         {
-            DynamicScopeValidationAsync(AuthScopes.Communities_Edit, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.Communities_Edit, authToken).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(communityId))
                 throw new BadParameterException("The community id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -186,7 +186,7 @@ namespace TwitchLib.Api.V5
                 throw new BadParameterException("The cover image is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
             var payload = "{\"cover_image\": \"" + coverImage + "\"}";
-            return TwitchPostAsync($"/communities/{communityId}/images/cover", ApiVersion.V5, payload, accessToken: authToken);
+            await TwitchPostAsync($"/communities/{communityId}/images/cover", ApiVersion.V5, payload, accessToken: authToken).ConfigureAwait(false);
         }
 
         #endregion
@@ -195,7 +195,7 @@ namespace TwitchLib.Api.V5
 
         public async Task DeleteCommunityCoverImageAsync(string communityId, string authToken = null)
         {
-            DynamicScopeValidationAsync(AuthScopes.Communities_Edit, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.Communities_Edit, authToken).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(communityId))
                 throw new BadParameterException("The community id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -206,13 +206,13 @@ namespace TwitchLib.Api.V5
 
         #region GetCommunityModerators
 
-        public Task<Moderators> GetCommunityModeratorsAsync(string communityId, string authToken)
+        public async Task<Moderators> GetCommunityModeratorsAsync(string communityId, string authToken)
         {
-            DynamicScopeValidationAsync(AuthScopes.Communities_Edit, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.Communities_Edit, authToken).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(communityId))
                 throw new BadParameterException("The community id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
-            return TwitchGetGenericAsync<Moderators>($"/communities/{communityId}/moderators", ApiVersion.V5, accessToken: authToken);
+            return await TwitchGetGenericAsync<Moderators>($"/communities/{communityId}/moderators", ApiVersion.V5, accessToken: authToken).ConfigureAwait(false);
         }
 
         #endregion
@@ -221,7 +221,7 @@ namespace TwitchLib.Api.V5
 
         public async Task AddCommunityModeratorAsync(string communityId, string userId, string authToken = null)
         {
-            DynamicScopeValidationAsync(AuthScopes.Communities_Edit, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.Communities_Edit, authToken).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(communityId))
                 throw new BadParameterException("The community id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -237,7 +237,7 @@ namespace TwitchLib.Api.V5
 
         public async Task DeleteCommunityModeratorAsync(string communityId, string userId, string authToken = null)
         {
-            DynamicScopeValidationAsync(AuthScopes.Communities_Edit, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.Communities_Edit, authToken).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(communityId))
                 throw new BadParameterException("The community id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -251,13 +251,13 @@ namespace TwitchLib.Api.V5
 
         #region GetCommunityPermissions
 
-        public Task<Dictionary<string, bool>> GetCommunityPermissionsAsync(string communityId, string authToken = null)
+        public async Task<Dictionary<string, bool>> GetCommunityPermissionsAsync(string communityId, string authToken = null)
         {
-            DynamicScopeValidationAsync(AuthScopes.Any, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.Any, authToken).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(communityId))
                 throw new BadParameterException("The community id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
-            return TwitchGetGenericAsync<Dictionary<string, bool>>($"/communities/{communityId}/permissions", ApiVersion.V5, accessToken: authToken);
+            return await TwitchGetGenericAsync<Dictionary<string, bool>>($"/communities/{communityId}/permissions", ApiVersion.V5, accessToken: authToken).ConfigureAwait(false);
         }
 
         #endregion
@@ -280,9 +280,9 @@ namespace TwitchLib.Api.V5
 
         #region GetCommunityTimedOutUsers
 
-        public Task<TimedOutUsers> GetCommunityTimedOutUsersAsync(string communityId, long? limit = null, string cursor = null, string authToken = null)
+        public async Task<TimedOutUsers> GetCommunityTimedOutUsersAsync(string communityId, long? limit = null, string cursor = null, string authToken = null)
         {
-            DynamicScopeValidationAsync(AuthScopes.Communities_Moderate, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.Communities_Moderate, authToken).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(communityId))
                 throw new BadParameterException("The community id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -292,7 +292,7 @@ namespace TwitchLib.Api.V5
             if (!string.IsNullOrEmpty(cursor))
                 getParams.Add(new KeyValuePair<string, string>("cursor", cursor));
 
-            return TwitchGetGenericAsync<TimedOutUsers>($"/communities/{communityId}/timeouts", ApiVersion.V5, getParams, authToken);
+            return await TwitchGetGenericAsync<TimedOutUsers>($"/communities/{communityId}/timeouts", ApiVersion.V5, getParams, authToken).ConfigureAwait(false);
         }
 
         #endregion
@@ -301,7 +301,7 @@ namespace TwitchLib.Api.V5
 
         public async Task AddCommunityTimedOutUserAsync(string communityId, string userId, int duration, string reason = null, string authToken = null)
         {
-            DynamicScopeValidationAsync(AuthScopes.Communities_Moderate, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.Communities_Moderate, authToken).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(communityId))
                 throw new BadParameterException("The community id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -318,7 +318,7 @@ namespace TwitchLib.Api.V5
 
         public async Task DeleteCommunityTimedOutUserAsync(string communityId, string userId, string authToken = null)
         {
-            DynamicScopeValidationAsync(AuthScopes.Communities_Moderate, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.Communities_Moderate, authToken).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(communityId))
                 throw new BadParameterException("The community id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 

--- a/TwitchLib.Api.V5/Communities.cs
+++ b/TwitchLib.Api.V5/Communities.cs
@@ -41,9 +41,9 @@ namespace TwitchLib.Api.V5
 
         #region UpdateCommunity
 
-        public Task UpdateCommunityAsync(string communityId, string summary = null, string description = null, string rules = null, string email = null, string authToken = null)
+        public async Task UpdateCommunityAsync(string communityId, string summary = null, string description = null, string rules = null, string email = null, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.Communities_Edit, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.Communities_Edit, authToken).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(communityId))
                 throw new BadParameterException("The community id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -73,7 +73,7 @@ namespace TwitchLib.Api.V5
 
             payload = "{" + payload + "}";
 
-            return TwitchPutAsync($"/communities/{communityId}", ApiVersion.V5, payload, accessToken: authToken);
+            await TwitchPutAsync($"/communities/{communityId}", ApiVersion.V5, payload, accessToken: authToken).ConfigureAwait(false);
         }
 
         #endregion
@@ -97,7 +97,7 @@ namespace TwitchLib.Api.V5
 
         public Task<BannedUsers> GetCommunityBannedUsersAsync(string communityId, long? limit = null, string cursor = null, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.Communities_Moderate, authToken);
+            DynamicScopeValidationAsync(AuthScopes.Communities_Moderate, authToken);
             if (string.IsNullOrWhiteSpace(communityId))
                 throw new BadParameterException("The community id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -116,7 +116,7 @@ namespace TwitchLib.Api.V5
 
         public Task BanCommunityUserAsync(string communityId, string userId, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.Communities_Moderate, authToken);
+            DynamicScopeValidationAsync(AuthScopes.Communities_Moderate, authToken);
             if (string.IsNullOrWhiteSpace(communityId))
                 throw new BadParameterException("The community id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -132,7 +132,7 @@ namespace TwitchLib.Api.V5
 
         public Task UnBanCommunityUserAsync(string communityId, string userId, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.Communities_Moderate, authToken);
+            DynamicScopeValidationAsync(AuthScopes.Communities_Moderate, authToken);
             if (string.IsNullOrWhiteSpace(communityId))
                 throw new BadParameterException("The community id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -148,7 +148,7 @@ namespace TwitchLib.Api.V5
 
         public Task CreateCommunityAvatarImageAsync(string communityId, string avatarImage, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.Communities_Edit, authToken);
+            DynamicScopeValidationAsync(AuthScopes.Communities_Edit, authToken);
             if (string.IsNullOrWhiteSpace(communityId))
                 throw new BadParameterException("The community id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -165,7 +165,7 @@ namespace TwitchLib.Api.V5
 
         public Task DeleteCommunityAvatarImageAsync(string communityId, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.Communities_Edit, authToken);
+            DynamicScopeValidationAsync(AuthScopes.Communities_Edit, authToken);
             if (string.IsNullOrWhiteSpace(communityId))
                 throw new BadParameterException("The community id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -178,7 +178,7 @@ namespace TwitchLib.Api.V5
 
         public Task CreateCommunityCoverImageAsync(string communityId, string coverImage, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.Communities_Edit, authToken);
+            DynamicScopeValidationAsync(AuthScopes.Communities_Edit, authToken);
             if (string.IsNullOrWhiteSpace(communityId))
                 throw new BadParameterException("The community id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -195,7 +195,7 @@ namespace TwitchLib.Api.V5
 
         public async Task DeleteCommunityCoverImageAsync(string communityId, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.Communities_Edit, authToken);
+            DynamicScopeValidationAsync(AuthScopes.Communities_Edit, authToken);
             if (string.IsNullOrWhiteSpace(communityId))
                 throw new BadParameterException("The community id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -208,7 +208,7 @@ namespace TwitchLib.Api.V5
 
         public Task<Moderators> GetCommunityModeratorsAsync(string communityId, string authToken)
         {
-            DynamicScopeValidation(AuthScopes.Communities_Edit, authToken);
+            DynamicScopeValidationAsync(AuthScopes.Communities_Edit, authToken);
             if (string.IsNullOrWhiteSpace(communityId))
                 throw new BadParameterException("The community id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -221,7 +221,7 @@ namespace TwitchLib.Api.V5
 
         public async Task AddCommunityModeratorAsync(string communityId, string userId, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.Communities_Edit, authToken);
+            DynamicScopeValidationAsync(AuthScopes.Communities_Edit, authToken);
             if (string.IsNullOrWhiteSpace(communityId))
                 throw new BadParameterException("The community id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -237,7 +237,7 @@ namespace TwitchLib.Api.V5
 
         public async Task DeleteCommunityModeratorAsync(string communityId, string userId, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.Communities_Edit, authToken);
+            DynamicScopeValidationAsync(AuthScopes.Communities_Edit, authToken);
             if (string.IsNullOrWhiteSpace(communityId))
                 throw new BadParameterException("The community id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -253,7 +253,7 @@ namespace TwitchLib.Api.V5
 
         public Task<Dictionary<string, bool>> GetCommunityPermissionsAsync(string communityId, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.Any, authToken);
+            DynamicScopeValidationAsync(AuthScopes.Any, authToken);
             if (string.IsNullOrWhiteSpace(communityId))
                 throw new BadParameterException("The community id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -282,7 +282,7 @@ namespace TwitchLib.Api.V5
 
         public Task<TimedOutUsers> GetCommunityTimedOutUsersAsync(string communityId, long? limit = null, string cursor = null, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.Communities_Moderate, authToken);
+            DynamicScopeValidationAsync(AuthScopes.Communities_Moderate, authToken);
             if (string.IsNullOrWhiteSpace(communityId))
                 throw new BadParameterException("The community id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -301,7 +301,7 @@ namespace TwitchLib.Api.V5
 
         public async Task AddCommunityTimedOutUserAsync(string communityId, string userId, int duration, string reason = null, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.Communities_Moderate, authToken);
+            DynamicScopeValidationAsync(AuthScopes.Communities_Moderate, authToken);
             if (string.IsNullOrWhiteSpace(communityId))
                 throw new BadParameterException("The community id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -318,7 +318,7 @@ namespace TwitchLib.Api.V5
 
         public async Task DeleteCommunityTimedOutUserAsync(string communityId, string userId, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.Communities_Moderate, authToken);
+            DynamicScopeValidationAsync(AuthScopes.Communities_Moderate, authToken);
             if (string.IsNullOrWhiteSpace(communityId))
                 throw new BadParameterException("The community id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 

--- a/TwitchLib.Api.V5/Streams.cs
+++ b/TwitchLib.Api.V5/Streams.cs
@@ -85,9 +85,9 @@ namespace TwitchLib.Api.V5
 
         #region GetFollowedStreams
 
-        public Task<FollowedStreams> GetFollowedStreamsAsync(string streamType = null, int? limit = null, int? offset = null, string authToken = null)
+        public async Task<FollowedStreams> GetFollowedStreamsAsync(string streamType = null, int? limit = null, int? offset = null, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.User_Read, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.User_Read, authToken).ConfigureAwait(false);
             var getParams = new List<KeyValuePair<string, string>>();
             if (!string.IsNullOrWhiteSpace(streamType) && (streamType == "live" || streamType == "playlist" || streamType == "all" || streamType == "watch_party"))
                 getParams.Add(new KeyValuePair<string, string>("stream_type", streamType));
@@ -96,7 +96,7 @@ namespace TwitchLib.Api.V5
             if (offset != null)
                 getParams.Add(new KeyValuePair<string, string>("offset", offset.ToString()));
 
-            return TwitchGetGenericAsync<FollowedStreams>("/streams/followed", ApiVersion.V5, getParams, authToken);
+            return await TwitchGetGenericAsync<FollowedStreams>("/streams/followed", ApiVersion.V5, getParams, authToken).ConfigureAwait(false);
         }
 
         #endregion

--- a/TwitchLib.Api.V5/Users.cs
+++ b/TwitchLib.Api.V5/Users.cs
@@ -35,11 +35,11 @@ namespace TwitchLib.Api.V5
 
         #region GetUser
 
-        public Task<UserAuthed> GetUserAsync(string authToken = null)
+        public async Task<UserAuthed> GetUserAsync(string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.User_Read, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.User_Read, authToken).ConfigureAwait(false);
 
-            return TwitchGetGenericAsync<UserAuthed>("/user", ApiVersion.V5, accessToken: authToken);
+            return await TwitchGetGenericAsync<UserAuthed>("/user", ApiVersion.V5, accessToken: authToken).ConfigureAwait(false);
         }
 
         #endregion
@@ -73,7 +73,7 @@ namespace TwitchLib.Api.V5
 
         public Task<UserEmotes> GetUserEmotesAsync(string userId, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.User_Subscriptions, authToken);
+            DynamicScopeValidationAsync(AuthScopes.User_Subscriptions, authToken);
             if (string.IsNullOrWhiteSpace(userId))
                 throw new BadParameterException("The user id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -86,7 +86,7 @@ namespace TwitchLib.Api.V5
 
         public Task<Subscription> CheckUserSubscriptionByChannelAsync(string userId, string channelId, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.User_Subscriptions, authToken);
+            DynamicScopeValidationAsync(AuthScopes.User_Subscriptions, authToken);
             if (string.IsNullOrWhiteSpace(userId))
                 throw new BadParameterException("The user id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -162,7 +162,7 @@ namespace TwitchLib.Api.V5
 
         public Task<UserFollow> FollowChannelAsync(string userId, string channelId, bool? notifications = null, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.User_Follows_Edit, authToken);
+            DynamicScopeValidationAsync(AuthScopes.User_Follows_Edit, authToken);
             if (string.IsNullOrWhiteSpace(userId))
                 throw new BadParameterException("The user id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -179,7 +179,7 @@ namespace TwitchLib.Api.V5
 
         public Task UnfollowChannelAsync(string userId, string channelId, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.User_Follows_Edit, authToken);
+            DynamicScopeValidationAsync(AuthScopes.User_Follows_Edit, authToken);
             if (string.IsNullOrWhiteSpace(userId))
                 throw new BadParameterException("The user id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -195,7 +195,7 @@ namespace TwitchLib.Api.V5
 
         public Task<UserBlocks> GetUserBlockListAsync(string userId, int? limit = null, int? offset = null, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.User_Blocks_Read, authToken);
+            DynamicScopeValidationAsync(AuthScopes.User_Blocks_Read, authToken);
             if (string.IsNullOrWhiteSpace(userId))
                 throw new BadParameterException("The user id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -214,7 +214,7 @@ namespace TwitchLib.Api.V5
 
         public Task<UserBlock> BlockUserAsync(string sourceUserId, string targetUserId, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.User_Blocks_Edit, authToken);
+            DynamicScopeValidationAsync(AuthScopes.User_Blocks_Edit, authToken);
             if (string.IsNullOrWhiteSpace(sourceUserId))
                 throw new BadParameterException("The source user id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -230,7 +230,7 @@ namespace TwitchLib.Api.V5
 
         public Task UnblockUserAsync(string sourceUserId, string targetUserId, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.User_Blocks_Edit, authToken);
+            DynamicScopeValidationAsync(AuthScopes.User_Blocks_Edit, authToken);
             if (string.IsNullOrWhiteSpace(sourceUserId))
                 throw new BadParameterException("The source user id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -248,7 +248,7 @@ namespace TwitchLib.Api.V5
 
         public Task CreateUserConnectionToViewerHeartbeatServiceAsync(string identifier, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.Viewing_Activity_Read, authToken);
+            DynamicScopeValidationAsync(AuthScopes.Viewing_Activity_Read, authToken);
             if (string.IsNullOrWhiteSpace(identifier))
                 throw new BadParameterException("The identifier is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -262,7 +262,7 @@ namespace TwitchLib.Api.V5
 
         public Task<VHSConnectionCheck> CheckUserConnectionToViewerHeartbeatServiceAsync(string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.User_Read, authToken);
+            DynamicScopeValidationAsync(AuthScopes.User_Read, authToken);
 
             return TwitchGetGenericAsync<VHSConnectionCheck>("/user/vhs", ApiVersion.V5, accessToken: authToken);
         }
@@ -273,7 +273,7 @@ namespace TwitchLib.Api.V5
 
         public Task DeleteUserConnectionToViewerHeartbeatServicechStreamsAsync(string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.Viewing_Activity_Read, authToken);
+            DynamicScopeValidationAsync(AuthScopes.Viewing_Activity_Read, authToken);
 
             return TwitchDeleteAsync("/user/vhs", ApiVersion.V5, accessToken: authToken);
         }

--- a/TwitchLib.Api.V5/Users.cs
+++ b/TwitchLib.Api.V5/Users.cs
@@ -71,29 +71,29 @@ namespace TwitchLib.Api.V5
 
         #region GetUserEmotes
 
-        public Task<UserEmotes> GetUserEmotesAsync(string userId, string authToken = null)
+        public async Task<UserEmotes> GetUserEmotesAsync(string userId, string authToken = null)
         {
-            DynamicScopeValidationAsync(AuthScopes.User_Subscriptions, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.User_Subscriptions, authToken).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(userId))
                 throw new BadParameterException("The user id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
-            return TwitchGetGenericAsync<UserEmotes>($"/users/{userId}/emotes", ApiVersion.V5, accessToken: authToken);
+            return await TwitchGetGenericAsync<UserEmotes>($"/users/{userId}/emotes", ApiVersion.V5, accessToken: authToken).ConfigureAwait(false);
         }
 
         #endregion
 
         #region CheckUserSubscriptionByChannel
 
-        public Task<Subscription> CheckUserSubscriptionByChannelAsync(string userId, string channelId, string authToken = null)
+        public async Task<Subscription> CheckUserSubscriptionByChannelAsync(string userId, string channelId, string authToken = null)
         {
-            DynamicScopeValidationAsync(AuthScopes.User_Subscriptions, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.User_Subscriptions, authToken).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(userId))
                 throw new BadParameterException("The user id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
             if (string.IsNullOrWhiteSpace(channelId))
                 throw new BadParameterException("The channel id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
-            return TwitchGetGenericAsync<Subscription>($"/users/{userId}/subscriptions/{channelId}", ApiVersion.V5, accessToken: authToken);
+            return await TwitchGetGenericAsync<Subscription>($"/users/{userId}/subscriptions/{channelId}", ApiVersion.V5, accessToken: authToken).ConfigureAwait(false);
         }
 
         #endregion
@@ -160,9 +160,9 @@ namespace TwitchLib.Api.V5
 
         #region FollowChannel
 
-        public Task<UserFollow> FollowChannelAsync(string userId, string channelId, bool? notifications = null, string authToken = null)
+        public async Task<UserFollow> FollowChannelAsync(string userId, string channelId, bool? notifications = null, string authToken = null)
         {
-            DynamicScopeValidationAsync(AuthScopes.User_Follows_Edit, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.User_Follows_Edit, authToken).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(userId))
                 throw new BadParameterException("The user id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -170,32 +170,32 @@ namespace TwitchLib.Api.V5
                 throw new BadParameterException("The channel id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
             var optionalRequestBody = notifications.HasValue ? "{\"notifications\": " + notifications.Value.ToString().ToLower() + "}" : null;
-            return TwitchPutGenericAsync<UserFollow>($"/users/{userId}/follows/channels/{channelId}", ApiVersion.V5, optionalRequestBody, accessToken: authToken);
+            return await TwitchPutGenericAsync<UserFollow>($"/users/{userId}/follows/channels/{channelId}", ApiVersion.V5, optionalRequestBody, accessToken: authToken).ConfigureAwait(false);
         }
 
         #endregion
 
         #region UnfollowChannel
 
-        public Task UnfollowChannelAsync(string userId, string channelId, string authToken = null)
+        public async Task UnfollowChannelAsync(string userId, string channelId, string authToken = null)
         {
-            DynamicScopeValidationAsync(AuthScopes.User_Follows_Edit, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.User_Follows_Edit, authToken).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(userId))
                 throw new BadParameterException("The user id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
             if (string.IsNullOrWhiteSpace(channelId))
                 throw new BadParameterException("The channel id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
-            return TwitchDeleteAsync($"/users/{userId}/follows/channels/{channelId}", ApiVersion.V5, accessToken: authToken);
+            await TwitchDeleteAsync($"/users/{userId}/follows/channels/{channelId}", ApiVersion.V5, accessToken: authToken).ConfigureAwait(false);
         }
 
         #endregion
 
         #region GetUserBlockList
 
-        public Task<UserBlocks> GetUserBlockListAsync(string userId, int? limit = null, int? offset = null, string authToken = null)
+        public async Task<UserBlocks> GetUserBlockListAsync(string userId, int? limit = null, int? offset = null, string authToken = null)
         {
-            DynamicScopeValidationAsync(AuthScopes.User_Blocks_Read, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.User_Blocks_Read, authToken).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(userId))
                 throw new BadParameterException("The user id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -205,39 +205,39 @@ namespace TwitchLib.Api.V5
             if (offset.HasValue)
                 getParams.Add(new KeyValuePair<string, string>("offset", offset.Value.ToString()));
 
-            return TwitchGetGenericAsync<UserBlocks>($"/users/{userId}/blocks", ApiVersion.V5, getParams, authToken);
+            return await TwitchGetGenericAsync<UserBlocks>($"/users/{userId}/blocks", ApiVersion.V5, getParams, authToken).ConfigureAwait(false);
         }
 
         #endregion
 
         #region BlockUser
 
-        public Task<UserBlock> BlockUserAsync(string sourceUserId, string targetUserId, string authToken = null)
+        public async Task<UserBlock> BlockUserAsync(string sourceUserId, string targetUserId, string authToken = null)
         {
-            DynamicScopeValidationAsync(AuthScopes.User_Blocks_Edit, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.User_Blocks_Edit, authToken).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(sourceUserId))
                 throw new BadParameterException("The source user id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
             if (string.IsNullOrWhiteSpace(targetUserId))
                 throw new BadParameterException("The target user id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
-            return TwitchPutGenericAsync<UserBlock>($"/users/{sourceUserId}/blocks/{targetUserId}", ApiVersion.V5, null, accessToken: authToken);
+            return await TwitchPutGenericAsync<UserBlock>($"/users/{sourceUserId}/blocks/{targetUserId}", ApiVersion.V5, null, accessToken: authToken).ConfigureAwait(false);
         }
 
         #endregion
 
         #region UnblockUser
 
-        public Task UnblockUserAsync(string sourceUserId, string targetUserId, string authToken = null)
+        public async Task UnblockUserAsync(string sourceUserId, string targetUserId, string authToken = null)
         {
-            DynamicScopeValidationAsync(AuthScopes.User_Blocks_Edit, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.User_Blocks_Edit, authToken).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(sourceUserId))
                 throw new BadParameterException("The source user id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
             if (string.IsNullOrWhiteSpace(targetUserId))
                 throw new BadParameterException("The target user id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
-            return TwitchDeleteAsync($"/users/{sourceUserId}/blocks/{targetUserId}", ApiVersion.V5, accessToken: authToken);
+            await TwitchDeleteAsync($"/users/{sourceUserId}/blocks/{targetUserId}", ApiVersion.V5, accessToken: authToken).ConfigureAwait(false);
         }
 
         #endregion
@@ -246,36 +246,36 @@ namespace TwitchLib.Api.V5
 
         #region CreateUserConnectionToViewerHeartbeatService
 
-        public Task CreateUserConnectionToViewerHeartbeatServiceAsync(string identifier, string authToken = null)
+        public async Task CreateUserConnectionToViewerHeartbeatServiceAsync(string identifier, string authToken = null)
         {
-            DynamicScopeValidationAsync(AuthScopes.Viewing_Activity_Read, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.Viewing_Activity_Read, authToken).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(identifier))
                 throw new BadParameterException("The identifier is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
             var payload = "{\"identifier\": \"" + identifier + "\"}";
-            return TwitchPutAsync("/user/vhs", ApiVersion.V5, payload, accessToken: authToken);
+            await TwitchPutAsync("/user/vhs", ApiVersion.V5, payload, accessToken: authToken).ConfigureAwait(false);
         }
 
         #endregion
 
         #region CheckUserConnectionToViewerHeartbeatService
 
-        public Task<VHSConnectionCheck> CheckUserConnectionToViewerHeartbeatServiceAsync(string authToken = null)
+        public async Task<VHSConnectionCheck> CheckUserConnectionToViewerHeartbeatServiceAsync(string authToken = null)
         {
-            DynamicScopeValidationAsync(AuthScopes.User_Read, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.User_Read, authToken).ConfigureAwait(false);
 
-            return TwitchGetGenericAsync<VHSConnectionCheck>("/user/vhs", ApiVersion.V5, accessToken: authToken);
+            return await TwitchGetGenericAsync<VHSConnectionCheck>("/user/vhs", ApiVersion.V5, accessToken: authToken).ConfigureAwait(false);
         }
 
         #endregion
 
         #region DeleteUserConnectionToViewerHeartbeatService
 
-        public Task DeleteUserConnectionToViewerHeartbeatServicechStreamsAsync(string authToken = null)
+        public async Task DeleteUserConnectionToViewerHeartbeatServicechStreamsAsync(string authToken = null)
         {
-            DynamicScopeValidationAsync(AuthScopes.Viewing_Activity_Read, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.Viewing_Activity_Read, authToken).ConfigureAwait(false);
 
-            return TwitchDeleteAsync("/user/vhs", ApiVersion.V5, accessToken: authToken);
+            await TwitchDeleteAsync("/user/vhs", ApiVersion.V5, accessToken: authToken).ConfigureAwait(false);
         }
 
         #endregion

--- a/TwitchLib.Api.V5/Users.cs
+++ b/TwitchLib.Api.V5/Users.cs
@@ -147,7 +147,7 @@ namespace TwitchLib.Api.V5
 
             try
             {
-                await TwitchGetGenericAsync<UserFollow>($"/users/{userId}/follows/channels/{channelId}", ApiVersion.V5);
+                await TwitchGetGenericAsync<UserFollow>($"/users/{userId}/follows/channels/{channelId}", ApiVersion.V5).ConfigureAwait(false);
                 return true;
             }
             catch (BadResourceException)

--- a/TwitchLib.Api.V5/Videos.cs
+++ b/TwitchLib.Api.V5/Videos.cs
@@ -114,7 +114,7 @@ namespace TwitchLib.Api.V5
         public async Task<UploadedVideo> UploadVideoAsync(string channelId, string videoPath, string title, string description, string game, string language = "en", string tagList = "", Viewable viewable = Viewable.Public, DateTime? viewableAt = null, string accessToken = null)
         {
             await DynamicScopeValidationAsync(AuthScopes.Channel_Editor, accessToken).ConfigureAwait(false);
-            var listing = await CreateVideoAsync(channelId, title, description, game, language, tagList, viewable, viewableAt);
+            var listing = await CreateVideoAsync(channelId, title, description, game, language, tagList, viewable, viewableAt).ConfigureAwait(false);
             await UploadVideoPartsAsync(videoPath, listing.Upload).ConfigureAwait(false);
             await CompleteVideoUploadAsync(listing.Upload, accessToken).ConfigureAwait(false);
 

--- a/TwitchLib.Api.V5/Videos.cs
+++ b/TwitchLib.Api.V5/Videos.cs
@@ -75,9 +75,9 @@ namespace TwitchLib.Api.V5
 
         #region GetFollowedVideos
 
-        public Task<FollowedVideos> GetFollowedVideosAsync(int? limit = null, int? offset = null, List<string> broadcastType = null, List<string> language = null, string sort = null, string authToken = null)
+        public async Task<FollowedVideos> GetFollowedVideosAsync(int? limit = null, int? offset = null, List<string> broadcastType = null, List<string> language = null, string sort = null, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.User_Read, authToken);
+            await DynamicScopeValidationAsync(AuthScopes.User_Read, authToken).ConfigureAwait(false);
             var getParams = new List<KeyValuePair<string, string>>();
             if (limit.HasValue)
                 getParams.Add(new KeyValuePair<string, string>("limit", limit.Value.ToString()));
@@ -104,7 +104,7 @@ namespace TwitchLib.Api.V5
             if (!string.IsNullOrWhiteSpace(sort) && (sort == "views" || sort == "time"))
                 getParams.Add(new KeyValuePair<string, string>("sort", sort));
 
-            return TwitchGetGenericAsync<FollowedVideos>("/videos/followed", ApiVersion.V5, getParams, authToken);
+            return await TwitchGetGenericAsync<FollowedVideos>("/videos/followed", ApiVersion.V5, getParams, authToken).ConfigureAwait(false);
         }
 
         #endregion
@@ -113,7 +113,7 @@ namespace TwitchLib.Api.V5
 
         public async Task<UploadedVideo> UploadVideoAsync(string channelId, string videoPath, string title, string description, string game, string language = "en", string tagList = "", Viewable viewable = Viewable.Public, DateTime? viewableAt = null, string accessToken = null)
         {
-            DynamicScopeValidation(AuthScopes.Channel_Editor, accessToken);
+            DynamicScopeValidationAsync(AuthScopes.Channel_Editor, accessToken);
             var listing = await CreateVideoAsync(channelId, title, description, game, language, tagList, viewable, viewableAt);
             UploadVideoParts(videoPath, listing.Upload);
             await CompleteVideoUploadAsync(listing.Upload, accessToken);
@@ -127,7 +127,7 @@ namespace TwitchLib.Api.V5
 
         public Task<Video> UpdateVideoAsync(string videoId, string description = null, string game = null, string language = null, string tagList = null, string title = null, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.Channel_Editor, authToken);
+            DynamicScopeValidationAsync(AuthScopes.Channel_Editor, authToken);
             if (string.IsNullOrWhiteSpace(videoId))
                 throw new BadParameterException("The video id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 
@@ -152,7 +152,7 @@ namespace TwitchLib.Api.V5
 
         public Task DeleteVideoAsync(string videoId, string authToken = null)
         {
-            DynamicScopeValidation(AuthScopes.Channel_Editor, authToken);
+            DynamicScopeValidationAsync(AuthScopes.Channel_Editor, authToken);
             if (string.IsNullOrWhiteSpace(videoId))
                 throw new BadParameterException("The video id is not valid. It is not allowed to be null, empty or filled with whitespaces.");
 

--- a/TwitchLib.Api/Helpers/ExtensionAnalyticsHelper.cs
+++ b/TwitchLib.Api/Helpers/ExtensionAnalyticsHelper.cs
@@ -11,7 +11,7 @@ namespace TwitchLib.Api.Helpers
     {
         public static async Task<List<ExtensionAnalytics>> HandleUrlAsync(string url)
         {
-            var cnts = await GetContentsAsync(url);
+            var cnts = await GetContentsAsync(url).ConfigureAwait(false);
             var data = ExtractData(cnts);
 
             return data.Select(line => new ExtensionAnalytics(line)).ToList();
@@ -25,7 +25,7 @@ namespace TwitchLib.Api.Helpers
         private static async Task<string[]> GetContentsAsync(string url)
         {
             var client = new HttpClient();
-            var lines = (await client.GetStringAsync(url)).Split(new[] { Environment.NewLine }, StringSplitOptions.None);
+            var lines = (await client.GetStringAsync(url).ConfigureAwait(false)).Split(new[] { Environment.NewLine }, StringSplitOptions.None);
             return lines;
         }
     }

--- a/TwitchLib.Api/Services/Core/FollowerService/NameBasedMonitor.cs
+++ b/TwitchLib.Api/Services/Core/FollowerService/NameBasedMonitor.cs
@@ -18,10 +18,10 @@ namespace TwitchLib.Api.Services.Core.FollowerService
         {
             if (!_channelToId.TryGetValue(channel, out var channelId))
             {
-                channelId = (await _api.Helix.Users.GetUsersAsync(logins: new List<string> { channel })).Users.FirstOrDefault()?.Id;
+                channelId = (await _api.Helix.Users.GetUsersAsync(logins: new List<string> { channel }).ConfigureAwait(false)).Users.FirstOrDefault()?.Id;
                 _channelToId[channel] = channelId ?? throw new InvalidOperationException($"No channel with the name \"{channel}\" could be found.");
             }
-            return await _api.Helix.Users.GetUsersFollowsAsync(first: queryCount, toId: channelId);
+            return await _api.Helix.Users.GetUsersFollowsAsync(first: queryCount, toId: channelId).ConfigureAwait(false);
         }
 
         public void ClearCache()

--- a/TwitchLib.Api/Services/Core/LiveStreamMonitor/NameBasedMonitor.cs
+++ b/TwitchLib.Api/Services/Core/LiveStreamMonitor/NameBasedMonitor.cs
@@ -18,7 +18,7 @@ namespace TwitchLib.Api.Services.Core.LiveStreamMonitor
         {
             if (!_channelToId.TryGetValue(channel, out var channelId))
             {
-                channelId = (await _api.Helix.Users.GetUsersAsync(logins: new List<string> { channel })).Users.FirstOrDefault()?.Id;
+                channelId = (await _api.Helix.Users.GetUsersAsync(logins: new List<string> { channel }).ConfigureAwait(false)).Users.FirstOrDefault()?.Id;
                 _channelToId[channel] = channelId ?? throw new InvalidOperationException($"No channel with the name \"{channel}\" could be found.");
             }
 

--- a/TwitchLib.Api/Services/Core/ServiceTimer.cs
+++ b/TwitchLib.Api/Services/Core/ServiceTimer.cs
@@ -21,7 +21,7 @@ namespace TwitchLib.Api.Services.Core
 
         private async void TimerElapsedAsync(object sender, ElapsedEventArgs e)
         {
-            await _serviceTimerTickAsyncCallback();
+            await _serviceTimerTickAsyncCallback().ConfigureAwait(false);
         }
     }
 }

--- a/TwitchLib.Api/Services/FollowerService.cs
+++ b/TwitchLib.Api/Services/FollowerService.cs
@@ -115,7 +115,7 @@ namespace TwitchLib.Api.Services
             foreach (var channel in ChannelsToMonitor)
             {
                 List<Follow> newFollowers;
-                var latestFollowers = await GetLatestFollowersAsync(channel);
+                var latestFollowers = await GetLatestFollowersAsync(channel).ConfigureAwait(false);
 
                 if (latestFollowers.Count == 0)
                     return;
@@ -165,13 +165,13 @@ namespace TwitchLib.Api.Services
 
         protected override async Task OnServiceTimerTick()
         {
-            await base.OnServiceTimerTick();
-            await UpdateLatestFollowersAsync();
+            await base.OnServiceTimerTick().ConfigureAwait(false);
+            await UpdateLatestFollowersAsync().ConfigureAwait(false);
         }
 
         private async Task<List<Follow>> GetLatestFollowersAsync(string channel)
         {
-            var resultset = await _monitor.GetUsersFollowsAsync(channel, QueryCountPerRequest);
+            var resultset = await _monitor.GetUsersFollowsAsync(channel, QueryCountPerRequest).ConfigureAwait(false);
             
             return resultset.Follows.Reverse().ToList();
         }

--- a/TwitchLib.Api/Services/LiveStreamMonitorService.cs
+++ b/TwitchLib.Api/Services/LiveStreamMonitorService.cs
@@ -84,11 +84,11 @@ namespace TwitchLib.Api.Services
 
         public async Task UpdateLiveStreamersAsync(bool callEvents = true)
         {
-            var result = await GetLiveStreamersAsync();
+            var result = await GetLiveStreamersAsync().ConfigureAwait(false);
 
             foreach (var channel in ChannelsToMonitor)
             {
-                var liveStream = result.FirstOrDefault(await _monitor.CompareStream(channel));
+                var liveStream = result.FirstOrDefault(await _monitor.CompareStream(channel).ConfigureAwait(false));
 
                 if (liveStream != null)
                 {
@@ -103,8 +103,8 @@ namespace TwitchLib.Api.Services
 
         protected override async Task OnServiceTimerTick()
         {
-            await base.OnServiceTimerTick();
-            await UpdateLiveStreamersAsync();
+            await base.OnServiceTimerTick().ConfigureAwait(false);
+            await UpdateLiveStreamersAsync().ConfigureAwait(false);
         }
 
         private void HandleLiveStreamUpdate(string channel, Stream liveStream, bool callEvents)
@@ -149,7 +149,7 @@ namespace TwitchLib.Api.Services
             for (var i = 0; i < pages; i++)
             {
                 var selectedSet = ChannelsToMonitor.Skip(i * MaxStreamRequestCountPerRequest).Take(MaxStreamRequestCountPerRequest).ToList();
-                var resultset = await _monitor.GetStreamsAsync(selectedSet);
+                var resultset = await _monitor.GetStreamsAsync(selectedSet).ConfigureAwait(false);
 
                 if (resultset.Streams == null)
                     continue;


### PR DESCRIPTION
Fixes some thread concurrency issues dealing with the API tokens.
ApiBase now locks securely, waits for a token per client, and fetches a new API Access token once until expired.
It's generally discouraged to Task.Run and run sync code unless it's pure CPU bound work, as you're trying up the thread pool waiting for requests to finish. Code is now completely async all the way through.