### PR TITLE
Stream marker ID is a guid and not an int as reported in the API docs..

### DIFF
--- a/TwitchLib.Api.Helix.Models/Streams/GetStreamMarkers/Marker.cs
+++ b/TwitchLib.Api.Helix.Models/Streams/GetStreamMarkers/Marker.cs
@@ -8,7 +8,7 @@ namespace TwitchLib.Api.Helix.Models.Streams.GetStreamMarkers
     public class Marker
     {
         [JsonProperty(PropertyName = "id")]
-        public int Id { get; protected set; }
+        public string Id { get; protected set; }
         [JsonProperty(PropertyName = "created_at")]
         public DateTime CreatedAt { get; protected set; }
         [JsonProperty(PropertyName = "description")]


### PR DESCRIPTION
This issue is causing this request to result in an exception, however it is successful on the twitch side.

Example JSON response from API:

`{
  "data": [
    {
      "id": "7a6fec6c050e04781d7f324b5a8b81f0",
      "created_at": "2022-01-01T00:13:58.887310204Z",
      "position_seconds": 6326,
      "description": "Created from bot"
    }
  ]
}`