### PR TITLE
support for predictions and polls

### DIFF
--- a/TwitchLib.Api.Core.Enums/AuthScopesEnum.cs
+++ b/TwitchLib.Api.Core.Enums/AuthScopesEnum.cs
@@ -45,6 +45,10 @@
         Helix_User_Read_BlockedUsers,
         Helix_User_Manage_BlockedUsers,
         Helix_User_Read_Subscriptions,
+        Helix_Channel_Manage_Polls,
+        Helix_Channel_Manage_Predictions,
+        Helix_Channel_Read_Polls,
+        Helix_Channel_Read_Predictions
         None
     }
 }

--- a/TwitchLib.Api.Core.Enums/AuthScopesEnum.cs
+++ b/TwitchLib.Api.Core.Enums/AuthScopesEnum.cs
@@ -48,7 +48,7 @@
         Helix_Channel_Manage_Polls,
         Helix_Channel_Manage_Predictions,
         Helix_Channel_Read_Polls,
-        Helix_Channel_Read_Predictions
+        Helix_Channel_Read_Predictions,
         None
     }
 }

--- a/TwitchLib.Api.Core.Enums/PollStatusEnum.cs
+++ b/TwitchLib.Api.Core.Enums/PollStatusEnum.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.Api.Core.Enums
+{
+    public enum PollStatusEnum
+    {
+        TERMINATED,
+        ARCHIVED
+    }
+}

--- a/TwitchLib.Api.Core.Enums/PredictionStatusEnum.cs
+++ b/TwitchLib.Api.Core.Enums/PredictionStatusEnum.cs
@@ -7,7 +7,7 @@ namespace TwitchLib.Api.Core.Enums
     public enum PredictionStatusEnum
     {
         RESOLVED,
-        CANCELLED,
+        CANCELED,
         LOCKED
     }
 }

--- a/TwitchLib.Api.Core.Enums/PredictionStatusEnum.cs
+++ b/TwitchLib.Api.Core.Enums/PredictionStatusEnum.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.Api.Core.Enums
+{
+    public enum PredictionStatusEnum
+    {
+        RESOLVED,
+        CANCELLED,
+        LOCKED
+    }
+}

--- a/TwitchLib.Api.Core/ApiBase.cs
+++ b/TwitchLib.Api.Core/ApiBase.cs
@@ -509,6 +509,18 @@ namespace TwitchLib.Api.Core
                     case "user:read:subscriptions":
                         scopes.Add(AuthScopes.Helix_User_Read_Subscriptions);
                         break;
+                    case "channel:manage:polls":
+                        scopes.Add(AuthScopes.Helix_Channel_Manage_Polls);
+                        break;
+                    case "channel:manage:predictions":
+                        scopes.Add(AuthScopes.Helix_Channel_Manage_Predictions);
+                        break;
+                    case "channel:read:polls":
+                        scopes.Add(AuthScopes.Helix_Channel_Read_Polls);
+                        break;
+                    case "channel:read:predictions":
+                        scopes.Add(AuthScopes.Helix_Channel_Read_Predictions);
+                        break;
                 }
             }
 

