### PR TITLE
fix(auth): avoid doubly encoding the redirect_uri

### DIFF
--- a/TwitchLib.Api/Auth/Auth.cs
+++ b/TwitchLib.Api/Auth/Auth.cs
@@ -111,7 +111,7 @@ namespace TwitchLib.Api.Auth
                 new KeyValuePair<string, string>("code", code),
                 new KeyValuePair<string, string>("client_id", internalClientId),
                 new KeyValuePair<string, string>("client_secret", clientSecret),
-                new KeyValuePair<string, string>("redirect_uri", System.Web.HttpUtility.UrlEncode(redirectUri))
+                new KeyValuePair<string, string>("redirect_uri", redirectUri)
             };
 
             return TwitchPostGenericAsync<AuthCodeResponse>("/oauth2/token", ApiVersion.V5, null, getParams, customBase: "https://id.twitch.tv");


### PR DESCRIPTION
Avoids doubly encoding the redirect_uri (first on `Auth:114` and then on `ApiBase:338`) to fix an error 400 from `GetAccessTokenFromCodeAsync`

Thanks to @Syzuna for debugging and `Vlad0sZ#2829` for reporting

Note: haven't tested `GetAccessTokenFromCodeAsync` myself
