### PR TITLE
Fix some Helix APIs

### DIFF
--- a/TwitchLib.Api.Helix.Models/Ads/StartCommercialRequest.cs
+++ b/TwitchLib.Api.Helix.Models/Ads/StartCommercialRequest.cs
@@ -8,8 +8,8 @@ namespace TwitchLib.Api.Helix.Models.Ads
     public class StartCommercialRequest
     {
         [JsonProperty(PropertyName = "broadcaster_id")]
-        public string BroadcasterId { get; protected set; }
+        public string BroadcasterId { get; set; }
         [JsonProperty(PropertyName = "length")]
-        public int Length { get; protected set; }
+        public int Length { get; set; }
     }
 }

--- a/TwitchLib.Api.Helix.Models/Channels/ModifyChannelInformation/ModifyChannelInformationRequest.cs
+++ b/TwitchLib.Api.Helix.Models/Channels/ModifyChannelInformation/ModifyChannelInformationRequest.cs
@@ -5,13 +5,13 @@ namespace TwitchLib.Api.Helix.Models.Channels.ModifyChannelInformation
     [JsonObject(ItemNullValueHandling = NullValueHandling.Ignore)]
     public class ModifyChannelInformationRequest
     {
-        [JsonProperty(PropertyName = "game_id")]
+        [JsonProperty(PropertyName = "game_id", NullValueHandling = NullValueHandling.Ignore)]
         public string GameId { get; set; }
-        [JsonProperty(PropertyName = "title")]
+        [JsonProperty(PropertyName = "title", NullValueHandling = NullValueHandling.Ignore)]
         public string Title { get; set; }
-        [JsonProperty(PropertyName = "broadcaster_language")]
+        [JsonProperty(PropertyName = "broadcaster_language", NullValueHandling = NullValueHandling.Ignore)]
         public string BroadcasterLanguage { get; set; }
-        [JsonProperty(PropertyName = "delay")]
-        public int Delay { get; set; }
+        [JsonProperty(PropertyName = "delay", NullValueHandling = NullValueHandling.Ignore)]
+        public int? Delay { get; set; }
     }
 }


### PR DESCRIPTION
Using the StartCommercialRequest was pretty much impossible, since setting its fields was blocked off by the access level.

Using ModifyChannelInformation was possible, but only on partnered channels(since delay only works there), and it was not possible to omit some of the other optional fields (like only setting the title, without touching the game/language).