### PR TITLE
support for GetChannelChatBadges and GetGlobalChatBadges

### DIFF
--- a/TwitchLib.Api.Helix.Models/Chat/EmoteSet.cs
+++ b/TwitchLib.Api.Helix.Models/Chat/EmoteSet.cs
@@ -1,0 +1,15 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.Api.Helix.Models.Chat
+{
+    public class EmoteSet
+    {
+        [JsonProperty(PropertyName = "set_id")]
+        public string SetId { get; protected set; }
+        [JsonProperty(PropertyName = "versions")]
+        public Version[] Versions { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Chat/GetChannelChatBadges/GetChannelChatBadgesResponse.cs
+++ b/TwitchLib.Api.Helix.Models/Chat/GetChannelChatBadges/GetChannelChatBadgesResponse.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.Api.Helix.Models.Chat.GetChannelChatBadges
+{
+    public class GetChannelChatBadgesResponse
+    {
+        [JsonProperty(PropertyName = "data")]
+        public EmoteSet[] EmoteSet { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Chat/GetGlobalChatBadges/GetGlobalChatBadgesResponse.cs
+++ b/TwitchLib.Api.Helix.Models/Chat/GetGlobalChatBadges/GetGlobalChatBadgesResponse.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.Api.Helix.Models.Chat.GetGlobalChatBadges
+{
+    public class GetGlobalChatBadgesResponse
+    {
+        [JsonProperty(PropertyName = "data")]
+        public EmoteSet[] EmoteSet { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Chat/Version.cs
+++ b/TwitchLib.Api.Helix.Models/Chat/Version.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.Api.Helix.Models.Chat
+{
+    public class Version
+    {
+        [JsonProperty(PropertyName = "id")]
+        public string Id { get; protected set; }
+        [JsonProperty(PropertyName = "image_url_1x")]
+        public string ImageUrl1x { get; protected set; }
+        [JsonProperty(PropertyName = "image_url_2x")]
+        public string ImageUrl2x { get; protected set; }
+        [JsonProperty(PropertyName = "image_url_4x")]
+        public string ImageUrl4x { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix/Chat.cs
+++ b/TwitchLib.Api.Helix/Chat.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using TwitchLib.Api.Core;
+using TwitchLib.Api.Core.Enums;
+using TwitchLib.Api.Core.Interfaces;
+using TwitchLib.Api.Helix.Models.Chat.GetChannelChatBadges;
+using TwitchLib.Api.Helix.Models.Chat.GetGlobalChatBadges;
+
+namespace TwitchLib.Api.Helix
+{
+    public class Chat : ApiBase
+    {
+        public Chat(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http)
+        { }
+
+        public Task<GetChannelChatBadgesResponse> GetChannelChatBadges(string broadcasterId, string authToken = null)
+        {
+            var getParams = new List<KeyValuePair<string, string>>()
+            {
+                new KeyValuePair<string, string>("broadcaster_id", broadcasterId)
+            };
+            return TwitchGetGenericAsync<GetChannelChatBadgesResponse>("/chat/badges", ApiVersion.Helix, getParams, authToken);
+        }
+
+        public Task<GetGlobalChatBadgesResponse> GetGlobalChatBadges(string authToken = null)
+        {
+            return TwitchGetGenericAsync<GetGlobalChatBadgesResponse>("/chat/badges/global", ApiVersion.Helix, accessToken: authToken);
+        }
+    }
+}

--- a/TwitchLib.Api.Helix/Helix.cs
+++ b/TwitchLib.Api.Helix/Helix.cs
@@ -13,6 +13,7 @@ namespace TwitchLib.Api.Helix
         public Analytics Analytics { get; }
         public Ads Ads { get; }
         public Bits Bits { get; }
+        public Chat Chat { get; }
         public Channels Channels { get; }
         public ChannelPoints ChannelPoints { get; }
         public Clips Clips { get; }
@@ -51,6 +52,7 @@ namespace TwitchLib.Api.Helix
             Analytics = new Analytics(Settings, rateLimiter, http);
             Ads = new Ads(Settings, rateLimiter, http);
             Bits = new Bits(Settings, rateLimiter, http);
+            Chat = new Chat(Settings, rateLimiter, http);
             Channels = new Channels(Settings, rateLimiter, http);
             ChannelPoints = new ChannelPoints(Settings, rateLimiter, http);
             Clips = new Clips(Settings, rateLimiter, http);


### PR DESCRIPTION
Adds the following functions in `helix/chat`:
- `GetChannelChatBadges(string broadcasterId, string authToken = null)`
- `GetGlobalChatBadges(string authToken = null)`

These *have* been tested and are working.

Added on 2021-05-28: https://dev.twitch.tv/docs/change-log