### PR TITLE
Fix Requesting Multiple Clips with Helix Api

### DIFF
--- a/TwitchLib.Api.Helix/Clips.cs
+++ b/TwitchLib.Api.Helix/Clips.cs
@@ -32,7 +32,7 @@ namespace TwitchLib.Api.Helix
             if (broadcasterId != null)
                 getParams.Add(new KeyValuePair<string, string>("broadcaster_id", broadcasterId));
 
-            if (getParams.Count != 1)
+            if (getParams.Count == 0 || (getParams.Count > 1 && gameId != null && broadcasterId != null))
                 throw new BadParameterException("One of the following parameters must be set: clipId, gameId, broadcasterId. Only one is allowed to be set.");
 
             if (startedAt == null && endedAt != null)


### PR DESCRIPTION
The previous code checked for getParams.Count != 1 which is only true if a single id is given.
This change better reflects the actual limitations of the Api ("For a query to be valid, id (one or more), broadcaster_id, or game_id must be specified. You may specify only one of these parameters.").