### PR TITLE
Fix invalid request in TwitchAPI.V5.Channels.GetAllSubscribersAsync/GetAllFollowersAsync

### DIFF
--- a/TwitchLib.Api.V5/Channels.cs
+++ b/TwitchLib.Api.V5/Channels.cs
@@ -200,9 +200,12 @@ namespace TwitchLib.Api.V5
                 await Task.Delay(1000);
             }
 
-            // get leftover subs
-            var leftOverFollowersRequest = await GetChannelFollowersAsync(channelId, leftOverFollowers, cursor: cursor).ConfigureAwait(false);
-            followers.AddRange(leftOverFollowersRequest.Follows.OfType<ChannelFollow>().ToList());
+			// get leftover followers
+            if (leftOverFollowers > 0)
+			{
+				var leftOverFollowersRequest = await GetChannelFollowersAsync(channelId, leftOverFollowers, cursor: cursor).ConfigureAwait(false);
+				followers.AddRange(leftOverFollowersRequest.Follows.OfType<ChannelFollow>().ToList());
+			}
 
             return followers;
         }
@@ -294,8 +297,11 @@ namespace TwitchLib.Api.V5
             }
 
             // get leftover subs
-            var leftOverSubsRequest = await GetChannelSubscribersAsync(channelId, leftOverSubs, currentOffset, "asc", accessToken).ConfigureAwait(false);
-            allSubs.AddRange(leftOverSubsRequest.Subscriptions);
+            if (leftOverSubs > 0)
+            {
+                var leftOverSubsRequest = await GetChannelSubscribersAsync(channelId, leftOverSubs, currentOffset, "asc", accessToken).ConfigureAwait(false);
+                allSubs.AddRange(leftOverSubsRequest.Subscriptions);
+            }
 
             return allSubs;
         }


### PR DESCRIPTION
I recently started to run into problems (internal server error 500) when retrieving a list of all subscribers of a channel.
Turns out while the total number of subscribers as indicated by the request was 43, the list of subscribers was 44 entries long (I don't have an explaination for this, might be a canceled subscription or just twitch being twitch).
This however results in leftOverSubs having a value of -1 when sending the last request resulting in a internal server error on twitchs end.

This commit adds a safeguard to GetAllSubscribersAsync to only execute the final request if the are more than zero entries to retrieve, which prevents both my problem and an unnecessary in case there are no more entries to retrieve.
Since GetAllFollowersAsync has the same logic usingleftOverFollowers, the same safeguard is added there to prevent the additional request if it is not needed. 