### PR TITLE
add from_login to Helix GetUserFollows' Follow model

### DIFF
--- a/TwitchLib.Api.Helix.Models/Users/GetUserFollows/Follow.cs
+++ b/TwitchLib.Api.Helix.Models/Users/GetUserFollows/Follow.cs
@@ -7,6 +7,8 @@ namespace TwitchLib.Api.Helix.Models.Users.GetUserFollows
     {
         [JsonProperty(PropertyName = "from_id")]
         public string FromUserId { get; protected set; }
+        [JsonProperty(PropertyName = "from_login")]
+        public string FromLogin { get; protected set; }
         [JsonProperty(PropertyName = "from_name")]
         public string FromUserName { get; protected set; }
         [JsonProperty(PropertyName = "to_id")]

--- a/TwitchLib.Api.Helix.Models/Users/GetUserFollows/Follow.cs
+++ b/TwitchLib.Api.Helix.Models/Users/GetUserFollows/Follow.cs
@@ -13,6 +13,8 @@ namespace TwitchLib.Api.Helix.Models.Users.GetUserFollows
         public string FromUserName { get; protected set; }
         [JsonProperty(PropertyName = "to_id")]
         public string ToUserId { get; protected set; }
+        [JsonProperty(PropertyName = "to_login")]
+        public string ToLogin { get; protected set; }
         [JsonProperty(PropertyName = "to_name")]
         public string ToUserName { get; protected set; }
         [JsonProperty(PropertyName = "followed_at")]


### PR DESCRIPTION
Originally mentioned in https://github.com/TwitchLib/TwitchLib/issues/1075
Relevant documentation: https://dev.twitch.tv/docs/api/reference#get-users-follows

Adds `from_login` field to Follow model.