### PR TITLE
add missing optional accessToken params, rename incorrectly named params

### DIFF
--- a/TwitchLib.Api.Helix/Ads.cs
+++ b/TwitchLib.Api.Helix/Ads.cs
@@ -17,7 +17,7 @@ namespace TwitchLib.Api.Helix
         }
 
         #region StartCommercial
-        public Task<StartCommercialResponse> StartCommercial(StartCommercialRequest request, string accessToken = null)
+        public Task<StartCommercialResponse> StartCommercialAsync(StartCommercialRequest request, string accessToken = null)
         {
             return TwitchPostGenericAsync<StartCommercialResponse>("/channels/commercial", ApiVersion.Helix, JsonConvert.SerializeObject(request), null, accessToken);
         }

--- a/TwitchLib.Api.Helix/Analytics.cs
+++ b/TwitchLib.Api.Helix/Analytics.cs
@@ -15,26 +15,26 @@ namespace TwitchLib.Api.Helix
 
         #region GetGameAnalytics
 
-        public Task<GetGameAnalyticsResponse> GetGameAnalyticsAsync(string gameId = null, string authToken = null)
+        public Task<GetGameAnalyticsResponse> GetGameAnalyticsAsync(string gameId = null, string accessToken = null)
         {
             var getParams = new List<KeyValuePair<string, string>>();
             if (gameId != null)
                 getParams.Add(new KeyValuePair<string, string>("game_id", gameId));
 
-            return TwitchGetGenericAsync<GetGameAnalyticsResponse>("/analytics/games", ApiVersion.Helix, getParams, authToken);
+            return TwitchGetGenericAsync<GetGameAnalyticsResponse>("/analytics/games", ApiVersion.Helix, getParams, accessToken);
         }
 
         #endregion
 
         #region GetExtensionAnalytics
 
-        public Task<GetExtensionAnalyticsResponse> GetExtensionAnalyticsAsync(string extensionId, string authToken = null)
+        public Task<GetExtensionAnalyticsResponse> GetExtensionAnalyticsAsync(string extensionId, string accessToken = null)
         {
             var getParams = new List<KeyValuePair<string, string>>();
             if (extensionId != null)
                 getParams.Add(new KeyValuePair<string, string>("extension_id", extensionId));
 
-            return TwitchGetGenericAsync<GetExtensionAnalyticsResponse>("/analytics/extensions", ApiVersion.Helix, getParams, authToken);
+            return TwitchGetGenericAsync<GetExtensionAnalyticsResponse>("/analytics/extensions", ApiVersion.Helix, getParams, accessToken);
         }
 
         #endregion

--- a/TwitchLib.Api.Helix/Bits.cs
+++ b/TwitchLib.Api.Helix/Bits.cs
@@ -16,7 +16,7 @@ namespace TwitchLib.Api.Helix
         }
 
         #region GetCheermotes
-        public Task<GetCheermotesResponse> GetCheermotes(string broadcasterId = null, string accessToken = null)
+        public Task<GetCheermotesResponse> GetCheermotesAsync(string broadcasterId = null, string accessToken = null)
         {
             var getParams = new List<KeyValuePair<string, string>>();
             if (broadcasterId != null)

--- a/TwitchLib.Api.Helix/ChannelPoints.cs
+++ b/TwitchLib.Api.Helix/ChannelPoints.cs
@@ -19,7 +19,7 @@ namespace TwitchLib.Api.Helix
         }
 
         #region CreateCustomRewards
