### PR TITLE
Support for managing automod held messages

### DIFF
--- a/TwitchLib.Api.Core.Enums/AuthScopesEnum.cs
+++ b/TwitchLib.Api.Core.Enums/AuthScopesEnum.cs
@@ -49,6 +49,7 @@
         Helix_Channel_Manage_Predictions,
         Helix_Channel_Read_Polls,
         Helix_Channel_Read_Predictions,
+        Helix_Channel_Moderator_Manage_Automod,
         None
     }
 }

--- a/TwitchLib.Api.Core.Enums/ManageHeldAutoModMessageAction.cs
+++ b/TwitchLib.Api.Core.Enums/ManageHeldAutoModMessageAction.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.Api.Core.Enums
+{
+    public enum ManageHeldAutoModMessageActionEnum
+    {
+        ALLOW,
+        DENY
+    }
+}

--- a/TwitchLib.Api.Core/ApiBase.cs
+++ b/TwitchLib.Api.Core/ApiBase.cs
@@ -521,6 +521,9 @@ namespace TwitchLib.Api.Core
                     case "channel:read:predictions":
                         scopes.Add(AuthScopes.Helix_Channel_Read_Predictions);
                         break;
+                    case "moderator:manage:automod":
+                        scopes.Add(AuthScopes.Helix_Channel_Moderator_Manage_Automod);
+                        break;
                 }
             }
 

--- a/TwitchLib.Api.Helix/Moderation.cs
+++ b/TwitchLib.Api.Helix/Moderation.cs
@@ -23,7 +23,7 @@ namespace TwitchLib.Api.Helix
         {
         }
 
-        public Task ManageHeldAutoMessages(string userId, string msgId, ManageHeldAutoModMessageActionEnum action, string accessToken = null)
+        public Task ManageHeldAutoModMessages(string userId, string msgId, ManageHeldAutoModMessageActionEnum action, string accessToken = null)
         {
             if(String.IsNullOrEmpty(userId) || String.IsNullOrEmpty(msgId))
                 throw new BadParameterException("userId and msgId cannot be null and must be greater than 0 length");

--- a/TwitchLib.Api.Helix/Moderation.cs
+++ b/TwitchLib.Api.Helix/Moderation.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -20,6 +21,19 @@ namespace TwitchLib.Api.Helix
     {
         public Moderation(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http)
         {
+        }
+
+        public Task ManageHeldAutoMessages(string userId, string msgId, ManageHeldAutoModMessageActionEnum action, string accessToken = null)
+        {
+            if(String.IsNullOrEmpty(userId) || String.IsNullOrEmpty(msgId))
+                throw new BadParameterException("userId and msgId cannot be null and must be greater than 0 length");
+
+            JObject json = new JObject();
+            json["user_id"] = userId;
+            json["msg_id"] = msgId;
+            json["action"] = action.ToString().ToUpper();
+
+            return TwitchPostAsync("/moderation/automod/message", ApiVersion.Helix, json.ToString(), accessToken: accessToken);
         }
 
         #region CheckAutoModeStatus

--- a/TwitchLib.Api/ThirdParty/AuthorizationFlow/PingResponse.cs
+++ b/TwitchLib.Api/ThirdParty/AuthorizationFlow/PingResponse.cs
@@ -117,6 +117,8 @@ namespace TwitchLib.Api.ThirdParty.AuthorizationFlow
                     return AuthScopes.Helix_Channel_Read_Polls;
                 case "channel:read:predictions":
                     return AuthScopes.Helix_Channel_Read_Predictions;
+                case "moderator:manage:automod":
+                    return AuthScopes.Helix_Channel_Moderator_Manage_Automod;
                 case "":
                     return AuthScopes.None;
                 default:


### PR DESCRIPTION
This PR adds the new `moderator:manage:automod` scope, as well as support for the recently added `ManageHeldAutoModMessages` endpoint.

This code HAS been tested and is working.