--- a/TwitchLib.Api.Helix.Models/Polls/Choice.cs
+++ b/TwitchLib.Api.Helix.Models/Polls/Choice.cs
@@ -1,0 +1,21 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.Api.Helix.Models.Polls
+{
+    public class Choice
+    {
+        [JsonProperty(PropertyName = "id")]
+        public string Id { get; protected set; }
+        [JsonProperty(PropertyName = "title")]
+        public string Title { get; protected set; }
+        [JsonProperty(PropertyName = "votes")]
+        public int Votes { get; protected set; }
+        [JsonProperty(PropertyName = "channel_points_votes")]
+        public int ChannelPointsVotes { get; protected set; }
+        [JsonProperty(PropertyName = "bits_votes")]
+        public int BitsVotes { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Polls/CreatePoll/Choice.cs
+++ b/TwitchLib.Api.Helix.Models/Polls/CreatePoll/Choice.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.Api.Helix.Models.Polls.CreatePoll
+{
+    public class Choice
+    {
+        [JsonProperty(PropertyName = "title")]
+        public string Title { get; set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Polls/CreatePoll/CreatePollRequest.cs
+++ b/TwitchLib.Api.Helix.Models/Polls/CreatePoll/CreatePollRequest.cs
@@ -1,0 +1,27 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.Api.Helix.Models.Polls.CreatePoll
+{
+    public class CreatePollRequest
+    {
+        [JsonProperty(PropertyName = "broadcaster_id")]
+        public string BroadcasterId { get; set; }
+        [JsonProperty(PropertyName = "title")]
+        public string Title { get; set; }
+        [JsonProperty(PropertyName = "choices")]
+        public Choice[] Choices { get; set; }
+        [JsonProperty(PropertyName = "bits_voting_enabled")]
+        public bool BitsVotingEnabled { get; set; }
+        [JsonProperty(PropertyName = "bits_per_vote")]
+        public int BitsPerVote { get; set; }
+        [JsonProperty(PropertyName = "channel_points_voting_enabled")]
+        public bool ChannelPointsVotingEnabled { get; set; }
+        [JsonProperty(PropertyName = "channel_points_per_vote")]
+        public int ChannelPointsPerVote { get; set; }
+        [JsonProperty(PropertyName = "duration")]
+        public int DurationSeconds { get; set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Polls/CreatePoll/CreatePollResponse.cs
+++ b/TwitchLib.Api.Helix.Models/Polls/CreatePoll/CreatePollResponse.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.Api.Helix.Models.Polls.CreatePoll
+{
+    public class CreatePollResponse
+    {
+        [JsonProperty(PropertyName = "data")]
+        public Poll[] Data { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Polls/EndPoll/EndPollResponse.cs
+++ b/TwitchLib.Api.Helix.Models/Polls/EndPoll/EndPollResponse.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.Api.Helix.Models.Polls.EndPoll
+{
+    public class EndPollResponse
+    {
+        [JsonProperty(PropertyName = "data")]
+        public Poll[] Data { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Polls/GetPolls/GetPollsResponse.cs
+++ b/TwitchLib.Api.Helix.Models/Polls/GetPolls/GetPollsResponse.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using TwitchLib.Api.Helix.Models.Common;
+
+namespace TwitchLib.Api.Helix.Models.Polls.GetPolls
+{
+    public class GetPollsResponse
+    {
+        [JsonProperty(PropertyName = "data")]
+        public Poll[] Data { get; protected set; }
+        [JsonProperty(PropertyName = "pagination")]
+        public Pagination Pagination { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Polls/Poll.cs
+++ b/TwitchLib.Api.Helix.Models/Polls/Poll.cs
@@ -1,0 +1,37 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.Api.Helix.Models.Polls
+{
+    public class Poll
+    {
+        [JsonProperty(PropertyName = "id")]
+        public string Id { get; protected set; }
+        [JsonProperty(PropertyName = "broadcaster_id")]
+        public string BroadcasterId { get; protected set; }
+        [JsonProperty(PropertyName = "broadcaster_name")]
+        public string BroadcasterName { get; protected set; }
+        [JsonProperty(PropertyName = "broadcaster_login")]
+        public string BroadcasterLogin { get; protected set; }
+        [JsonProperty(PropertyName = "title")]
+        public string Title { get; protected set; }
+        [JsonProperty(PropertyName = "choices")]
+        public Choice[] Choices { get; protected set; }
+        [JsonProperty(PropertyName = "bits_voting_enabled")]
+        public bool BitsVotingEnabled { get; protected set; }
+        [JsonProperty(PropertyName = "bits_per_vote")]
+        public int BitsPerVote { get; protected set; }
+        [JsonProperty(PropertyName = "channel_points_voting_enabled")]
+        public bool ChannelPointsVotingEnabled { get; protected set; }
+        [JsonProperty(PropertyName = "channel_points_per_vote")]
+        public int ChannelPointsPerVote { get; protected set; }
+        [JsonProperty(PropertyName = "status")]
+        public string Status { get; protected set; }
+        [JsonProperty(PropertyName = "duration")]
+        public int DurationSeconds { get; protected set; }
+        [JsonProperty(PropertyName = "started_at")]
+        public DateTime StartedAt { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Predictions/CreatePrediction/CreatePredictionRequest.cs
+++ b/TwitchLib.Api.Helix.Models/Predictions/CreatePrediction/CreatePredictionRequest.cs
@@ -12,7 +12,7 @@ namespace TwitchLib.Api.Helix.Models.Predictions.CreatePrediction
         [JsonProperty(PropertyName = "title")]
         public string Title { get; set; }
         [JsonProperty(PropertyName = "outcomes")]
-        public Outcome Outcomes { get; set; }
+        public Outcome[] Outcomes { get; set; }
         [JsonProperty(PropertyName = "prediction_window")]
         public int PredictionWindowSeconds { get; set; }
     }

--- a/TwitchLib.Api.Helix.Models/Predictions/CreatePrediction/CreatePredictionRequest.cs
+++ b/TwitchLib.Api.Helix.Models/Predictions/CreatePrediction/CreatePredictionRequest.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.Api.Helix.Models.Predictions.CreatePrediction
+{
+    public class CreatePredictionRequest
+    {
+        [JsonProperty(PropertyName = "broadcaster_id")]
+        public string BroadcasterId { get; set; }
+        [JsonProperty(PropertyName = "title")]
+        public string Title { get; set; }
+        [JsonProperty(PropertyName = "outcomes")]
+        public Outcome Outcomes { get; set; }
+        [JsonProperty(PropertyName = "prediction_window")]
+        public int PredictionWindowSeconds { get; set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Predictions/CreatePrediction/CreatePredictionResponse.cs
+++ b/TwitchLib.Api.Helix.Models/Predictions/CreatePrediction/CreatePredictionResponse.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.Api.Helix.Models.Predictions.CreatePrediction
+{
+    public class CreatePredictionResponse
+    {
+        [JsonProperty(PropertyName = "data")]
+        public Prediction[] Data { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Predictions/CreatePrediction/Outcome.cs
+++ b/TwitchLib.Api.Helix.Models/Predictions/CreatePrediction/Outcome.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.Api.Helix.Models.Predictions.CreatePrediction
+{
+    public class Outcome
+    {
+        [JsonProperty(PropertyName = "title")]
+        public string Title { get; set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Predictions/EndPrediction/EndPredictionResponse.cs
+++ b/TwitchLib.Api.Helix.Models/Predictions/EndPrediction/EndPredictionResponse.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.Api.Helix.Models.Predictions.EndPrediction
+{
+    public class EndPredictionResponse
+    {
+        [JsonProperty(PropertyName = "data")]
+        public Prediction[] Data { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Predictions/GetPredictions/GetPredictionsResponse.cs
+++ b/TwitchLib.Api.Helix.Models/Predictions/GetPredictions/GetPredictionsResponse.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using TwitchLib.Api.Helix.Models.Common;
+
+namespace TwitchLib.Api.Helix.Models.Predictions.GetPredictions
+{
+    public class GetPredictionsResponse
+    {
+        [JsonProperty(PropertyName = "data")]
+        public Prediction[] Data { get; protected set; }
+        [JsonProperty(PropertyName = "pagination")]
+        public Pagination Pagination { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Predictions/Outcome.cs
+++ b/TwitchLib.Api.Helix.Models/Predictions/Outcome.cs
@@ -1,0 +1,23 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.Api.Helix.Models.Predictions
+{
+    public class Outcome
+    {
+        [JsonProperty(PropertyName = "id")]
+        public string Id { get; protected set; }
+        [JsonProperty(PropertyName = "title")]
+        public string Title { get; protected set; }
+        [JsonProperty(PropertyName = "users")]
+        public int ChannelPoints { get; protected set; }
+        [JsonProperty(PropertyName = "channel_points")]
+        public int ChannelPointsVotes { get; protected set; }
+        [JsonProperty(PropertyName = "top_predictors")]
+        public TopPredictor[] TopPredictors { get; protected set; }
+        [JsonProperty(PropertyName = "color")]
+        public string Color { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Predictions/Prediction.cs
+++ b/TwitchLib.Api.Helix.Models/Predictions/Prediction.cs
@@ -1,0 +1,25 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.Api.Helix.Models.Predictions
+{
+    public class Prediction
+    {
+        [JsonProperty(PropertyName = "id")]
+        public string Id { get; protected set; }
+        [JsonProperty(PropertyName = "broadcaster_id")]
+        public string BroadcasterId { get; protected set; }
+        [JsonProperty(PropertyName = "broadcaster_name")]
+        public string BroadcasterName { get; protected set; }
+        [JsonProperty(PropertyName = "broadcaster_login")]
+        public string BroadcasterLogin { get; protected set; }
+        [JsonProperty(PropertyName = "title")]
+        public string Title { get; protected set; }
+        [JsonProperty(PropertyName = "winning_outcome_id")]
+        public string WinningOutcomeId { get; protected set; }
+        [JsonProperty(PropertyName = "outcomes")]
+        public Outcome[] Outcomes { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Predictions/TopPredictor.cs
+++ b/TwitchLib.Api.Helix.Models/Predictions/TopPredictor.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.Api.Helix.Models.Predictions
+{
+    public class TopPredictor
+    {
+        [JsonProperty(PropertyName = "user")]
+        public User User { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Predictions/User.cs
+++ b/TwitchLib.Api.Helix.Models/Predictions/User.cs
@@ -1,0 +1,21 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.Api.Helix.Models.Predictions
+{
+    public class User
+    {
+        [JsonProperty(PropertyName = "id")]
+        public string Id { get; protected set; }
+        [JsonProperty(PropertyName = "name")]
+        public string Name { get; protected set; }
+        [JsonProperty(PropertyName = "login")]
+        public string Login { get; protected set; }
+        [JsonProperty(PropertyName = "channel_points_used")]
+        public int ChannelPointsUsed { get; protected set; }
+        [JsonProperty(PropertyName = "channel_points_won")]
+        public int ChannelPointsWon { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix/Helix.cs
+++ b/TwitchLib.Api.Helix/Helix.cs
@@ -22,6 +22,8 @@ namespace TwitchLib.Api.Helix
         public Games Games { get; }
         public HypeTrain HypeTrain { get; }
         public Moderation Moderation { get; }
+        public Polls Polls { get; }
+        public Predictions Predictions { get; }
         public Search Search { get; }
         public Subscriptions Subscriptions { get; }
         public Streams Streams { get; }
@@ -58,6 +60,8 @@ namespace TwitchLib.Api.Helix
             Games = new Games(Settings, rateLimiter, http);
             HypeTrain = new HypeTrain(Settings, rateLimiter, http);
             Moderation = new Moderation(Settings, rateLimiter, http);
+            Polls = new Polls(Settings, rateLimiter, http);
+            Predictions = new Predictions(Settings, rateLimiter, http);
             Search = new Search(Settings, rateLimiter, http);
             Streams = new Streams(Settings, rateLimiter, http);
             Subscriptions = new Subscriptions(Settings, rateLimiter, http);

--- a/TwitchLib.Api.Helix/Polls.cs
+++ b/TwitchLib.Api.Helix/Polls.cs
@@ -58,7 +58,7 @@ namespace TwitchLib.Api.Helix
             json["id"] = id;
             json["status"] = status.ToString();
 
-            return TwitchPostGenericAsync<EndPollResponse>("/polls", ApiVersion.Helix, json.ToString(), accessToken: accessToken);
+            return TwitchPatchGenericAsync<EndPollResponse>("/polls", ApiVersion.Helix, json.ToString(), accessToken: accessToken);
         }
     }
 }

--- a/TwitchLib.Api.Helix/Polls.cs
+++ b/TwitchLib.Api.Helix/Polls.cs
@@ -1,0 +1,64 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using TwitchLib.Api.Core;
+using TwitchLib.Api.Core.Enums;
+using TwitchLib.Api.Core.Interfaces;
+using TwitchLib.Api.Helix.Models.Polls.CreatePoll;
+using TwitchLib.Api.Helix.Models.Polls.EndPoll;
+using TwitchLib.Api.Helix.Models.Polls.GetPolls;
+
+namespace TwitchLib.Api.Helix
+{
+    public class Polls : ApiBase
+    {
+        public Polls(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http)
+        {
+        }
+
+        public Task<GetPollsResponse> GetPolls(string broadcasterId, List<string> ids = null, string after = null, int first = 20, string accessToken = null)
+        {
+            DynamicScopeValidation(AuthScopes.Helix_Channel_Read_Polls, accessToken);
+
+            var getParams = new List<KeyValuePair<string, string>>
+            { 
+                new KeyValuePair<string, string>("broadcaster_id", broadcasterId),
+                new KeyValuePair<string, string>("first", first.ToString())
+            };
+
+            if (ids != null && ids.Count > 0)
+            {
+                foreach (var id in ids)
+                {
+                    getParams.Add(new KeyValuePair<string, string>("id", id));
+                }
+            }
+            if (after != null)
+                getParams.Add(new KeyValuePair<string, string>("after", after));
+
+            return TwitchGetGenericAsync<GetPollsResponse>("/polls", ApiVersion.Helix, getParams, accessToken);
+        }
+
+        public Task<CreatePollResponse> CreatePoll(CreatePollRequest request, string accessToken = null)
+        {
+            DynamicScopeValidation(AuthScopes.Helix_Channel_Manage_Polls, accessToken);
+
+            return TwitchPostGenericAsync<CreatePollResponse>("/polls", ApiVersion.Helix, JsonConvert.SerializeObject(request), accessToken: accessToken);
+        }
+
+        public Task<EndPollResponse> EndPoll(string broadcasterId, string id, PollStatusEnum status, string accessToken = null)
+        {
+            DynamicScopeValidation(AuthScopes.Helix_Channel_Manage_Polls, accessToken);
+
+            JObject json = new JObject();
+            json["broadcaster_id"] = broadcasterId;
+            json["id"] = id;
+            json["status"] = status.ToString();
+
+            return TwitchPostGenericAsync<EndPollResponse>("/polls", ApiVersion.Helix, json.ToString(), accessToken: accessToken);
+        }
+    }
+}

--- a/TwitchLib.Api.Helix/Predictions.cs
+++ b/TwitchLib.Api.Helix/Predictions.cs
@@ -1,0 +1,66 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using TwitchLib.Api.Core;
+using TwitchLib.Api.Core.Enums;
+using TwitchLib.Api.Core.Interfaces;
+using TwitchLib.Api.Helix.Models.Predictions.CreatePrediction;
+using TwitchLib.Api.Helix.Models.Predictions.EndPrediction;
+using TwitchLib.Api.Helix.Models.Predictions.GetPredictions;
+
+namespace TwitchLib.Api.Helix
+{
+    public class Predictions : ApiBase
+    {
+        public Predictions(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http)
+        {
+        }
+
+        public Task<GetPredictionsResponse> GetPredictions(string broadcasterId, List<string> ids = null, string after = null, int first = 20, string accessToken = null)
+        {
+            DynamicScopeValidation(AuthScopes.Helix_Channel_Read_Predictions, accessToken);
+
+            var getParams = new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("broadcaster_id", broadcasterId),
+                new KeyValuePair<string, string>("first", first.ToString())
+            };
+
+            if (ids != null && ids.Count > 0)
+            {
+                foreach (var id in ids)
+                {
+                    getParams.Add(new KeyValuePair<string, string>("id", id));
+                }
+            }
+            if (after != null)
+                getParams.Add(new KeyValuePair<string, string>("after", after));
+
+            return TwitchGetGenericAsync<GetPredictionsResponse>("/predictions", ApiVersion.Helix, getParams, accessToken);
+        }
+
+        public Task<CreatePredictionResponse> CreatePrediction(CreatePredictionRequest request, string accessToken = null)
+        {
+            DynamicScopeValidation(AuthScopes.Helix_Channel_Manage_Predictions, accessToken);
+
+            return TwitchPostGenericAsync<CreatePredictionResponse>("/predictions", ApiVersion.Helix, JsonConvert.SerializeObject(request), accessToken: accessToken);
+        }
+
+        public Task<EndPredictionResponse> EndPrediction(string broadcasterId, string id, PredictionStatusEnum status, string winningOutcomeId = null, string accessToken = null)
+        {
+            DynamicScopeValidation(AuthScopes.Helix_Channel_Manage_Predictions, accessToken);
+
+            JObject json = new JObject();
+            json["broadcaster_id"] = broadcasterId;
+            json["id"] = id;
+            json["status"] = status.ToString();
+            if (winningOutcomeId != null)
+                json["winning_outcome_id"] = winningOutcomeId;
+
+            return TwitchPatchGenericAsync<EndPredictionResponse>("/predictions", ApiVersion.Helix, json.ToString(), accessToken: accessToken);
+        }
+    }
+}

--- a/TwitchLib.Api/ThirdParty/AuthorizationFlow/PingResponse.cs
+++ b/TwitchLib.Api/ThirdParty/AuthorizationFlow/PingResponse.cs
@@ -109,6 +109,14 @@ namespace TwitchLib.Api.ThirdParty.AuthorizationFlow
                     return AuthScopes.Helix_User_Manage_BlockedUsers;
                 case "user:read:subscriptions":
                     return AuthScopes.Helix_User_Read_Subscriptions;
+                case "channel:manage:polls":
+                    return AuthScopes.Helix_Channel_Manage_Polls;
+                case "channel:manage:predictions":
+                    return AuthScopes.Helix_Channel_Manage_Predictions;
+                case "channel:read:polls":
+                    return AuthScopes.Helix_Channel_Read_Polls;
+                case "channel:read:predictions":
+                    return AuthScopes.Helix_Channel_Read_Predictions;
                 case "":
                     return AuthScopes.None;
                 default:


### PR DESCRIPTION
This pull request adds support for Predictions and Polls endpoints (and their associated scope permissions).
This code is UNTESTED, as I'm awaiting for an oauth token from my broadcaster to test this. Please don't merge this until I've tested it :)

Polls:
- `CreatePoll`
- `GetPolls`
- `EndPoll`

Predictions:
- `CreatePrediction`
- `GetPredictions`
- `EndPrediction`

Scope Permissions:
- `channel:manage:polls`
- `channel:manage:predictions`
- `channel:read:polls`
- `channel:read:predictions`