### PR TITLE
add support for new Soundtrack apis

### DIFF
--- a/TwitchLib.Api.Helix.Models/Soundtrack/Album.cs
+++ b/TwitchLib.Api.Helix.Models/Soundtrack/Album.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace TwitchLib.Api.Helix.Models.Soundtrack
+{
+    public class Album
+    {
+        [JsonProperty(PropertyName = "id")]
+        public string Id { get; protected set; }
+        [JsonProperty(PropertyName = "name")]
+        public string Name { get; protected set; }
+        [JsonProperty(PropertyName = "image_url")]
+        public string ImageUrl { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Soundtrack/Artist.cs
+++ b/TwitchLib.Api.Helix.Models/Soundtrack/Artist.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace TwitchLib.Api.Helix.Models.Soundtrack
+{
+    public class Artist
+    {
+        [JsonProperty(PropertyName = "id")]
+        public string Id { get; protected set; }
+        [JsonProperty(PropertyName = "name")]
+        public string Name { get; protected set; }
+        [JsonProperty(PropertyName = "creator_channel_id")]
+        public string CreatorChannelId { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Soundtrack/GetCurrentTrack/CurrentTrack.cs
+++ b/TwitchLib.Api.Helix.Models/Soundtrack/GetCurrentTrack/CurrentTrack.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace TwitchLib.Api.Helix.Models.Soundtrack.GetCurrentTrack
+{
+    public class CurrentTrack
+    {
+        [JsonProperty(PropertyName = "track")]
+        public Track Track { get; protected set; }
+        [JsonProperty(PropertyName = "source")]
+        public Source Source { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Soundtrack/GetCurrentTrack/GetCurrentTrackResponse.cs
+++ b/TwitchLib.Api.Helix.Models/Soundtrack/GetCurrentTrack/GetCurrentTrackResponse.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace TwitchLib.Api.Helix.Models.Soundtrack.GetCurrentTrack
+{
+    public class GetCurrentTrackResponse
+    {
+        [JsonProperty(PropertyName = "data")]
+        public CurrentTrack[] Data { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Soundtrack/GetPlaylist/GetPlaylistResponse.cs
+++ b/TwitchLib.Api.Helix.Models/Soundtrack/GetPlaylist/GetPlaylistResponse.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace TwitchLib.Api.Helix.Models.Soundtrack.GetPlaylist
+{
+    public class GetPlaylistResponse
+    {
+        [JsonProperty(PropertyName = "data")]
+        public PlaylistTrack[] Data { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Soundtrack/GetPlaylist/PlaylistTrack.cs
+++ b/TwitchLib.Api.Helix.Models/Soundtrack/GetPlaylist/PlaylistTrack.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace TwitchLib.Api.Helix.Models.Soundtrack.GetPlaylist
+{
+    public class PlaylistTrack
+    {
+        [JsonProperty(PropertyName = "title")]
+        public string Title { get; protected set; }
+        [JsonProperty(PropertyName = "id")]
+        public string Id { get; protected set; }
+        [JsonProperty(PropertyName = "image_url")]
+        public string ImageUrl { get; protected set; }
+        [JsonProperty(PropertyName = "description")]
+        public string Description { get; protected set; }
+        [JsonProperty(PropertyName = "catalog_tracks")]
+        public Track[] CatalogTracks { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Soundtrack/GetPlaylists/GetPlaylistsResponse.cs
+++ b/TwitchLib.Api.Helix.Models/Soundtrack/GetPlaylists/GetPlaylistsResponse.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace TwitchLib.Api.Helix.Models.Soundtrack.GetPlaylists
+{
+    public class GetPlaylistsResponse
+    {
+        [JsonProperty(PropertyName = "data")]
+        public PlaylistMetadata[] Data { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Soundtrack/GetPlaylists/PlaylistMetadata.cs
+++ b/TwitchLib.Api.Helix.Models/Soundtrack/GetPlaylists/PlaylistMetadata.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace TwitchLib.Api.Helix.Models.Soundtrack.GetPlaylists
+{
+    public class PlaylistMetadata
+    {
+        [JsonProperty(PropertyName = "title")]
+        public string Title { get; protected set; }
+        [JsonProperty(PropertyName = "id")]
+        public string Id { get; protected set; }
+        [JsonProperty(PropertyName = "image_url")]
+        public string ImageUrl { get; protected set; }
+        [JsonProperty(PropertyName = "description")]
+        public string Description { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Soundtrack/Source.cs
+++ b/TwitchLib.Api.Helix.Models/Soundtrack/Source.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace TwitchLib.Api.Helix.Models.Soundtrack
+{
+    public class Source
+    {
+        [JsonProperty(PropertyName = "id")]
+        public string Id { get; protected set; }
+        [JsonProperty(PropertyName = "content_type")]
+        public string ContentType { get; protected set; }
+        [JsonProperty(PropertyName = "title")]
+        public string Title { get; protected set; }
+        [JsonProperty(PropertyName = "image_url")]
+        public string ImageUrl { get; protected set; }
+        [JsonProperty(PropertyName = "soundtrack_url")]
+        public string SoundtrackUrl { get; protected set; }
+        [JsonProperty(PropertyName = "spotify_url")]
+        public string SpotifyUrl { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Soundtrack/Track.cs
+++ b/TwitchLib.Api.Helix.Models/Soundtrack/Track.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace TwitchLib.Api.Helix.Models.Soundtrack
+{
+    public class Track
+    {
+        [JsonProperty(PropertyName = "artists")]
+        public Artist[] Artists { get; protected set; }
+        [JsonProperty(PropertyName = "id")]
+        public string Id { get; protected set; }
+        [JsonProperty(PropertyName = "duration")]
+        public int Duration { get; protected set; }
+        [JsonProperty(PropertyName = "title")]
+        public string Title { get; protected set; }
+        [JsonProperty(PropertyName = "album")]
+        public Album Album { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/TwitchLib.Api.Helix.Models.csproj
+++ b/TwitchLib.Api.Helix.Models/TwitchLib.Api.Helix.Models.csproj
@@ -32,7 +32,19 @@
     <ProjectReference Include="..\TwitchLib.Api.Core.Interfaces\TwitchLib.Api.Core.Interfaces.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <None Remove="Soundtrack\" />
+    <None Remove="Soundtrack\GetCurrentTrack\" />
+    <None Remove="Soundtrack\GetPlaylist\" />
+    <None Remove="Soundtrack\GetPlaylists\" />
+  </ItemGroup>
+  <ItemGroup>
     <None Include="twitchlib.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Soundtrack\" />
+    <Folder Include="Soundtrack\GetCurrentTrack\" />
+    <Folder Include="Soundtrack\GetPlaylist\" />
+    <Folder Include="Soundtrack\GetPlaylists\" />
+  </ItemGroup>
 </Project>

--- a/TwitchLib.Api.Helix/Helix.cs
+++ b/TwitchLib.Api.Helix/Helix.cs
@@ -28,8 +28,9 @@ namespace TwitchLib.Api.Helix
         public Predictions Predictions { get; }
         public Schedule Schedule { get; }
         public Search Search { get; }
-        public Subscriptions Subscriptions { get; }
+        public Soundtrack Soundtrack { get; }
         public Streams Streams { get; }
+        public Subscriptions Subscriptions { get; }
         public Tags Tags { get; }
         public Teams Teams { get; }
         public Videos Videos { get; }
@@ -67,6 +68,7 @@ namespace TwitchLib.Api.Helix
             Predictions = new Predictions(Settings, rateLimiter, http);
             Schedule = new Schedule(Settings, rateLimiter, http);
             Search = new Search(Settings, rateLimiter, http);
+            Soundtrack = new Soundtrack(Settings, rateLimiter, http);
             Streams = new Streams(Settings, rateLimiter, http);
             Subscriptions = new Subscriptions(Settings, rateLimiter, http);
             Tags = new Tags(Settings, rateLimiter, http);

--- a/TwitchLib.Api.Helix/Soundtrack.cs
+++ b/TwitchLib.Api.Helix/Soundtrack.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using TwitchLib.Api.Core;
+using TwitchLib.Api.Core.Enums;
+using TwitchLib.Api.Core.Exceptions;
+using TwitchLib.Api.Core.Interfaces;
+using TwitchLib.Api.Helix.Models.Soundtrack.GetCurrentTrack;
+using TwitchLib.Api.Helix.Models.Soundtrack.GetPlaylist;
+using TwitchLib.Api.Helix.Models.Soundtrack.GetPlaylists;
+
+namespace TwitchLib.Api.Helix
+{
+    public class Soundtrack : ApiBase
+    {
+        public Soundtrack(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http)
+        {
+        }
+
+        public Task<GetCurrentTrackResponse> GetCurrentTrackAsync(string broadcasterId, string accessToken = null)
+        {
+            if (string.IsNullOrEmpty(broadcasterId))
+                throw new BadParameterException("'broadcasterId' must be set");
+
+            var getParams = new List<KeyValuePair<string, string>>
+            {
+                    new KeyValuePair<string, string>("broadcaster_id", broadcasterId)
+            };
+
+            return TwitchGetGenericAsync<GetCurrentTrackResponse>("/soundtrack/current_track", ApiVersion.Helix, getParams, accessToken);
+        }
+
+        public Task<GetPlaylistResponse> GetPlaylistAsync(string id, string accessToken = null)
+        {
+            if (string.IsNullOrEmpty(id))
+                throw new BadParameterException("'id' must be set");
+
+            var getParams = new List<KeyValuePair<string, string>>
+            {
+                    new KeyValuePair<string, string>("id", id)
+            };
+
+            return TwitchGetGenericAsync<GetPlaylistResponse>("/soundtrack/playlist", ApiVersion.Helix, getParams, accessToken);
+        }
+
+        public Task<GetPlaylistsResponse> GetPlaylistsAsync(string accessToken = null)
+        {
+            return TwitchGetGenericAsync<GetPlaylistsResponse>("/soundtrack/playlists", ApiVersion.Helix, accessToken: accessToken);
+        }
+    }
+}


### PR DESCRIPTION
Support for Twitch's new Soundtrack API endpoints:
- `GetCurrentTrackAsync(string broadcasterId)`
- `GetPlaylistAsync(string id)`
- `GetPlaylistsAsync()`

All tested and working.