### PR TITLE
Include xml comments into nuget package

### DIFF
--- a/TwitchLib.Api.Core.Enums/TwitchLib.Api.Core.Enums.csproj
+++ b/TwitchLib.Api.Core.Enums/TwitchLib.Api.Core.Enums.csproj
@@ -20,6 +20,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <AssemblyVersion>3.2.4</AssemblyVersion>
     <FileVersion>3.2.4</FileVersion>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/TwitchLib.Api.Core.Interfaces/TwitchLib.Api.Core.Interfaces.csproj
+++ b/TwitchLib.Api.Core.Interfaces/TwitchLib.Api.Core.Interfaces.csproj
@@ -20,6 +20,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <AssemblyVersion>3.2.4</AssemblyVersion>
     <FileVersion>3.2.4</FileVersion>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/TwitchLib.Api.Core.Models/TwitchLib.Api.Core.Models.csproj
+++ b/TwitchLib.Api.Core.Models/TwitchLib.Api.Core.Models.csproj
@@ -20,6 +20,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <AssemblyVersion>3.2.4</AssemblyVersion>
     <FileVersion>3.2.4</FileVersion>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/TwitchLib.Api.Core/TwitchLib.Api.Core.csproj
+++ b/TwitchLib.Api.Core/TwitchLib.Api.Core.csproj
@@ -20,6 +20,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <AssemblyVersion>3.2.4</AssemblyVersion>
     <FileVersion>3.2.4</FileVersion>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TwitchLib.Api.Helix.Models/TwitchLib.Api.Helix.Models.csproj
+++ b/TwitchLib.Api.Helix.Models/TwitchLib.Api.Helix.Models.csproj
@@ -20,6 +20,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <AssemblyVersion>3.2.4</AssemblyVersion>
     <FileVersion>3.2.4</FileVersion>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TwitchLib.Api.Helix/TwitchLib.Api.Helix.csproj
+++ b/TwitchLib.Api.Helix/TwitchLib.Api.Helix.csproj
@@ -20,6 +20,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <AssemblyVersion>3.2.4</AssemblyVersion>
     <FileVersion>3.2.4</FileVersion>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\TwitchLib.Api.Core\TwitchLib.Api.Core.csproj" />

--- a/TwitchLib.Api.Test/TwitchLib.Api.Test.csproj
+++ b/TwitchLib.Api.Test/TwitchLib.Api.Test.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
+
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TwitchLib.Api.V5.Models/TwitchLib.Api.V5.Models.csproj
+++ b/TwitchLib.Api.V5.Models/TwitchLib.Api.V5.Models.csproj
@@ -21,6 +21,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <AssemblyVersion>3.2.4</AssemblyVersion>
     <FileVersion>3.2.4</FileVersion>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TwitchLib.Api.V5/TwitchLib.Api.V5.csproj
+++ b/TwitchLib.Api.V5/TwitchLib.Api.V5.csproj
@@ -20,6 +20,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <AssemblyVersion>3.2.4</AssemblyVersion>
     <FileVersion>3.2.4</FileVersion>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TwitchLib.Api/TwitchLib.Api.csproj
+++ b/TwitchLib.Api/TwitchLib.Api.csproj
@@ -20,6 +20,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <AssemblyVersion>3.2.4</AssemblyVersion>
     <FileVersion>3.2.4</FileVersion>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />


### PR DESCRIPTION
Currently XML comments aren't included in the Nuget package and therefore don't show in the users intellisense.
This PR aims to include the comments to enable the users intellisense to support them with information they may need.