### PR TITLE
Added new fields to GetBannedUsers and GetBannedEvents

### DIFF
--- a/TwitchLib.Api.Helix.Models/Moderation/GetBannedEvents/EventData.cs
+++ b/TwitchLib.Api.Helix.Models/Moderation/GetBannedEvents/EventData.cs
@@ -1,7 +1,5 @@
 ﻿using Newtonsoft.Json;
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace TwitchLib.Api.Helix.Models.Moderation.GetBannedEvents
 {
@@ -21,5 +19,13 @@ namespace TwitchLib.Api.Helix.Models.Moderation.GetBannedEvents
         public string UserName { get; protected set; }
         [JsonProperty(PropertyName = "expires_at")]
         public DateTime? ExpiresAt { get; protected set; }
+        [JsonProperty(PropertyName = "reason")]
+        public string Reason { get; protected set; }
+        [JsonProperty(PropertyName = "moderator_id")]
+        public string ModeratorId { get; protected set; }
+        [JsonProperty(PropertyName = "moderator_login")]
+        public string ModeratorLogin { get; protected set; }
+        [JsonProperty(PropertyName = "moderator_name")]
+        public string ModeratorName { get; protected set; }
     }
 }

--- a/TwitchLib.Api.Helix.Models/Moderation/GetBannedUsers/BannedUserEvent.cs
+++ b/TwitchLib.Api.Helix.Models/Moderation/GetBannedUsers/BannedUserEvent.cs
@@ -1,7 +1,5 @@
 ﻿using Newtonsoft.Json;
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace TwitchLib.Api.Helix.Models.Moderation.GetBannedUsers
 {
@@ -15,5 +13,13 @@ namespace TwitchLib.Api.Helix.Models.Moderation.GetBannedUsers
         public string UserName { get; protected set; }
         [JsonProperty(PropertyName = "expires_at")]
         public DateTime? ExpiresAt { get; protected set; }
+        [JsonProperty(PropertyName = "reason")]
+        public string Reason { get; protected set; }
+        [JsonProperty(PropertyName = "moderator_id")]
+        public string ModeratorId { get; protected set; }
+        [JsonProperty(PropertyName = "moderator_login")]
+        public string ModeratorLogin { get; protected set; }
+        [JsonProperty(PropertyName = "moderator_name")]
+        public string ModeratorName { get; protected set; }
     }
 }


### PR DESCRIPTION
Added new fields to GetBannedUsers and GetBannedEvents models. 
This includes:

- "moderator_id" - User ID of the moderator who initiated the ban
- "moderator_login" - Login of the moderator who initiated the ban
- "moderator_name" - Display name of the moderator who initiated the ban
- "reason" - The reason for the ban if provided by the moderator

for both models