### PR TITLE
Add Schedule API support

### DIFF
--- a/TwitchLib.Api.Helix.Models/Schedule/Category.cs
+++ b/TwitchLib.Api.Helix.Models/Schedule/Category.cs
@@ -1,0 +1,12 @@
+﻿using Newtonsoft.Json;
+
+namespace TwitchLib.Api.Helix.Models.Schedule
+{
+    public class Category
+    {
+        [JsonProperty("id")]
+        public string Id { get; protected set; }
+        [JsonProperty("name")]
+        public string Name { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Schedule/ChannelStreamSchedule.cs
+++ b/TwitchLib.Api.Helix.Models/Schedule/ChannelStreamSchedule.cs
@@ -1,0 +1,18 @@
+﻿using Newtonsoft.Json;
+
+namespace TwitchLib.Api.Helix.Models.Schedule
+{
+    public class ChannelStreamSchedule
+    {
+        [JsonProperty("segments")]
+        public Segment[] Segments { get; protected set; }
+        [JsonProperty("broadcaster_id")]
+        public string BroadcasterId { get; protected set; }
+        [JsonProperty("broadcaster_name")]
+        public string BroadcasterName { get; protected set; }
+        [JsonProperty("broadcaster_login")]
+        public string BroadcasterLogin { get; protected set; }
+        [JsonProperty("vacation")]
+        public Vacation Vacation { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Schedule/CreateChannelStreamSegment/CreateChannelStreamSegmentRequest.cs
+++ b/TwitchLib.Api.Helix.Models/Schedule/CreateChannelStreamSegment/CreateChannelStreamSegmentRequest.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using System;
 
 namespace TwitchLib.Api.Helix.Models.Schedule.CreateChannelStreamSegment
 {
@@ -6,7 +7,7 @@ namespace TwitchLib.Api.Helix.Models.Schedule.CreateChannelStreamSegment
     {
         // required
         [JsonProperty("start_time")]
-        public string StartTime { get; set; }
+        public DateTime StartTime { get; set; }
         [JsonProperty("timezone")]
         public string Timezone { get; set; }
         [JsonProperty("is_recurring")]

--- a/TwitchLib.Api.Helix.Models/Schedule/CreateChannelStreamSegment/CreateChannelStreamSegmentRequest.cs
+++ b/TwitchLib.Api.Helix.Models/Schedule/CreateChannelStreamSegment/CreateChannelStreamSegmentRequest.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+
+namespace TwitchLib.Api.Helix.Models.Schedule.CreateChannelStreamSegment
+{
+    public class CreateChannelStreamSegmentRequest
+    {
+        // required
+        [JsonProperty("start_time")]
+        public string StartTime { get; set; }
+        [JsonProperty("timezone")]
+        public string Timezone { get; set; }
+        [JsonProperty("is_recurring")]
+        public bool IsRecurring { get; set; }
+        // optional
+        [JsonProperty("duration")]
+        public string Duration { get; set; }
+        [JsonProperty("category_id")]
+        public string CategoryId { get; set; }
+        [JsonProperty("title")]
+        public string Title { get; set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Schedule/CreateChannelStreamSegment/CreateChannelStreamSegmentResponse.cs
+++ b/TwitchLib.Api.Helix.Models/Schedule/CreateChannelStreamSegment/CreateChannelStreamSegmentResponse.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace TwitchLib.Api.Helix.Models.Schedule.CreateChannelStreamSegment
+{
+    public class CreateChannelStreamSegmentResponse
+    {
+        [JsonProperty("data")]
+        public ChannelStreamSchedule[] Schedule { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Schedule/GetChannelStreamSchedule/GetChannelStreamScheduleResponse.cs
+++ b/TwitchLib.Api.Helix.Models/Schedule/GetChannelStreamSchedule/GetChannelStreamScheduleResponse.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+using TwitchLib.Api.Helix.Models.Common;
+
+namespace TwitchLib.Api.Helix.Models.Schedule.GetChannelStreamSchedule
+{
+    public class GetChannelStreamScheduleResponse
+    {
+        [JsonProperty("data")]
+        public ChannelStreamSchedule[] Schedule { get; protected set; }
+        [JsonProperty("pagination")]
+        public Pagination Pagination { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Schedule/Segment.cs
+++ b/TwitchLib.Api.Helix.Models/Schedule/Segment.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using System;
 
 namespace TwitchLib.Api.Helix.Models.Schedule
 {
@@ -7,13 +8,13 @@ namespace TwitchLib.Api.Helix.Models.Schedule
         [JsonProperty("id")]
         public string Id { get; protected set; }
         [JsonProperty("start_time")]
-        public string StartTime { get; protected set; }
+        public DateTime StartTime { get; protected set; }
         [JsonProperty("end_time")]
-        public string EndTime { get; protected set; }
+        public DateTime EndTime { get; protected set; }
         [JsonProperty("title")]
         public string Title { get; protected set; }
         [JsonProperty("canceled_until")]
-        public string CanceledUntil { get; protected set; }
+        public DateTime? CanceledUntil { get; protected set; }
         [JsonProperty("category")]
         public Category Category { get; protected set; }
         [JsonProperty("is_recurring")]

--- a/TwitchLib.Api.Helix.Models/Schedule/Segment.cs
+++ b/TwitchLib.Api.Helix.Models/Schedule/Segment.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+
+namespace TwitchLib.Api.Helix.Models.Schedule
+{
+    public class Segment
+    {
+        [JsonProperty("id")]
+        public string Id { get; protected set; }
+        [JsonProperty("start_time")]
+        public string StartTime { get; protected set; }
+        [JsonProperty("end_time")]
+        public string EndTime { get; protected set; }
+        [JsonProperty("title")]
+        public string Title { get; protected set; }
+        [JsonProperty("canceled_until")]
+        public string CanceledUntil { get; protected set; }
+        [JsonProperty("category")]
+        public Category Category { get; protected set; }
+        [JsonProperty("is_recurring")]
+        public bool IsRecurring { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Schedule/UpdateChannelStreamSegment/UpdateChannelStreamSegmentRequest.cs
+++ b/TwitchLib.Api.Helix.Models/Schedule/UpdateChannelStreamSegment/UpdateChannelStreamSegmentRequest.cs
@@ -1,0 +1,18 @@
+﻿using Newtonsoft.Json;
+
+namespace TwitchLib.Api.Helix.Models.Schedule.UpdateChannelStreamSegment
+{
+    public class UpdateChannelStreamSegmentRequest
+    {
+        [JsonProperty("start_time")]
+        public string StartTime { get; set; }
+        [JsonProperty("duration")]
+        public string Duration { get; set; }
+        [JsonProperty("category_id")]
+        public string CategoryId { get; set; }
+        [JsonProperty("is_canceled")]
+        public bool IsCanceled { get; set; }
+        [JsonProperty("timezone")]
+        public string Timezone { get; set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Schedule/UpdateChannelStreamSegment/UpdateChannelStreamSegmentRequest.cs
+++ b/TwitchLib.Api.Helix.Models/Schedule/UpdateChannelStreamSegment/UpdateChannelStreamSegmentRequest.cs
@@ -1,11 +1,12 @@
 ﻿using Newtonsoft.Json;
+using System;
 
 namespace TwitchLib.Api.Helix.Models.Schedule.UpdateChannelStreamSegment
 {
     public class UpdateChannelStreamSegmentRequest
     {
         [JsonProperty("start_time")]
-        public string StartTime { get; set; }
+        public DateTime StartTime { get; set; }
         [JsonProperty("duration")]
         public string Duration { get; set; }
         [JsonProperty("category_id")]

--- a/TwitchLib.Api.Helix.Models/Schedule/UpdateChannelStreamSegment/UpdateChannelStreamSegmentResponse.cs
+++ b/TwitchLib.Api.Helix.Models/Schedule/UpdateChannelStreamSegment/UpdateChannelStreamSegmentResponse.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace TwitchLib.Api.Helix.Models.Schedule.UpdateChannelStreamSegment
+{
+    public class UpdateChannelStreamSegmentResponse
+    {
+        [JsonProperty("data")]
+        public ChannelStreamSchedule[] Schedule { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Schedule/Vacation.cs
+++ b/TwitchLib.Api.Helix.Models/Schedule/Vacation.cs
@@ -1,12 +1,13 @@
 ﻿using Newtonsoft.Json;
+using System;
 
 namespace TwitchLib.Api.Helix.Models.Schedule
 {
     public class Vacation
     {
         [JsonProperty("start_time")]
-        public string StartTime { get; protected set; }
+        public DateTime StartTime { get; protected set; }
         [JsonProperty("end_time")]
-        public string EndTime { get; protected set; }
+        public DateTime EndTime { get; protected set; }
     }
 }

--- a/TwitchLib.Api.Helix.Models/Schedule/Vacation.cs
+++ b/TwitchLib.Api.Helix.Models/Schedule/Vacation.cs
@@ -1,0 +1,12 @@
+﻿using Newtonsoft.Json;
+
+namespace TwitchLib.Api.Helix.Models.Schedule
+{
+    public class Vacation
+    {
+        [JsonProperty("start_time")]
+        public string StartTime { get; protected set; }
+        [JsonProperty("end_time")]
+        public string EndTime { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix/Helix.cs
+++ b/TwitchLib.Api.Helix/Helix.cs
@@ -25,6 +25,7 @@ namespace TwitchLib.Api.Helix
         public Moderation Moderation { get; }
         public Polls Polls { get; }
         public Predictions Predictions { get; }
+        public Schedule Schedule { get; }
         public Search Search { get; }
         public Subscriptions Subscriptions { get; }
         public Streams Streams { get; }
@@ -64,6 +65,7 @@ namespace TwitchLib.Api.Helix
             Moderation = new Moderation(Settings, rateLimiter, http);
             Polls = new Polls(Settings, rateLimiter, http);
             Predictions = new Predictions(Settings, rateLimiter, http);
+            Schedule = new Schedule(Settings, rateLimiter, http);
             Search = new Search(Settings, rateLimiter, http);
             Streams = new Streams(Settings, rateLimiter, http);
             Subscriptions = new Subscriptions(Settings, rateLimiter, http);

--- a/TwitchLib.Api.Helix/Schedule.cs
+++ b/TwitchLib.Api.Helix/Schedule.cs
@@ -1,0 +1,11 @@
+﻿using TwitchLib.Api.Core;
+using TwitchLib.Api.Core.Interfaces;
+
+namespace TwitchLib.Api.Helix
+{
+    public class Schedule : ApiBase
+    {
+        public Schedule(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http)
+        { }
+    }
+}

--- a/TwitchLib.Api.Helix/Schedule.cs
+++ b/TwitchLib.Api.Helix/Schedule.cs
@@ -1,5 +1,13 @@
-﻿using TwitchLib.Api.Core;
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using TwitchLib.Api.Core;
+using TwitchLib.Api.Core.Enums;
 using TwitchLib.Api.Core.Interfaces;
+using TwitchLib.Api.Helix.Models.Schedule.CreateChannelStreamSegment;
+using TwitchLib.Api.Helix.Models.Schedule.GetChannelStreamSchedule;
+using TwitchLib.Api.Helix.Models.Schedule.UpdateChannelStreamSegment;
 
 namespace TwitchLib.Api.Helix
 {
@@ -7,5 +15,83 @@ namespace TwitchLib.Api.Helix
     {
         public Schedule(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http)
         { }
+
+        public Task<GetChannelStreamScheduleResponse> GetChannelStreamScheduleAsync(string broadcasterId, List<string> segmentIds = null, string startTime = null, string utcOffset = null,
+            int first = 20, string after = null, string authToken = null)
+        {
+            var getParams = new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("broadcaster_id", broadcasterId),
+                new KeyValuePair<string, string>("first", first.ToString())
+            };
+
+            if (segmentIds != null && segmentIds.Count > 0)
+            {
+                getParams.AddRange(segmentIds.Select(segmentId => new KeyValuePair<string, string>("id", segmentId)));
+            }
+
+            if (!string.IsNullOrWhiteSpace(startTime))
+                getParams.Add(new KeyValuePair<string, string>("start_time", startTime));
+            if (!string.IsNullOrWhiteSpace(utcOffset))
+                getParams.Add(new KeyValuePair<string, string>("utc_offset", utcOffset));
+            if (!string.IsNullOrWhiteSpace(after))
+                getParams.Add(new KeyValuePair<string, string>("after", after));
+
+            return TwitchGetGenericAsync<GetChannelStreamScheduleResponse>("/schedule", ApiVersion.Helix, getParams, authToken);
+        }
+
+        public Task UpdateChannelStreamScheduleAsync(string broadcasterId, bool? isVacationEnabled = null, string vacationStartTime = null, string vacationEndTime = null,
+            string timezone = null, string authToken = null)
+        {
+            var getParams = new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("broadcaster_id", broadcasterId)
+            };
+
+            if (isVacationEnabled.HasValue)
+                getParams.Add(new KeyValuePair<string, string>("is_vacation_enabled", isVacationEnabled.Value.ToString()));
+
+            if (!string.IsNullOrWhiteSpace(vacationStartTime))
+                getParams.Add(new KeyValuePair<string, string>("vacation_start_time", vacationStartTime));
+            if (!string.IsNullOrWhiteSpace(vacationEndTime))
+                getParams.Add(new KeyValuePair<string, string>("vacation_end_time", vacationEndTime));
+            if (!string.IsNullOrWhiteSpace(timezone))
+                getParams.Add(new KeyValuePair<string, string>("timezone", timezone));
+
+            return TwitchPatchAsync("/schedule/settings", ApiVersion.Helix, null, getParams, authToken);
+        }
+
+        public Task<CreateChannelStreamSegmentResponse> CreateChannelStreamScheduleSegmentAsync(string broadcasterId, CreateChannelStreamSegmentRequest payload, string authToken = null)
+        {
+            var getParams = new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("broadcaster_id", broadcasterId)
+            };
+
+            return TwitchPostGenericAsync<CreateChannelStreamSegmentResponse>("/schedule/segment", ApiVersion.Helix, JsonConvert.SerializeObject(payload), getParams, authToken);
+        }
+
+        public Task<UpdateChannelStreamSegmentResponse> UpdateChannelStreamScheduleSegmentAsync(string broadcasterId, string segmentId, UpdateChannelStreamSegmentRequest payload,
+            string authToken = null)
+        {
+            var getParams = new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("broadcaster_id", broadcasterId),
+                new KeyValuePair<string, string>("id", segmentId)
+            };
+
+            return TwitchPatchGenericAsync<UpdateChannelStreamSegmentResponse>("/schedule/segment", ApiVersion.Helix, JsonConvert.SerializeObject(payload), getParams, authToken);
+        }
+
+        public Task DeleteChannelStreamScheduleSegmentAsync(string broadcasterId, string segmentId, string authToken = null)
+        {
+            var getParams = new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("broadcaster_id", broadcasterId),
+                new KeyValuePair<string, string>("id", segmentId)
+            };
+
+            return TwitchDeleteAsync("/schedule/segment", ApiVersion.Helix, getParams, authToken);
+        }
     }
 }

--- a/TwitchLib.Api.Helix/Schedule.cs
+++ b/TwitchLib.Api.Helix/Schedule.cs
@@ -1,5 +1,7 @@
 ﻿using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using TwitchLib.Api.Core;
@@ -40,7 +42,7 @@ namespace TwitchLib.Api.Helix
             return TwitchGetGenericAsync<GetChannelStreamScheduleResponse>("/schedule", ApiVersion.Helix, getParams, authToken);
         }
 
-        public Task UpdateChannelStreamScheduleAsync(string broadcasterId, bool? isVacationEnabled = null, string vacationStartTime = null, string vacationEndTime = null,
+        public Task UpdateChannelStreamScheduleAsync(string broadcasterId, bool? isVacationEnabled = null, DateTime? vacationStartTime = null, DateTime? vacationEndTime = null,
             string timezone = null, string authToken = null)
         {
             var getParams = new List<KeyValuePair<string, string>>
@@ -51,10 +53,10 @@ namespace TwitchLib.Api.Helix
             if (isVacationEnabled.HasValue)
                 getParams.Add(new KeyValuePair<string, string>("is_vacation_enabled", isVacationEnabled.Value.ToString()));
 
-            if (!string.IsNullOrWhiteSpace(vacationStartTime))
-                getParams.Add(new KeyValuePair<string, string>("vacation_start_time", vacationStartTime));
-            if (!string.IsNullOrWhiteSpace(vacationEndTime))
-                getParams.Add(new KeyValuePair<string, string>("vacation_end_time", vacationEndTime));
+            if (vacationStartTime.HasValue)
+                getParams.Add(new KeyValuePair<string, string>("vacation_start_time", vacationStartTime.Value.ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss.fffzzz", DateTimeFormatInfo.InvariantInfo)));
+            if (vacationEndTime.HasValue)
+                getParams.Add(new KeyValuePair<string, string>("vacation_end_time", vacationEndTime.Value.ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss.fffzzz", DateTimeFormatInfo.InvariantInfo)));
             if (!string.IsNullOrWhiteSpace(timezone))
                 getParams.Add(new KeyValuePair<string, string>("timezone", timezone));
 


### PR DESCRIPTION
This PR adds support for the following endpoint functionality:

- Get Channel Stream Schedule
- Update Channel Stream Schedule
- Create Channel Stream Schedule Segment
- Update Channel Stream Schedule Segment
- Delete Channel Stream Schedule Segment

Get Channel iCalendar was not added as it rather aims at end user usage in an calendar app rather than in an API wrapper library