### PR TITLE
Added new response and request fields specified in the docs update of 2021‑04‑15

### DIFF
--- a/TwitchLib.Api.Helix.Models/Channels/ModifyChannelInformation/ModifyChannelInformationRequest.cs
+++ b/TwitchLib.Api.Helix.Models/Channels/ModifyChannelInformation/ModifyChannelInformationRequest.cs
@@ -1,7 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace TwitchLib.Api.Helix.Models.Channels.ModifyChannelInformation
 {
@@ -14,5 +11,7 @@ namespace TwitchLib.Api.Helix.Models.Channels.ModifyChannelInformation
         public string Title { get; set; }
         [JsonProperty(PropertyName = "broadcaster_language")]
         public string BroadcasterLanguage { get; set; }
+        [JsonProperty(PropertyName = "delay")]
+        public int Delay { get; set; }
     }
 }

--- a/TwitchLib.Api.Helix.Models/Clips/GetClips/Clip.cs
+++ b/TwitchLib.Api.Helix.Models/Clips/GetClips/Clip.cs
@@ -28,5 +28,7 @@ namespace TwitchLib.Api.Helix.Models.Clips.GetClips
         public string CreatedAt { get; protected set; }
         [JsonProperty(PropertyName = "thumbnail_url")]
         public string ThumbnailUrl { get; protected set; }
+        [JsonProperty(PropertyName = "duration")]
+        public int Duration { get; protected set; }
     }
 }

--- a/TwitchLib.Api.Helix.Models/Search/Channel.cs
+++ b/TwitchLib.Api.Helix.Models/Search/Channel.cs
@@ -8,6 +8,8 @@ namespace TwitchLib.Api.Helix.Models.Search
     {
         [JsonProperty(PropertyName = "game_id")]
         public string GameId { get; protected set; }
+        [JsonProperty(PropertyName = "game_name")]
+        public string GameName { get; protected set; }
         [JsonProperty(PropertyName = "id")]
         public string Id { get; protected set; }
         [JsonProperty(PropertyName = "broadcaster_login")]

--- a/TwitchLib.Api.Helix.Models/Streams/GetStreams/Stream.cs
+++ b/TwitchLib.Api.Helix.Models/Streams/GetStreams/Stream.cs
@@ -31,5 +31,7 @@ namespace TwitchLib.Api.Helix.Models.Streams.GetStreams
         public string Language { get; protected set; }
         [JsonProperty(PropertyName = "thumbnail_url")]
         public string ThumbnailUrl { get; protected set; }
+        [JsonProperty(PropertyName = "is_mature")]
+        public bool IsMature { get; protected set; }
     }
 }

--- a/TwitchLib.Api.Helix.Models/Videos/GetVideos/MutedSegment.cs
+++ b/TwitchLib.Api.Helix.Models/Videos/GetVideos/MutedSegment.cs
@@ -1,0 +1,12 @@
+﻿using Newtonsoft.Json;
+
+namespace TwitchLib.Api.Helix.Models.Videos.GetVideos
+{
+    public class MutedSegment
+    {
+        [JsonProperty(PropertyName = "duration")]
+        public int Duration { get; protected set; }
+        [JsonProperty(PropertyName = "offset")]
+        public int Offset { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Videos/GetVideos/Video.cs
+++ b/TwitchLib.Api.Helix.Models/Videos/GetVideos/Video.cs
@@ -28,5 +28,9 @@ namespace TwitchLib.Api.Helix.Models.Videos.GetVideos
         public string UserName { get; protected set; }
         [JsonProperty(PropertyName = "view_count")]
         public int ViewCount { get; protected set; }
+        [JsonProperty(PropertyName = "stream_id")]
+        public string StreamId { get; protected set; }
+        [JsonProperty(PropertyName = "muted_segments")]
+        public MutedSegment[] MutedSegments { get; protected set; }
     }
 }

--- a/TwitchLib.Api.Helix/Channels.cs
+++ b/TwitchLib.Api.Helix/Channels.cs
@@ -1,7 +1,5 @@
 ﻿using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 using TwitchLib.Api.Core;
 using TwitchLib.Api.Core.Enums;


### PR DESCRIPTION
Modify Channel Information – delay added as an optional body parameter.

New API response fields added:

- Get Streams: is_mature
- Get Clips: duration
- Search Channels: game_name
- Get Videos: stream_id
- Get Videos: muted_segments array of objects with duration and offset