### PR TITLE
Several fixes for (Top)Game response

### DIFF
--- a/TwitchLib.Api.Helix.Models/Games/Game.cs
+++ b/TwitchLib.Api.Helix.Models/Games/Game.cs
@@ -4,7 +4,7 @@ namespace TwitchLib.Api.Helix.Models.Games
 {
     public class Game
     {
-        [JsonProperty(PropertyName = "id")]
+        [JsonProperty(PropertyName = "_id")]
         public string Id { get; protected set; }
         [JsonProperty(PropertyName = "name")]
         public string Name { get; protected set; }

--- a/TwitchLib.Api.Helix.Models/Games/Game.cs
+++ b/TwitchLib.Api.Helix.Models/Games/Game.cs
@@ -5,7 +5,7 @@ namespace TwitchLib.Api.Helix.Models.Games
     public class Game
     {
         [JsonProperty(PropertyName = "_id")]
-        public string Id { get; protected set; }
+        public int Id { get; protected set; }
         [JsonProperty(PropertyName = "name")]
         public string Name { get; protected set; }
         [JsonProperty(PropertyName = "box_art_url")]

--- a/TwitchLib.Api.V5.Models/Games/Game.cs
+++ b/TwitchLib.Api.V5.Models/Games/Game.cs
@@ -8,10 +8,6 @@ namespace TwitchLib.Api.V5.Models.Games
         [JsonProperty(PropertyName = "_id")]
         public int Id { get; protected set; }
         #endregion
-        #region Viewers
-        [JsonProperty(PropertyName = "viewers")]
-        public int Viewers { get; protected set; }
-        #endregion
         #region Box
         [JsonProperty(PropertyName = "box")]
         public GameBox Box { get; protected set; }
@@ -27,10 +23,6 @@ namespace TwitchLib.Api.V5.Models.Games
         #region Name
         [JsonProperty(PropertyName = "name")]
         public string Name { get; protected set; }
-        #endregion
-        #region Popularity
-        [JsonProperty(PropertyName = "popularity")]
-        public int Popularity { get; protected set; }
         #endregion
     }
 }


### PR DESCRIPTION
According to https://dev.twitch.tv/docs/v5/reference/games#get-top-games this should:
- read the correct json property `_id` instead of `id`
- remove a couple of properties which are not in the example response

For the `Id` propety: after this PR it should be the same as a similar model at:
https://github.com/TwitchLib/TwitchLib.Api/blob/master/TwitchLib.Api.Helix.Models/Games/Game.cs

Screenshot for example response:
![image](https://user-images.githubusercontent.com/19928782/83977176-c8aa8780-a8fe-11ea-8d04-e4453ff0b1fc.png)