-        public Task<CreateCustomRewardsResponse> CreateCustomRewards(string broadcasterId, CreateCustomRewardsRequest request, string accessToken = null)
+        public Task<CreateCustomRewardsResponse> CreateCustomRewardsAsync(string broadcasterId, CreateCustomRewardsRequest request, string accessToken = null)
         {
             var getParams = new List<KeyValuePair<string, string>>
             {
@@ -31,7 +31,7 @@ namespace TwitchLib.Api.Helix
         #endregion
 
         #region DeleteCustomReward
-        public Task DeleteCustomReward(string broadcasterId, string rewardId, string accessToken = null)
+        public Task DeleteCustomRewardAsync(string broadcasterId, string rewardId, string accessToken = null)
         {
             var getParams = new List<KeyValuePair<string, string>>
             {
@@ -44,7 +44,7 @@ namespace TwitchLib.Api.Helix
         #endregion
 
         #region GetCustomReward
-        public Task<GetCustomRewardsResponse> GetCustomReward(string broadcasterId, List<string> rewardIds = null, bool onlyManageableRewards = false, string accessToken = null)
+        public Task<GetCustomRewardsResponse> GetCustomRewardAsync(string broadcasterId, List<string> rewardIds = null, bool onlyManageableRewards = false, string accessToken = null)
         {
             var getParams = new List<KeyValuePair<string, string>>
                     {
@@ -65,7 +65,7 @@ namespace TwitchLib.Api.Helix
         #endregion
 
         #region UpdateCustomReward
-        public Task<UpdateCustomRewardResponse> UpdateCustomReward(string broadcasterId, string rewardId, UpdateCustomRewardRequest request, string accessToken = null)
+        public Task<UpdateCustomRewardResponse> UpdateCustomRewardAsync(string broadcasterId, string rewardId, UpdateCustomRewardRequest request, string accessToken = null)
         {
             var getParams = new List<KeyValuePair<string, string>>
                     {
@@ -78,7 +78,7 @@ namespace TwitchLib.Api.Helix
         #endregion
 
         #region GetCustomRewardRedemption
-        public Task<GetCustomRewardRedemptionResponse> GetCustomRewardRedemption(string broadcasterId, string rewardId, string redemptionId = null, string status = null, string sort = null, string after = null, string first = null, string accessToken = null)
+        public Task<GetCustomRewardRedemptionResponse> GetCustomRewardRedemptionAsync(string broadcasterId, string rewardId, string redemptionId = null, string status = null, string sort = null, string after = null, string first = null, string accessToken = null)
         {
             var getParams = new List<KeyValuePair<string, string>>
                     {
@@ -111,7 +111,7 @@ namespace TwitchLib.Api.Helix
         #endregion
 
         #region UpdateCustomRewardRedemption
-        public Task<UpdateCustomRewardRedemptionStatusResponse> UpdateCustomRewardRedemptionStatus(string broadcasterId, string rewardId, List<string> redemptionIds, UpdateCustomRewardRedemptionStatusRequest request, string accessToken = null)
+        public Task<UpdateCustomRewardRedemptionStatusResponse> UpdateCustomRewardRedemptionStatusAsync(string broadcasterId, string rewardId, List<string> redemptionIds, UpdateCustomRewardRedemptionStatusRequest request, string accessToken = null)
         {
             var getParams = new List<KeyValuePair<string, string>>
                     {

--- a/TwitchLib.Api.Helix/Chat.cs
+++ b/TwitchLib.Api.Helix/Chat.cs
@@ -17,44 +17,44 @@ namespace TwitchLib.Api.Helix
         { }
 
         #region Badges
-        public Task<GetChannelChatBadgesResponse> GetChannelChatBadgesAsync(string broadcasterId, string authToken = null)
+        public Task<GetChannelChatBadgesResponse> GetChannelChatBadgesAsync(string broadcasterId, string accessToken = null)
         {
             var getParams = new List<KeyValuePair<string, string>>
             {
                 new KeyValuePair<string, string>("broadcaster_id", broadcasterId)
             };
-            return TwitchGetGenericAsync<GetChannelChatBadgesResponse>("/chat/badges", ApiVersion.Helix, getParams, authToken);
+            return TwitchGetGenericAsync<GetChannelChatBadgesResponse>("/chat/badges", ApiVersion.Helix, getParams, accessToken);
         }
 
-        public Task<GetGlobalChatBadgesResponse> GetGlobalChatBadgesAsync(string authToken = null)
+        public Task<GetGlobalChatBadgesResponse> GetGlobalChatBadgesAsync(string accessToken = null)
         {
-            return TwitchGetGenericAsync<GetGlobalChatBadgesResponse>("/chat/badges/global", ApiVersion.Helix, accessToken: authToken);
+            return TwitchGetGenericAsync<GetGlobalChatBadgesResponse>("/chat/badges/global", ApiVersion.Helix, accessToken: accessToken);
         }
         #endregion
 
         #region Emotes
 
-        public Task<GetChannelEmotesResponse> GetChannelEmotesAsync(string broadcasterId, string authToken = null)
+        public Task<GetChannelEmotesResponse> GetChannelEmotesAsync(string broadcasterId, string accessToken = null)
         {
             var getParams = new List<KeyValuePair<string, string>>
             {
                 new KeyValuePair<string, string>("broadcaster_id", broadcasterId)
             };
-            return TwitchGetGenericAsync<GetChannelEmotesResponse>("/chat/emotes", ApiVersion.Helix, getParams, authToken);
+            return TwitchGetGenericAsync<GetChannelEmotesResponse>("/chat/emotes", ApiVersion.Helix, getParams, accessToken);
         }
 
-        public Task<GetEmoteSetsResponse> GetEmoteSetsAsync(string emoteSetId, string authToken = null)
+        public Task<GetEmoteSetsResponse> GetEmoteSetsAsync(string emoteSetId, string accessToken = null)
         {
             var getParams = new List<KeyValuePair<string, string>>
             {
                 new KeyValuePair<string, string>("emote_set_id", emoteSetId)
             };
-            return TwitchGetGenericAsync<GetEmoteSetsResponse>("/chat/emotes/set", ApiVersion.Helix, getParams, authToken);
+            return TwitchGetGenericAsync<GetEmoteSetsResponse>("/chat/emotes/set", ApiVersion.Helix, getParams, accessToken);
         }
 
-        public Task<GetGlobalEmotesResponse> GetGlobalEmotesAsync(string authToken = null)
+        public Task<GetGlobalEmotesResponse> GetGlobalEmotesAsync(string accessToken = null)
         {
-            return TwitchGetGenericAsync<GetGlobalEmotesResponse>("/chat/emotes/global", ApiVersion.Helix, accessToken: authToken);
+            return TwitchGetGenericAsync<GetGlobalEmotesResponse>("/chat/emotes/global", ApiVersion.Helix, accessToken: accessToken);
         }
         #endregion
     }

--- a/TwitchLib.Api.Helix/Clips.cs
+++ b/TwitchLib.Api.Helix/Clips.cs
@@ -19,7 +19,7 @@ namespace TwitchLib.Api.Helix
 
         #region GetClips
 
-        public Task<GetClipsResponse> GetClipsAsync(List<string> clipIds = null, string gameId = null, string broadcasterId = null, string before = null, string after = null, DateTime? startedAt = null, DateTime? endedAt = null, int first = 20)
+        public Task<GetClipsResponse> GetClipsAsync(List<string> clipIds = null, string gameId = null, string broadcasterId = null, string before = null, string after = null, DateTime? startedAt = null, DateTime? endedAt = null, int first = 20, string accessToken = null)
         {
             if (first < 0 || first > 100)
                 throw new BadParameterException("'first' must between 0 (inclusive) and 100 (inclusive).");
@@ -53,20 +53,20 @@ namespace TwitchLib.Api.Helix
                 getParams.Add(new KeyValuePair<string, string>("after", after));
             getParams.Add(new KeyValuePair<string, string>("first", first.ToString()));
 
-            return TwitchGetGenericAsync<GetClipsResponse>("/clips", ApiVersion.Helix, getParams);
+            return TwitchGetGenericAsync<GetClipsResponse>("/clips", ApiVersion.Helix, getParams, accessToken);
         }
 
         #endregion
 
         #region CreateClip
 
-        public Task<CreatedClipResponse> CreateClipAsync(string broadcasterId, string authToken = null)
+        public Task<CreatedClipResponse> CreateClipAsync(string broadcasterId, string accessToken = null)
         {
             var getParams = new List<KeyValuePair<string, string>>
                 {
                     new KeyValuePair<string, string>("broadcaster_id", broadcasterId)
                 };
-            return TwitchPostGenericAsync<CreatedClipResponse>("/clips", ApiVersion.Helix, null, getParams, authToken);
+            return TwitchPostGenericAsync<CreatedClipResponse>("/clips", ApiVersion.Helix, null, getParams, accessToken);
         }
 
         #endregion

--- a/TwitchLib.Api.Helix/Games.cs
+++ b/TwitchLib.Api.Helix/Games.cs
@@ -16,7 +16,7 @@ namespace TwitchLib.Api.Helix
 
             #region GetGames
 
-            public Task<GetGamesResponse> GetGamesAsync(List<string> gameIds = null, List<string> gameNames = null)
+            public Task<GetGamesResponse> GetGamesAsync(List<string> gameIds = null, List<string> gameNames = null, string accessToken = null)
             {
                 if (gameIds == null && gameNames == null || gameIds != null && gameIds.Count == 0 && gameNames == null || gameNames != null && gameNames.Count == 0 && gameIds == null)
                     throw new BadParameterException("Either gameIds or gameNames must have at least one value");
@@ -40,14 +40,14 @@ namespace TwitchLib.Api.Helix
                         getParams.Add(new KeyValuePair<string, string>("name", gameName));
                 }
 
-                return TwitchGetGenericAsync<GetGamesResponse>("/games", ApiVersion.Helix, getParams);
+                return TwitchGetGenericAsync<GetGamesResponse>("/games", ApiVersion.Helix, getParams, accessToken);
             }
 
             #endregion
 
             #region GetTopGames
 
-            public Task<GetTopGamesResponse> GetTopGamesAsync(string before = null, string after = null, int first = 20)
+            public Task<GetTopGamesResponse> GetTopGamesAsync(string before = null, string after = null, int first = 20, string accessToken = null)
             {
                 if (first < 0 || first > 100)
                     throw new BadParameterException("'first' parameter must be between 1 (inclusive) and 100 (inclusive).");
@@ -62,7 +62,7 @@ namespace TwitchLib.Api.Helix
                 if (after != null)
                     getParams.Add(new KeyValuePair<string, string>("after", after));
 
-                return TwitchGetGenericAsync<GetTopGamesResponse>("/games/top", ApiVersion.Helix, getParams);
+                return TwitchGetGenericAsync<GetTopGamesResponse>("/games/top", ApiVersion.Helix, getParams, accessToken);
             }
 
             #endregion

--- a/TwitchLib.Api.Helix/Goals.cs
+++ b/TwitchLib.Api.Helix/Goals.cs
@@ -17,7 +17,7 @@ namespace TwitchLib.Api.Helix
         }
 
         #region GetCreatorGoals
-        public Task<GetCreatorGoalsResponse> GetCreatorGoalsAsync(string broadcasterId, string authToken = null)
+        public Task<GetCreatorGoalsResponse> GetCreatorGoalsAsync(string broadcasterId, string accessToken = null)
         {
             if (string.IsNullOrEmpty(broadcasterId))
                 throw new BadParameterException("broadcasterId cannot be null or empty");
@@ -26,7 +26,7 @@ namespace TwitchLib.Api.Helix
             {
                 new KeyValuePair<string, string>("broadcaster_id", broadcasterId)
             };
-            return TwitchGetGenericAsync<GetCreatorGoalsResponse>("/goals", ApiVersion.Helix, getParams, authToken);
+            return TwitchGetGenericAsync<GetCreatorGoalsResponse>("/goals", ApiVersion.Helix, getParams, accessToken);
         }
         #endregion
 

--- a/TwitchLib.Api.Helix/HypeTrain.cs
+++ b/TwitchLib.Api.Helix/HypeTrain.cs
@@ -15,7 +15,7 @@ namespace TwitchLib.Api.Helix
         }
 
         // Requires Scope > channel:read:hype_train
-        public Task<GetHypeTrainResponse> GetHypeTrainEventsAsync(string broadcasterId, int first = 1, string id = null, string cursor = null)
+        public Task<GetHypeTrainResponse> GetHypeTrainEventsAsync(string broadcasterId, int first = 1, string id = null, string cursor = null, string accessToken = null)
         {
             if (string.IsNullOrEmpty(broadcasterId))
             {
@@ -30,7 +30,7 @@ namespace TwitchLib.Api.Helix
             if (cursor != null)
                 getParams.Add(new KeyValuePair<string, string>("cursor", cursor));
 
-            return TwitchGetGenericAsync<GetHypeTrainResponse>("/hypetrain/events", ApiVersion.Helix, getParams);
+            return TwitchGetGenericAsync<GetHypeTrainResponse>("/hypetrain/events", ApiVersion.Helix, getParams, accessToken);
         }
     }
 }

--- a/TwitchLib.Api.Helix/Moderation.cs
+++ b/TwitchLib.Api.Helix/Moderation.cs
@@ -23,7 +23,7 @@ namespace TwitchLib.Api.Helix
         {
         }
 
-        public Task ManageHeldAutoModMessages(string userId, string msgId, ManageHeldAutoModMessageActionEnum action, string accessToken = null)
+        public Task ManageHeldAutoModMessagesAsync(string userId, string msgId, ManageHeldAutoModMessageActionEnum action, string accessToken = null)
         {
             if(String.IsNullOrEmpty(userId) || String.IsNullOrEmpty(msgId))
                 throw new BadParameterException("userId and msgId cannot be null and must be greater than 0 length");

--- a/TwitchLib.Api.Helix/Polls.cs
+++ b/TwitchLib.Api.Helix/Polls.cs
@@ -19,7 +19,7 @@ namespace TwitchLib.Api.Helix
         {
         }
 
-        public Task<GetPollsResponse> GetPolls(string broadcasterId, List<string> ids = null, string after = null, int first = 20, string accessToken = null)
+        public Task<GetPollsResponse> GetPollsAsync(string broadcasterId, List<string> ids = null, string after = null, int first = 20, string accessToken = null)
         {
             var getParams = new List<KeyValuePair<string, string>>
             { 
@@ -40,12 +40,12 @@ namespace TwitchLib.Api.Helix
             return TwitchGetGenericAsync<GetPollsResponse>("/polls", ApiVersion.Helix, getParams, accessToken);
         }
 
-        public Task<CreatePollResponse> CreatePoll(CreatePollRequest request, string accessToken = null)
+        public Task<CreatePollResponse> CreatePollAsync(CreatePollRequest request, string accessToken = null)
         {
             return TwitchPostGenericAsync<CreatePollResponse>("/polls", ApiVersion.Helix, JsonConvert.SerializeObject(request), accessToken: accessToken);
         }
 
-        public Task<EndPollResponse> EndPoll(string broadcasterId, string id, PollStatusEnum status, string accessToken = null)
+        public Task<EndPollResponse> EndPollAsync(string broadcasterId, string id, PollStatusEnum status, string accessToken = null)
         {
             JObject json = new JObject();
             json["broadcaster_id"] = broadcasterId;

--- a/TwitchLib.Api.Helix/Predictions.cs
+++ b/TwitchLib.Api.Helix/Predictions.cs
@@ -19,7 +19,7 @@ namespace TwitchLib.Api.Helix
         {
         }
 
-        public Task<GetPredictionsResponse> GetPredictions(string broadcasterId, List<string> ids = null, string after = null, int first = 20, string accessToken = null)
+        public Task<GetPredictionsResponse> GetPredictionsAsync(string broadcasterId, List<string> ids = null, string after = null, int first = 20, string accessToken = null)
         {
             var getParams = new List<KeyValuePair<string, string>>
             {
@@ -40,12 +40,12 @@ namespace TwitchLib.Api.Helix
             return TwitchGetGenericAsync<GetPredictionsResponse>("/predictions", ApiVersion.Helix, getParams, accessToken);
         }
 
-        public Task<CreatePredictionResponse> CreatePrediction(CreatePredictionRequest request, string accessToken = null)
+        public Task<CreatePredictionResponse> CreatePredictionAsync(CreatePredictionRequest request, string accessToken = null)
         {
             return TwitchPostGenericAsync<CreatePredictionResponse>("/predictions", ApiVersion.Helix, JsonConvert.SerializeObject(request), accessToken: accessToken);
         }
 
-        public Task<EndPredictionResponse> EndPrediction(string broadcasterId, string id, PredictionStatusEnum status, string winningOutcomeId = null, string accessToken = null)
+        public Task<EndPredictionResponse> EndPredictionAsync(string broadcasterId, string id, PredictionStatusEnum status, string winningOutcomeId = null, string accessToken = null)
         {
             JObject json = new JObject();
             json["broadcaster_id"] = broadcasterId;

--- a/TwitchLib.Api.Helix/Schedule.cs
+++ b/TwitchLib.Api.Helix/Schedule.cs
@@ -19,7 +19,7 @@ namespace TwitchLib.Api.Helix
         { }
 
         public Task<GetChannelStreamScheduleResponse> GetChannelStreamScheduleAsync(string broadcasterId, List<string> segmentIds = null, string startTime = null, string utcOffset = null,
-            int first = 20, string after = null, string authToken = null)
+            int first = 20, string after = null, string accessToken = null)
         {
             var getParams = new List<KeyValuePair<string, string>>
             {
@@ -39,11 +39,11 @@ namespace TwitchLib.Api.Helix
             if (!string.IsNullOrWhiteSpace(after))
                 getParams.Add(new KeyValuePair<string, string>("after", after));
 
-            return TwitchGetGenericAsync<GetChannelStreamScheduleResponse>("/schedule", ApiVersion.Helix, getParams, authToken);
+            return TwitchGetGenericAsync<GetChannelStreamScheduleResponse>("/schedule", ApiVersion.Helix, getParams, accessToken);
         }
 
         public Task UpdateChannelStreamScheduleAsync(string broadcasterId, bool? isVacationEnabled = null, DateTime? vacationStartTime = null, DateTime? vacationEndTime = null,
-            string timezone = null, string authToken = null)
+            string timezone = null, string accessToken = null)
         {
             var getParams = new List<KeyValuePair<string, string>>
             {
@@ -60,21 +60,21 @@ namespace TwitchLib.Api.Helix
             if (!string.IsNullOrWhiteSpace(timezone))
                 getParams.Add(new KeyValuePair<string, string>("timezone", timezone));
 
-            return TwitchPatchAsync("/schedule/settings", ApiVersion.Helix, null, getParams, authToken);
+            return TwitchPatchAsync("/schedule/settings", ApiVersion.Helix, null, getParams, accessToken);
         }
 
-        public Task<CreateChannelStreamSegmentResponse> CreateChannelStreamScheduleSegmentAsync(string broadcasterId, CreateChannelStreamSegmentRequest payload, string authToken = null)
+        public Task<CreateChannelStreamSegmentResponse> CreateChannelStreamScheduleSegmentAsync(string broadcasterId, CreateChannelStreamSegmentRequest payload, string accessToken = null)
         {
             var getParams = new List<KeyValuePair<string, string>>
             {
                 new KeyValuePair<string, string>("broadcaster_id", broadcasterId)
             };
 
-            return TwitchPostGenericAsync<CreateChannelStreamSegmentResponse>("/schedule/segment", ApiVersion.Helix, JsonConvert.SerializeObject(payload), getParams, authToken);
+            return TwitchPostGenericAsync<CreateChannelStreamSegmentResponse>("/schedule/segment", ApiVersion.Helix, JsonConvert.SerializeObject(payload), getParams, accessToken);
         }
 
         public Task<UpdateChannelStreamSegmentResponse> UpdateChannelStreamScheduleSegmentAsync(string broadcasterId, string segmentId, UpdateChannelStreamSegmentRequest payload,
-            string authToken = null)
+            string accessToken = null)
         {
             var getParams = new List<KeyValuePair<string, string>>
             {
@@ -82,10 +82,10 @@ namespace TwitchLib.Api.Helix
                 new KeyValuePair<string, string>("id", segmentId)
             };
 
-            return TwitchPatchGenericAsync<UpdateChannelStreamSegmentResponse>("/schedule/segment", ApiVersion.Helix, JsonConvert.SerializeObject(payload), getParams, authToken);
+            return TwitchPatchGenericAsync<UpdateChannelStreamSegmentResponse>("/schedule/segment", ApiVersion.Helix, JsonConvert.SerializeObject(payload), getParams, accessToken);
         }
 
-        public Task DeleteChannelStreamScheduleSegmentAsync(string broadcasterId, string segmentId, string authToken = null)
+        public Task DeleteChannelStreamScheduleSegmentAsync(string broadcasterId, string segmentId, string accessToken = null)
         {
             var getParams = new List<KeyValuePair<string, string>>
             {
@@ -93,7 +93,7 @@ namespace TwitchLib.Api.Helix
                 new KeyValuePair<string, string>("id", segmentId)
             };
 
-            return TwitchDeleteAsync("/schedule/segment", ApiVersion.Helix, getParams, authToken);
+            return TwitchDeleteAsync("/schedule/segment", ApiVersion.Helix, getParams, accessToken);
         }
     }
 }

--- a/TwitchLib.Api.Helix/Search.cs
+++ b/TwitchLib.Api.Helix/Search.cs
@@ -16,7 +16,7 @@ namespace TwitchLib.Api.Helix
 
         #region SearchCategories
 
-        public Task<SearchCategoriesResponse> SearchCategoriesAsync(string encodedSearchQuery, string after = null, int first = 20)
+        public Task<SearchCategoriesResponse> SearchCategoriesAsync(string encodedSearchQuery, string after = null, int first = 20, string accessToken = null)
         {
             if (first < 0 || first > 100)
                 throw new BadParameterException("'first' parameter must be between 1 (inclusive) and 100 (inclusive).");
@@ -31,14 +31,14 @@ namespace TwitchLib.Api.Helix
 
             getParams.Add(new KeyValuePair<string, string>("first", first.ToString()));
 
-            return TwitchGetGenericAsync<SearchCategoriesResponse>("/search/categories", ApiVersion.Helix, getParams);
+            return TwitchGetGenericAsync<SearchCategoriesResponse>("/search/categories", ApiVersion.Helix, getParams, accessToken);
         }
 
         #endregion
 
         #region SearchChannels
 
-        public Task<SearchChannelsResponse> SearchChannelsAsync(string encodedSearchQuery, bool liveOnly = false, string after = null, int first = 20)
+        public Task<SearchChannelsResponse> SearchChannelsAsync(string encodedSearchQuery, bool liveOnly = false, string after = null, int first = 20, string accessToken = null)
         {
             if (first < 0 || first > 100)
                 throw new BadParameterException("'first' parameter must be between 1 (inclusive) and 100 (inclusive).");
@@ -55,7 +55,7 @@ namespace TwitchLib.Api.Helix
 
             getParams.Add(new KeyValuePair<string, string>("first", first.ToString()));
 
-            return TwitchGetGenericAsync<SearchChannelsResponse>("/search/channels", ApiVersion.Helix, getParams);
+            return TwitchGetGenericAsync<SearchChannelsResponse>("/search/channels", ApiVersion.Helix, getParams, accessToken);
         }
 
         #endregion

--- a/TwitchLib.Api.Helix/Streams.cs
+++ b/TwitchLib.Api.Helix/Streams.cs
@@ -21,7 +21,7 @@ namespace TwitchLib.Api.Helix
         {
         }
 
-        public Task<GetStreamsResponse> GetStreamsAsync(string after = null, List<string> communityIds = null, int first = 20, List<string> gameIds = null, List<string> languages = null, string type = "all", List<string> userIds = null, List<string> userLogins = null)
+        public Task<GetStreamsResponse> GetStreamsAsync(string after = null, List<string> communityIds = null, int first = 20, List<string> gameIds = null, List<string> languages = null, string type = "all", List<string> userIds = null, List<string> userLogins = null, string accessToken = null)
         {
             var getParams = new List<KeyValuePair<string, string>>
                 {
@@ -60,10 +60,10 @@ namespace TwitchLib.Api.Helix
                     getParams.Add(new KeyValuePair<string, string>("user_login", userLogin));
             }
 
-            return TwitchGetGenericAsync<GetStreamsResponse>($"/streams", ApiVersion.Helix, getParams);
+            return TwitchGetGenericAsync<GetStreamsResponse>($"/streams", ApiVersion.Helix, getParams, accessToken);
         }
 
-        public Task<GetStreamsMetadataResponse> GetStreamsMetadataAsync(string after = null, List<string> communityIds = null, int first = 20, List<string> gameIds = null, List<string> languages = null, string type = "all", List<string> userIds = null, List<string> userLogins = null)
+        public Task<GetStreamsMetadataResponse> GetStreamsMetadataAsync(string after = null, List<string> communityIds = null, int first = 20, List<string> gameIds = null, List<string> languages = null, string type = "all", List<string> userIds = null, List<string> userLogins = null, string accessToken = null)
         {
             var getParams = new List<KeyValuePair<string, string>>
                 {
@@ -102,7 +102,7 @@ namespace TwitchLib.Api.Helix
                     getParams.Add(new KeyValuePair<string, string>("user_login", userLogin));
             }
 
-            return TwitchGetGenericAsync<GetStreamsMetadataResponse>("/streams/metadata", ApiVersion.Helix, getParams);
+            return TwitchGetGenericAsync<GetStreamsMetadataResponse>("/streams/metadata", ApiVersion.Helix, getParams, accessToken);
         }
 
         public Task<GetStreamTagsResponse> GetStreamTagsAsync(string broadcasterId, string accessToken = null)

--- a/TwitchLib.Api.Helix/Subscriptions.cs
+++ b/TwitchLib.Api.Helix/Subscriptions.cs
@@ -52,7 +52,7 @@ namespace TwitchLib.Api.Helix
             return TwitchGetGenericAsync<GetUserSubscriptionsResponse>("/subscriptions", ApiVersion.Helix, getParams, accessToken);
         }
 
-        public Task<GetBroadcasterSubscriptionsResponse> GetBroadcasterSubscriptions(string broadcasterId, string cursor = null,
+        public Task<GetBroadcasterSubscriptionsResponse> GetBroadcasterSubscriptionsAsync(string broadcasterId, string cursor = null,
             int first = 20, string accessToken = null)
         {
             if (string.IsNullOrEmpty(broadcasterId))

--- a/TwitchLib.Api.Helix/Users.cs
+++ b/TwitchLib.Api.Helix/Users.cs
@@ -75,7 +75,7 @@ namespace TwitchLib.Api.Helix
             return TwitchGetGenericAsync<GetUsersResponse>("/users", ApiVersion.Helix, getParams, accessToken);
         }
 
-        public Task<GetUsersFollowsResponse> GetUsersFollowsAsync(string after = null, string before = null, int first = 20, string fromId = null, string toId = null)
+        public Task<GetUsersFollowsResponse> GetUsersFollowsAsync(string after = null, string before = null, int first = 20, string fromId = null, string toId = null, string accessToken = null)
         {
             var getParams = new List<KeyValuePair<string, string>>
                 {
@@ -90,7 +90,7 @@ namespace TwitchLib.Api.Helix
             if (toId != null)
                 getParams.Add(new KeyValuePair<string, string>("to_id", toId));
 
-            return TwitchGetGenericAsync<GetUsersFollowsResponse>("/users/follows", ApiVersion.Helix, getParams);
+            return TwitchGetGenericAsync<GetUsersFollowsResponse>("/users/follows", ApiVersion.Helix, getParams, accessToken);
         }
 
         public Task PutUsersAsync(string description, string accessToken = null)
@@ -103,21 +103,21 @@ namespace TwitchLib.Api.Helix
             return TwitchPutAsync("/users", ApiVersion.Helix, null, getParams, accessToken);
         }
 
-        public Task<GetUserExtensionsResponse> GetUserExtensionsAsync(string authToken = null)
+        public Task<GetUserExtensionsResponse> GetUserExtensionsAsync(string accessToken = null)
         {
-            return TwitchGetGenericAsync<GetUserExtensionsResponse>("/users/extensions/list", ApiVersion.Helix, accessToken: authToken);
+            return TwitchGetGenericAsync<GetUserExtensionsResponse>("/users/extensions/list", ApiVersion.Helix, accessToken: accessToken);
         }
 
-        public Task<GetUserActiveExtensionsResponse> GetUserActiveExtensionsAsync(string userid = null, string authToken = null)
+        public Task<GetUserActiveExtensionsResponse> GetUserActiveExtensionsAsync(string userid = null, string accessToken = null)
         {
             var getParams = new List<KeyValuePair<string, string>>();
             if (userid != null)
                 getParams.Add(new KeyValuePair<string, string>("user_id", userid));
 
-            return TwitchGetGenericAsync<GetUserActiveExtensionsResponse>("/users/extensions", ApiVersion.Helix, getParams, accessToken: authToken);
+            return TwitchGetGenericAsync<GetUserActiveExtensionsResponse>("/users/extensions", ApiVersion.Helix, getParams, accessToken: accessToken);
         }
 
-        public Task<GetUserActiveExtensionsResponse> UpdateUserExtensionsAsync(IEnumerable<ExtensionSlot> userExtensionStates, string authToken = null)
+        public Task<GetUserActiveExtensionsResponse> UpdateUserExtensionsAsync(IEnumerable<ExtensionSlot> userExtensionStates, string accessToken = null)
         {
             var panels = new Dictionary<string, UserExtensionState>();
             var overlays = new Dictionary<string, UserExtensionState>();
@@ -154,7 +154,7 @@ namespace TwitchLib.Api.Helix
             json.Add(new JProperty("data", JObject.FromObject(p)));
             var payload = json.ToString();
 
-            return TwitchPutGenericAsync<GetUserActiveExtensionsResponse>("/users/extensions", ApiVersion.Helix, payload, accessToken: authToken);
+            return TwitchPutGenericAsync<GetUserActiveExtensionsResponse>("/users/extensions", ApiVersion.Helix, payload, accessToken: accessToken);
         }
     }
 }

--- a/TwitchLib.Api.Helix/Users.cs
+++ b/TwitchLib.Api.Helix/Users.cs
@@ -156,52 +156,5 @@ namespace TwitchLib.Api.Helix
 
             return TwitchPutGenericAsync<GetUserActiveExtensionsResponse>("/users/extensions", ApiVersion.Helix, payload, accessToken: authToken);
         }
-
-        public Task CreateUserFollows(string from_id, string to_id, bool? allow_notifications = null, string authToken = null)
-        {
-            if (string.IsNullOrWhiteSpace(from_id))
-            {
-                throw new BadParameterException("from_id must be set");
-            }
-
-            if (string.IsNullOrWhiteSpace(to_id))
-            {
-                throw new BadParameterException("to_id must be set");
-            }
-
-            var json = new JObject();
-
-            json.Add(new JProperty("from_id", from_id));
-            json.Add(new JProperty("to_id", to_id));
-
-            if (allow_notifications.HasValue)
-            {
-                json.Add(new JProperty("allow_notifications", allow_notifications.Value));
-            }
-
-            var payload = json.ToString();
-
-            return TwitchPostAsync("/users/follows", ApiVersion.Helix, payload, accessToken: authToken);
-        }
-
-        public Task DeleteUserFollows(string from_id, string to_id, string authToken = null)
-        {
-            if (string.IsNullOrWhiteSpace(from_id))
-            {
-                throw new BadParameterException("from_id must be set");
-            }
-
-            if (string.IsNullOrWhiteSpace(to_id))
-            {
-                throw new BadParameterException("to_id must be set");
-            }
-
-            var getParams = new List<KeyValuePair<string, string>>();
-
-            getParams.Add(new KeyValuePair<string, string>("from_id", from_id));
-            getParams.Add(new KeyValuePair<string, string>("to_id", to_id));
-
-            return TwitchDeleteAsync("/users/follows", ApiVersion.Helix, getParams, accessToken: authToken);
-        }
     }
 }

--- a/TwitchLib.Api.Helix/Users.cs
+++ b/TwitchLib.Api.Helix/Users.cs
@@ -155,5 +155,6 @@ namespace TwitchLib.Api.Helix
             var payload = json.ToString();
 
             return TwitchPutGenericAsync<GetUserActiveExtensionsResponse>("/users/extensions", ApiVersion.Helix, payload, accessToken: accessToken);
+        }
     }
 }

--- a/TwitchLib.Api.Helix/Videos.cs
+++ b/TwitchLib.Api.Helix/Videos.cs
@@ -28,7 +28,7 @@ namespace TwitchLib.Api.Helix
             return TwitchDeleteGenericAsync<DeleteVideosResponse>("/videos", ApiVersion.Helix, getParams, accessToken);
         }
 
