### PR TITLE
Clip duration JsonSerializer Exception fix

### DIFF
--- a/TwitchLib.Api.Helix.Models/Clips/GetClips/Clip.cs
+++ b/TwitchLib.Api.Helix.Models/Clips/GetClips/Clip.cs
@@ -29,6 +29,6 @@ namespace TwitchLib.Api.Helix.Models.Clips.GetClips
         [JsonProperty(PropertyName = "thumbnail_url")]
         public string ThumbnailUrl { get; protected set; }
         [JsonProperty(PropertyName = "duration")]
-        public int Duration { get; protected set; }
+        public float Duration { get; protected set; }
     }
 }


### PR DESCRIPTION
This PR changes the type of the helix clip duration from int to float to fix a JsonSerializer exception (see #194 )

fixes #194