### PR TITLE
Fixes for Auth related calls running into credential exceptions

### DIFF
--- a/TwitchLib.Api.Core.Enums/ApiVersion.cs
+++ b/TwitchLib.Api.Core.Enums/ApiVersion.cs
@@ -2,6 +2,7 @@
 {
     public enum ApiVersion
     {
+        Auth = 1,
         V5 = 5,
         Helix = 6,
         Void = 0

--- a/TwitchLib.Api.Core/ApiBase.cs
+++ b/TwitchLib.Api.Core/ApiBase.cs
@@ -21,7 +21,7 @@ namespace TwitchLib.Api.Core
 
         internal const string BaseV5 = "https://api.twitch.tv/kraken";
         internal const string BaseHelix = "https://api.twitch.tv/helix";
-        internal const string BaseOauthToken = "https://id.twitch.tv/oauth2/token";
+        internal const string BaseAuth = "https://id.twitch.tv/oauth2";
 
         private DateTime? _serverBasedAccessTokenExpiry;
         private string _serverBasedAccessToken;
@@ -58,7 +58,7 @@ namespace TwitchLib.Api.Core
 
         internal async Task<string> GenerateServerBasedAccessToken()
         {
-            var result = await _http.GeneralRequestAsync($"{BaseOauthToken}?client_id={Settings.ClientId}&client_secret={Settings.Secret}&grant_type=client_credentials", "POST", null, ApiVersion.Helix, Settings.ClientId, null).ConfigureAwait(false);
+            var result = await _http.GeneralRequestAsync($"{BaseAuth}/token?client_id={Settings.ClientId}&client_secret={Settings.Secret}&grant_type=client_credentials", "POST", null, ApiVersion.Helix, Settings.ClientId, null).ConfigureAwait(false);
             if (result.Key == 200)
             {
                 var user = JsonConvert.DeserializeObject<dynamic>(result.Value);
@@ -332,6 +332,9 @@ namespace TwitchLib.Api.Core
                         url = $"{BaseV5}{resource}";
                         break;
                     case ApiVersion.Helix:
+                        url = $"{BaseHelix}{resource}";
+                        break;
+                    case ApiVersion.Auth:
                         url = $"{BaseHelix}{resource}";
                         break;
                 }

--- a/TwitchLib.Api.Core/ApiBase.cs
+++ b/TwitchLib.Api.Core/ApiBase.cs
@@ -335,7 +335,7 @@ namespace TwitchLib.Api.Core
                         url = $"{BaseHelix}{resource}";
                         break;
                     case ApiVersion.Auth:
-                        url = $"{BaseHelix}{resource}";
+                        url = $"{BaseAuth}{resource}";
                         break;
                 }
             }

--- a/TwitchLib.Api.Core/HttpCallHandlers/TwitchHttpClient.cs
+++ b/TwitchLib.Api.Core/HttpCallHandlers/TwitchHttpClient.cs
@@ -37,7 +37,8 @@ namespace TwitchLib.Api.Core.HttpCallHandlers
                 HandleWebException(response);
         }
 
-        public async Task<KeyValuePair<int, string>> GeneralRequestAsync(string url, string method, string payload = null, ApiVersion api = ApiVersion.V5, string clientId = null, string accessToken = null)
+        public async Task<KeyValuePair<int, string>> GeneralRequestAsync(string url, string method,
+            string payload = null, ApiVersion api = ApiVersion.V5, string clientId = null, string accessToken = null)
         {
             var request = new HttpRequestMessage
             {
@@ -45,16 +46,17 @@ namespace TwitchLib.Api.Core.HttpCallHandlers
                 Method = new HttpMethod(method)
             };
 
-            if (string.IsNullOrEmpty(clientId) && string.IsNullOrEmpty(accessToken))
-                throw new InvalidCredentialException("A Client-Id or OAuth token is required to use the Twitch API. If you previously set them in InitializeAsync, please be sure to await the method.");
-
-            if (!string.IsNullOrEmpty(clientId))
+            if (api == ApiVersion.V5 || api == ApiVersion.Helix)
             {
-                request.Headers.Add("Client-ID", clientId);
+                if (string.IsNullOrWhiteSpace(clientId) && string.IsNullOrWhiteSpace(accessToken))
+                    throw new InvalidCredentialException("A Client-Id or OAuth token is required to use the Twitch API. If you previously set them in InitializeAsync, please be sure to await the method.");
+
+                if (!string.IsNullOrWhiteSpace(clientId))
+                    request.Headers.Add("Client-ID", clientId);
             }
 
             var authPrefix = "OAuth";
-            if (api == ApiVersion.Helix)
+            if (api == ApiVersion.Helix || api == ApiVersion.Auth)
             {
                 request.Headers.Add(HttpRequestHeader.Accept.ToString(), "application/json");
                 authPrefix = "Bearer";
@@ -63,12 +65,11 @@ namespace TwitchLib.Api.Core.HttpCallHandlers
             {
                 request.Headers.Add(HttpRequestHeader.Accept.ToString(), $"application/vnd.twitchtv.v{(int)api}+json");
             }
-            if (!string.IsNullOrEmpty(accessToken))
+            if (!string.IsNullOrWhiteSpace(accessToken))
                 request.Headers.Add(HttpRequestHeader.Authorization.ToString(), $"{authPrefix} {Common.Helpers.FormatOAuth(accessToken)}");
 
             if (payload != null)
                 request.Content = new StringContent(payload, Encoding.UTF8, "application/json");
-
 
             var response = await _http.SendAsync(request).ConfigureAwait(false);
             if (response.IsSuccessStatusCode)

--- a/TwitchLib.Api/Auth/Auth.cs
+++ b/TwitchLib.Api/Auth/Auth.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using TwitchLib.Api.Core;
 using TwitchLib.Api.Core.Enums;
@@ -43,7 +41,7 @@ namespace TwitchLib.Api.Auth
                     new KeyValuePair<string, string>("client_secret", clientSecret)
                 };
 
-            return TwitchPostGenericAsync<RefreshResponse>("/oauth2/token", ApiVersion.Void, null, getParams, customBase: "https://id.twitch.tv");
+            return TwitchPostGenericAsync<RefreshResponse>("/token", ApiVersion.Auth, null, getParams, null, internalClientId);
         }
 
         /// <summary>
@@ -114,7 +112,7 @@ namespace TwitchLib.Api.Auth
                 new KeyValuePair<string, string>("redirect_uri", redirectUri)
             };
 
-            return TwitchPostGenericAsync<AuthCodeResponse>("/oauth2/token", ApiVersion.V5, null, getParams, customBase: "https://id.twitch.tv");
+            return TwitchPostGenericAsync<AuthCodeResponse>("/token", ApiVersion.Auth, null, getParams, null, internalClientId);
         }
 
         /// <summary>
@@ -126,7 +124,7 @@ namespace TwitchLib.Api.Auth
         {
             try
             {
-                return await TwitchGetGenericAsync<ValidateAccessTokenResponse>("/oauth2/validate", ApiVersion.Void, accessToken: accessToken, customBase: "https://id.twitch.tv");
+                return await TwitchGetGenericAsync<ValidateAccessTokenResponse>("/validate", ApiVersion.Auth, accessToken: accessToken);
             } catch(BadScopeException)
             {
                 // BadScopeException == 401, which is surfaced when token is invalid


### PR DESCRIPTION
- Added a new Auth ApiVersion
- ClientId header only gets injected for V5 and Helix ApiVersion
- changed auth api calls to use the new ApiVersion