-        public Task<GetVideosResponse> GetVideoAsync(List<string> videoIds = null, string userId = null, string gameId = null, string after = null, string before = null, int first = 20, string language = null, Period period = Period.All, VideoSort sort = VideoSort.Time, VideoType type = VideoType.All)
+        public Task<GetVideosResponse> GetVideosAsync(List<string> videoIds = null, string userId = null, string gameId = null, string after = null, string before = null, int first = 20, string language = null, Period period = Period.All, VideoSort sort = VideoSort.Time, VideoType type = VideoType.All, string accessToken = null)
         {
             if ((videoIds == null || videoIds.Count == 0) && userId == null && gameId == null)
                 throw new BadParameterException("VideoIds, userId, and gameId cannot all be null/empty.");
@@ -108,7 +108,7 @@ namespace TwitchLib.Api.Helix
                 }
             }
 
-            return TwitchGetGenericAsync<GetVideosResponse>("/videos", ApiVersion.Helix, getParams);
+            return TwitchGetGenericAsync<GetVideosResponse>("/videos", ApiVersion.Helix, getParams, accessToken);
         }
     }
 }

--- a/TwitchLib.Api/Services/Core/LiveStreamMonitor/CoreMonitor.cs
+++ b/TwitchLib.Api/Services/Core/LiveStreamMonitor/CoreMonitor.cs
@@ -11,8 +11,8 @@ namespace TwitchLib.Api.Services.Core.LiveStreamMonitor
     {
         protected readonly ITwitchAPI _api;
 
-        public abstract Task<GetStreamsResponse> GetStreamsAsync(List<string> channels);
-        public abstract Task<Func<Stream, bool>> CompareStream(string channel);
+        public abstract Task<GetStreamsResponse> GetStreamsAsync(List<string> channels, string accessToken = null);
+        public abstract Task<Func<Stream, bool>> CompareStream(string channel, string accessToken = null);
 
         protected CoreMonitor(ITwitchAPI api)
         {

--- a/TwitchLib.Api/Services/Core/LiveStreamMonitor/IdBasedMonitor.cs
+++ b/TwitchLib.Api/Services/Core/LiveStreamMonitor/IdBasedMonitor.cs
@@ -11,14 +11,14 @@ namespace TwitchLib.Api.Services.Core.LiveStreamMonitor
     {
         public IdBasedMonitor(ITwitchAPI api) : base(api) { }
 
-        public override Task<Func<Stream, bool>> CompareStream(string channel)
+        public override Task<Func<Stream, bool>> CompareStream(string channel, string accessToken = null)
         {
             return Task.FromResult(new Func<Stream, bool>(stream => stream.UserId == channel));
         }
 
-        public override Task<GetStreamsResponse> GetStreamsAsync(List<string> channels)
+        public override Task<GetStreamsResponse> GetStreamsAsync(List<string> channels, string accessToken = null)
         {
-            return _api.Helix.Streams.GetStreamsAsync(first: channels.Count, userIds: channels);
+            return _api.Helix.Streams.GetStreamsAsync(first: channels.Count, userIds: channels, accessToken: accessToken);
         }
     }
 }

--- a/TwitchLib.Api/Services/Core/LiveStreamMonitor/NameBasedMonitor.cs
+++ b/TwitchLib.Api/Services/Core/LiveStreamMonitor/NameBasedMonitor.cs
@@ -14,20 +14,20 @@ namespace TwitchLib.Api.Services.Core.LiveStreamMonitor
 
         public NameBasedMonitor(ITwitchAPI api) : base(api) { }
 
-        public override async Task<Func<Stream, bool>> CompareStream(string channel)
+        public override async Task<Func<Stream, bool>> CompareStream(string channel, string accessToken = null)
         {
             if (!_channelToId.TryGetValue(channel, out var channelId))
             {
-                channelId = (await _api.Helix.Users.GetUsersAsync(logins: new List<string> { channel })).Users.FirstOrDefault()?.Id;
+                channelId = (await _api.Helix.Users.GetUsersAsync(logins: new List<string> { channel }, accessToken: accessToken)).Users.FirstOrDefault()?.Id;
                 _channelToId[channel] = channelId ?? throw new InvalidOperationException($"No channel with the name \"{channel}\" could be found.");
             }
 
             return stream => stream.UserId == channelId;
         }
 
-        public override Task<GetStreamsResponse> GetStreamsAsync(List<string> channels)
+        public override Task<GetStreamsResponse> GetStreamsAsync(List<string> channels, string accessToken = null)
         {
-            return _api.Helix.Streams.GetStreamsAsync(first: channels.Count, userLogins: channels);
+            return _api.Helix.Streams.GetStreamsAsync(first: channels.Count, userLogins: channels, accessToken: accessToken);
         }
 
         public void ClearCache()


### PR DESCRIPTION
```
This tool source code analysis on TwitchLib.Api and compares against TwitchDev documentation
Getting library API methods...
Looking for missing and incorrecly named accessToken params...
Last param not accessToken (was: authToken): Analytics.GetGameAnalyticsAsync
Last param not accessToken (was: authToken): Analytics.GetExtensionAnalyticsAsync
Last param not accessToken (was: authToken): Chat.GetChannelChatBadgesAsync
Last param not accessToken (was: authToken): Chat.GetGlobalChatBadgesAsync
Last param not accessToken (was: authToken): Chat.GetChannelEmotesAsync
Last param not accessToken (was: authToken): Chat.GetEmoteSetsAsync
Last param not accessToken (was: authToken): Chat.GetGlobalEmotesAsync
Last param not accessToken (was: first): Clips.GetClipsAsync
Last param not accessToken (was: authToken): Clips.CreateClipAsync
Last param not accessToken (was: applicationAccessToken): Extensions.GetExtensionTransactionsAsync
Last param not accessToken (was: gameNames): Games.GetGamesAsync
Last param not accessToken (was: first): Games.GetTopGamesAsync
Last param not accessToken (was: authToken): Goals.GetCreatorGoalsAsync
Last param not accessToken (was: cursor): HypeTrain.GetHypeTrainEventsAsync
Last param not accessToken (was: authToken): Schedule.GetChannelStreamScheduleAsync
Last param not accessToken (was: authToken): Schedule.UpdateChannelStreamScheduleAsync
Last param not accessToken (was: authToken): Schedule.CreateChannelStreamScheduleSegmentAsync
Last param not accessToken (was: authToken): Schedule.UpdateChannelStreamScheduleSegmentAsync
Last param not accessToken (was: authToken): Schedule.DeleteChannelStreamScheduleSegmentAsync
Last param not accessToken (was: first): Search.SearchCategoriesAsync
Last param not accessToken (was: first): Search.SearchChannelsAsync
Last param not accessToken (was: userLogins): Streams.GetStreamsAsync
Last param not accessToken (was: userLogins): Streams.GetStreamsMetadataAsync
Last param not accessToken (was: type): Videos.GetVideoAsync
Last param not accessToken (was: toId): Users.GetUsersFollowsAsync
Last param not accessToken (was: authToken): Users.GetUserExtensionsAsync
Last param not accessToken (was: authToken): Users.GetUserActiveExtensionsAsync
Last param not accessToken (was: authToken): Users.UpdateUserExtensionsAsync
```