### PR TITLE
Convert public method collection parameters to interfaces

### DIFF
--- a/TwitchLib.Api.Core.Interfaces/IApiSettings.cs
+++ b/TwitchLib.Api.Core.Interfaces/IApiSettings.cs
@@ -11,7 +11,7 @@ namespace TwitchLib.Api.Core.Interfaces
         string ClientId { get; set; }
         bool SkipDynamicScopeValidation { get; set; }
         bool SkipAutoServerTokenGeneration { get; set; }
-        List<AuthScopes> Scopes { get; set; }
+        IList<AuthScopes> Scopes { get; set; }
 
         event PropertyChangedEventHandler PropertyChanged;
     }

--- a/TwitchLib.Api.Core/ApiSettings.cs
+++ b/TwitchLib.Api.Core/ApiSettings.cs
@@ -13,7 +13,7 @@ namespace TwitchLib.Api.Core
         private string _accessToken;
         private bool _skipDynamicScopeValidation;
         private bool _skipAutoServerTokenGeneration;
-        private List<AuthScopes> _scopes;
+        private IList<AuthScopes> _scopes;
         public string ClientId
         {
             get => _clientId;
@@ -74,7 +74,7 @@ namespace TwitchLib.Api.Core
                 }
             }
         }
-        public List<AuthScopes> Scopes
+        public IList<AuthScopes> Scopes
         {
             get => _scopes;
             set

--- a/TwitchLib.Api.Helix/ChannelPoints.cs
+++ b/TwitchLib.Api.Helix/ChannelPoints.cs
@@ -45,7 +45,7 @@ namespace TwitchLib.Api.Helix
         #endregion
 
         #region GetCustomReward
-        public Task<GetCustomRewardsResponse> GetCustomRewardAsync(string broadcasterId, List<string> rewardIds = null, bool onlyManageableRewards = false, string accessToken = null)
+        public Task<GetCustomRewardsResponse> GetCustomRewardAsync(string broadcasterId, ICollection<string> rewardIds = null, bool onlyManageableRewards = false, string accessToken = null)
         {
             var getParams = new List<KeyValuePair<string, string>>
                     {

--- a/TwitchLib.Api.Helix/Clips.cs
+++ b/TwitchLib.Api.Helix/Clips.cs
@@ -19,7 +19,7 @@ namespace TwitchLib.Api.Helix
 
         #region GetClips
 
-        public Task<GetClipsResponse> GetClipsAsync(List<string> clipIds = null, string gameId = null, string broadcasterId = null, string before = null, string after = null, DateTime? startedAt = null, DateTime? endedAt = null, int first = 20, string accessToken = null)
+        public Task<GetClipsResponse> GetClipsAsync(IEnumerable<string> clipIds = null, string gameId = null, string broadcasterId = null, string before = null, string after = null, DateTime? startedAt = null, DateTime? endedAt = null, int first = 20, string accessToken = null)
         {
             if (first < 0 || first > 100)
                 throw new BadParameterException("'first' must between 0 (inclusive) and 100 (inclusive).");

--- a/TwitchLib.Api.Helix/Entitlements.cs
+++ b/TwitchLib.Api.Helix/Entitlements.cs
@@ -19,7 +19,7 @@ namespace TwitchLib.Api.Helix
         }
 
         #region GetCodeStatus
-        public Task<GetCodeStatusResponse> GetCodeStatusAsync(List<string> codes, string userId, string accessToken = null)
+        public Task<GetCodeStatusResponse> GetCodeStatusAsync(ICollection<string> codes, string userId, string accessToken = null)
         {
             if (codes == null || codes.Count == 0 || codes.Count > 20)
                 throw new BadParameterException("codes cannot be null and must ahve between 1 and 20 items");
@@ -83,7 +83,7 @@ namespace TwitchLib.Api.Helix
         #endregion
 
         #region RedeemCode
-        public Task<RedeemCodeResponse> RedeemCodeAsync(List<string> codes, string accessToken = null)
+        public Task<RedeemCodeResponse> RedeemCodeAsync(ICollection<string> codes, string accessToken = null)
         {
             if (codes == null || codes.Count == 0 || codes.Count > 20)
                 throw new BadParameterException("codes cannot be null and must ahve between 1 and 20 items");

--- a/TwitchLib.Api.Helix/EventSub.cs
+++ b/TwitchLib.Api.Helix/EventSub.cs
@@ -15,7 +15,7 @@ namespace TwitchLib.Api.Helix
         {
         }
 
-        public Task<CreateEventSubSubscriptionResponse> CreateEventSubSubscriptionAsync(string type, string version, Dictionary<string, string> condition, string method, string callback,
+        public Task<CreateEventSubSubscriptionResponse> CreateEventSubSubscriptionAsync(string type, string version, IDictionary<string, string> condition, string method, string callback,
             string secret, string clientId = null, string accessToken = null)
         {
             if (string.IsNullOrEmpty(type))

--- a/TwitchLib.Api.Helix/Extensions.cs
+++ b/TwitchLib.Api.Helix/Extensions.cs
@@ -19,7 +19,7 @@ namespace TwitchLib.Api.Helix
 
         #region GetExtensionTransactions
 
-        public Task<GetExtensionTransactionsResponse> GetExtensionTransactionsAsync(string extensionId, List<string> ids = null, string after = null, int first = 20, string applicationAccessToken = null)
+        public Task<GetExtensionTransactionsResponse> GetExtensionTransactionsAsync(string extensionId, ICollection<string> ids = null, string after = null, int first = 20, string applicationAccessToken = null)
         {
             if(extensionId == null)
                 throw new BadParameterException("extensionId cannot be null");

--- a/TwitchLib.Api.Helix/Games.cs
+++ b/TwitchLib.Api.Helix/Games.cs
@@ -16,7 +16,7 @@ namespace TwitchLib.Api.Helix
 
             #region GetGames
 
-            public Task<GetGamesResponse> GetGamesAsync(List<string> gameIds = null, List<string> gameNames = null, string accessToken = null)
+            public Task<GetGamesResponse> GetGamesAsync(ICollection<string> gameIds = null, ICollection<string> gameNames = null, string accessToken = null)
             {
                 if (gameIds == null && gameNames == null || gameIds != null && gameIds.Count == 0 && gameNames == null || gameNames != null && gameNames.Count == 0 && gameIds == null)
                     throw new BadParameterException("Either gameIds or gameNames must have at least one value");

--- a/TwitchLib.Api.Helix/Moderation.cs
+++ b/TwitchLib.Api.Helix/Moderation.cs
@@ -40,7 +40,7 @@ namespace TwitchLib.Api.Helix
 
         #region CheckAutoModeStatus
 
-        public Task<CheckAutoModStatusResponse> CheckAutoModStatusAsync(List<Message> messages, string broadcasterId, string accessToken = null)
+        public Task<CheckAutoModStatusResponse> CheckAutoModStatusAsync(ICollection<Message> messages, string broadcasterId, string accessToken = null)
         {
             if (messages == null || messages.Count == 0)
                 throw new BadParameterException("messages cannot be null and must be greater than 0 length");
@@ -55,7 +55,7 @@ namespace TwitchLib.Api.Helix
 
             MessageRequest request = new MessageRequest()
             {
-                Messages = messages.ToArray()
+                Messages = (Message[])messages
             };
 
             return TwitchPostGenericAsync<CheckAutoModStatusResponse>("/moderation/enforcements/status", ApiVersion.Helix, JsonConvert.SerializeObject(request), getParams, accessToken);
@@ -65,7 +65,7 @@ namespace TwitchLib.Api.Helix
 
         #region GetBannedEvents
 
-        public Task<GetBannedEventsResponse> GetBannedEventsAsync(string broadcasterId, List<string> userIds = null, string after = null, string first = null, string accessToken = null)
+        public Task<GetBannedEventsResponse> GetBannedEventsAsync(string broadcasterId, ICollection<string> userIds = null, string after = null, string first = null, string accessToken = null)
         {
             if (broadcasterId == null || broadcasterId.Length == 0)
                 throw new BadParameterException("broadcasterId cannot be null and must be greater than 0 length");
@@ -92,7 +92,7 @@ namespace TwitchLib.Api.Helix
 
         #region GetBannedUsers
 
-        public Task<GetBannedUsersResponse> GetBannedUsersAsync(string broadcasterId, List<string> userIds = null, string after = null, string before = null, string accessToken = null)
+        public Task<GetBannedUsersResponse> GetBannedUsersAsync(string broadcasterId, ICollection<string> userIds = null, string after = null, string before = null, string accessToken = null)
         {
             if (broadcasterId == null || broadcasterId.Length == 0)
                 throw new BadParameterException("broadcasterId cannot be null and must be greater than 0 length");
@@ -119,7 +119,7 @@ namespace TwitchLib.Api.Helix
 
         #region GetModerators
 
-        public Task<GetModeratorsResponse> GetModeratorsAsync(string broadcasterId, List<string> userIds = null, string after = null, string accessToken = null)
+        public Task<GetModeratorsResponse> GetModeratorsAsync(string broadcasterId, ICollection<string> userIds = null, string after = null, string accessToken = null)
         {
             if (broadcasterId == null || broadcasterId.Length == 0)
                 throw new BadParameterException("broadcasterId cannot be null and must be greater than 0 length");
@@ -143,7 +143,7 @@ namespace TwitchLib.Api.Helix
 
         #region GetModeratorEvents
 
-        public Task<GetModeratorEventsResponse> GetModeratorEventsAsync(string broadcasterId, List<string> userIds = null, string accessToken = null)
+        public Task<GetModeratorEventsResponse> GetModeratorEventsAsync(string broadcasterId, ICollection<string> userIds = null, string accessToken = null)
         {
             if (broadcasterId == null || broadcasterId.Length == 0)
                 throw new BadParameterException("broadcasterId cannot be null and must be greater than 0 length");

--- a/TwitchLib.Api.Helix/Polls.cs
+++ b/TwitchLib.Api.Helix/Polls.cs
@@ -19,7 +19,7 @@ namespace TwitchLib.Api.Helix
         {
         }
 
-        public Task<GetPollsResponse> GetPollsAsync(string broadcasterId, List<string> ids = null, string after = null, int first = 20, string accessToken = null)
+        public Task<GetPollsResponse> GetPollsAsync(string broadcasterId, ICollection<string> ids = null, string after = null, int first = 20, string accessToken = null)
         {
             var getParams = new List<KeyValuePair<string, string>>
             { 

--- a/TwitchLib.Api.Helix/Predictions.cs
+++ b/TwitchLib.Api.Helix/Predictions.cs
@@ -19,7 +19,7 @@ namespace TwitchLib.Api.Helix
         {
         }
 
-        public Task<GetPredictionsResponse> GetPredictionsAsync(string broadcasterId, List<string> ids = null, string after = null, int first = 20, string accessToken = null)
+        public Task<GetPredictionsResponse> GetPredictionsAsync(string broadcasterId, ICollection<string> ids = null, string after = null, int first = 20, string accessToken = null)
         {
             var getParams = new List<KeyValuePair<string, string>>
             {

--- a/TwitchLib.Api.Helix/Schedule.cs
+++ b/TwitchLib.Api.Helix/Schedule.cs
@@ -18,7 +18,7 @@ namespace TwitchLib.Api.Helix
         public Schedule(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http)
         { }
 
-        public Task<GetChannelStreamScheduleResponse> GetChannelStreamScheduleAsync(string broadcasterId, List<string> segmentIds = null, string startTime = null, string utcOffset = null,
+        public Task<GetChannelStreamScheduleResponse> GetChannelStreamScheduleAsync(string broadcasterId, ICollection<string> segmentIds = null, string startTime = null, string utcOffset = null,
             int first = 20, string after = null, string accessToken = null)
         {
             var getParams = new List<KeyValuePair<string, string>>

--- a/TwitchLib.Api.Helix/Streams.cs
+++ b/TwitchLib.Api.Helix/Streams.cs
@@ -21,7 +21,7 @@ namespace TwitchLib.Api.Helix
         {
         }
 
-        public Task<GetStreamsResponse> GetStreamsAsync(string after = null, List<string> communityIds = null, int first = 20, List<string> gameIds = null, List<string> languages = null, string type = "all", List<string> userIds = null, List<string> userLogins = null, string accessToken = null)
+        public Task<GetStreamsResponse> GetStreamsAsync(string after = null, ICollection<string> communityIds = null, int first = 20, ICollection<string> gameIds = null, ICollection<string> languages = null, string type = "all", ICollection<string> userIds = null, ICollection<string> userLogins = null, string accessToken = null)
         {
             var getParams = new List<KeyValuePair<string, string>>
                 {
@@ -76,7 +76,7 @@ namespace TwitchLib.Api.Helix
             return TwitchGetGenericAsync<GetStreamTagsResponse>("/streams/tags", ApiVersion.Helix, getParams, accessToken);
         }
 
-        public Task ReplaceStreamTagsAsync(string broadcasterId, List<string> tagIds = null, string accessToken = null)
+        public Task ReplaceStreamTagsAsync(string broadcasterId, ICollection<string> tagIds = null, string accessToken = null)
         {
             var getParams = new List<KeyValuePair<string, string>>();
             getParams.Add(new KeyValuePair<string, string>("broadcaster_id", broadcasterId));

--- a/TwitchLib.Api.Helix/Subscriptions.cs
+++ b/TwitchLib.Api.Helix/Subscriptions.cs
@@ -31,7 +31,7 @@ namespace TwitchLib.Api.Helix
             return TwitchGetGenericAsync<CheckUserSubscriptionResponse>("/subscriptions/user", ApiVersion.Helix, getParams, accessToken);
         } 
 
-        public Task<GetUserSubscriptionsResponse> GetUserSubscriptionsAsync(string broadcasterId, List<string> userIds, string accessToken = null)
+        public Task<GetUserSubscriptionsResponse> GetUserSubscriptionsAsync(string broadcasterId, ICollection<string> userIds, string accessToken = null)
         {
             if (string.IsNullOrEmpty(broadcasterId))
             {

--- a/TwitchLib.Api.Helix/Users.cs
+++ b/TwitchLib.Api.Helix/Users.cs
@@ -57,7 +57,7 @@ namespace TwitchLib.Api.Helix
             return TwitchDeleteAsync("/user/blocks", ApiVersion.Helix, getParams, accessToken);
         }
 
-        public Task<GetUsersResponse> GetUsersAsync(List<string> ids = null, List<string> logins = null, string accessToken = null)
+        public Task<GetUsersResponse> GetUsersAsync(ICollection<string> ids = null, ICollection<string> logins = null, string accessToken = null)
         {
             var getParams = new List<KeyValuePair<string, string>>();
             if (ids != null && ids.Count > 0)

--- a/TwitchLib.Api.Helix/Videos.cs
+++ b/TwitchLib.Api.Helix/Videos.cs
@@ -28,7 +28,7 @@ namespace TwitchLib.Api.Helix
             return TwitchDeleteGenericAsync<DeleteVideosResponse>("/videos", ApiVersion.Helix, getParams, accessToken);
         }
 
-        public Task<GetVideosResponse> GetVideosAsync(List<string> videoIds = null, string userId = null, string gameId = null, string after = null, string before = null, int first = 20, string language = null, Period period = Period.All, VideoSort sort = VideoSort.Time, VideoType type = VideoType.All, string accessToken = null)
+        public Task<GetVideosResponse> GetVideosAsync(ICollection<string> videoIds = null, string userId = null, string gameId = null, string after = null, string before = null, int first = 20, string language = null, Period period = Period.All, VideoSort sort = VideoSort.Time, VideoType type = VideoType.All, string accessToken = null)
         {
             if ((videoIds == null || videoIds.Count == 0) && userId == null && gameId == null)
                 throw new BadParameterException("VideoIds, userId, and gameId cannot all be null/empty.");

--- a/TwitchLib.Api/Events/OnUserAuthorizationDetectedArgs.cs
+++ b/TwitchLib.Api/Events/OnUserAuthorizationDetectedArgs.cs
@@ -6,7 +6,7 @@ namespace TwitchLib.Api.Events
     public class OnUserAuthorizationDetectedArgs
     {
         public string Id { get; set; }
-        public List<AuthScopes> Scopes { get; set; }
+        public IList<AuthScopes> Scopes { get; set; }
         public string Username { get; set; }
         public string Token { get; set; }
         public string Refresh { get; set; }

--- a/TwitchLib.Api/Services/ApiService.cs
+++ b/TwitchLib.Api/Services/ApiService.cs
@@ -16,7 +16,7 @@ namespace TwitchLib.Api.Services
         /// <summary>
         /// The list with channels to monitor.
         /// </summary>
-        public List<string> ChannelsToMonitor { get; private set; }
+        public IList<string> ChannelsToMonitor { get; private set; }
         /// <summary>
         /// How often the service is being updated in seconds.
         /// </summary>
@@ -100,7 +100,7 @@ namespace TwitchLib.Api.Services
         /// <exception cref="ArgumentNullException">When <paramref name="channelsToMonitor"/> is null.</exception>
         /// <exception cref="ArgumentException">When <paramref name="channelsToMonitor"/> is empty.</exception>
         /// <param name="channelsToMonitor">The channels to monitor.</param>
-        protected virtual void SetChannels(List<string> channelsToMonitor)
+        protected virtual void SetChannels(ICollection<string> channelsToMonitor)
         {
             if (channelsToMonitor == null)
                 throw new ArgumentNullException(nameof(channelsToMonitor));
@@ -108,9 +108,9 @@ namespace TwitchLib.Api.Services
             if (channelsToMonitor.Count == 0)
                 throw new ArgumentException("The provided list is empty.", nameof(channelsToMonitor));
 
-            ChannelsToMonitor = channelsToMonitor;
+            ChannelsToMonitor = new List<string>(channelsToMonitor);
 
-            OnChannelsSet?.Invoke(this, new OnChannelsSetArgs {Channels = channelsToMonitor});
+            OnChannelsSet?.Invoke(this, new OnChannelsSetArgs {Channels = ChannelsToMonitor});
         }
         
         /// <summary>

--- a/TwitchLib.Api/Services/Core/LiveStreamMonitor/CoreMonitor.cs
+++ b/TwitchLib.Api/Services/Core/LiveStreamMonitor/CoreMonitor.cs
@@ -11,7 +11,7 @@ namespace TwitchLib.Api.Services.Core.LiveStreamMonitor
     {
         protected readonly ITwitchAPI _api;
 
-        public abstract Task<GetStreamsResponse> GetStreamsAsync(List<string> channels, string accessToken = null);
+        public abstract Task<GetStreamsResponse> GetStreamsAsync(ICollection<string> channels, string accessToken = null);
         public abstract Task<Func<Stream, bool>> CompareStream(string channel, string accessToken = null);
 
         protected CoreMonitor(ITwitchAPI api)

--- a/TwitchLib.Api/Services/Core/LiveStreamMonitor/IdBasedMonitor.cs
+++ b/TwitchLib.Api/Services/Core/LiveStreamMonitor/IdBasedMonitor.cs
@@ -16,7 +16,7 @@ namespace TwitchLib.Api.Services.Core.LiveStreamMonitor
             return Task.FromResult(new Func<Stream, bool>(stream => stream.UserId == channel));
         }
 
-        public override Task<GetStreamsResponse> GetStreamsAsync(List<string> channels, string accessToken = null)
+        public override Task<GetStreamsResponse> GetStreamsAsync(ICollection<string> channels, string accessToken = null)
         {
             return _api.Helix.Streams.GetStreamsAsync(first: channels.Count, userIds: channels, accessToken: accessToken);
         }

--- a/TwitchLib.Api/Services/Core/LiveStreamMonitor/NameBasedMonitor.cs
+++ b/TwitchLib.Api/Services/Core/LiveStreamMonitor/NameBasedMonitor.cs
@@ -25,7 +25,7 @@ namespace TwitchLib.Api.Services.Core.LiveStreamMonitor
             return stream => stream.UserId == channelId;
         }
 
-        public override Task<GetStreamsResponse> GetStreamsAsync(List<string> channels, string accessToken = null)
+        public override Task<GetStreamsResponse> GetStreamsAsync(ICollection<string> channels, string accessToken = null)
         {
             return _api.Helix.Streams.GetStreamsAsync(first: channels.Count, userLogins: channels, accessToken: accessToken);
         }

--- a/TwitchLib.Api/Services/Events/FollowerService/OnNewFollowersDetectedArgs.cs
+++ b/TwitchLib.Api/Services/Events/FollowerService/OnNewFollowersDetectedArgs.cs
@@ -13,6 +13,6 @@ namespace TwitchLib.Api.Services.Events.FollowerService
         /// <summary>Event property representing channel the service is currently monitoring.</summary>
         public string Channel;
         /// <summary>Event property representing all new followers detected.</summary>
-        public List<Follow> NewFollowers;
+        public IList<Follow> NewFollowers;
     }
 }

--- a/TwitchLib.Api/Services/Events/OnChannelsSetArgs.cs
+++ b/TwitchLib.Api/Services/Events/OnChannelsSetArgs.cs
@@ -12,6 +12,6 @@ namespace TwitchLib.Api.Services.Events
         /// <summary>
         /// The channels the service is currently monitoring.
         /// </summary>
-        public List<string> Channels;
+        public IList<string> Channels;
     }
 }

--- a/TwitchLib.Api/Services/FollowerService.cs
+++ b/TwitchLib.Api/Services/FollowerService.cs
@@ -21,7 +21,7 @@ namespace TwitchLib.Api.Services
         /// <summary>
         /// The current known followers for each channel.
         /// </summary>
-        public Dictionary<string, List<Follow>> KnownFollowers { get; } = new Dictionary<string, List<Follow>>(StringComparer.OrdinalIgnoreCase);
+        public IDictionary<string, List<Follow>> KnownFollowers { get; } = new Dictionary<string, List<Follow>>(StringComparer.OrdinalIgnoreCase);
         /// <summary>
         /// The amount of followers queried per request.
         /// </summary>
@@ -84,7 +84,7 @@ namespace TwitchLib.Api.Services
         /// <exception cref="ArgumentNullException">When <paramref name="channelsToMonitor"/> is null.</exception>
         /// <exception cref="ArgumentException">When <paramref name="channelsToMonitor"/> is empty.</exception>
         /// <param name="channelsToMonitor">A list with channels to monitor.</param>
-        public void SetChannelsById(List<string> channelsToMonitor)
+        public void SetChannelsById(ICollection<string> channelsToMonitor)
         {
             SetChannels(channelsToMonitor);
 
@@ -97,7 +97,7 @@ namespace TwitchLib.Api.Services
         /// <exception cref="ArgumentNullException">When <paramref name="channelsToMonitor"/> is null.</exception>
         /// <exception cref="ArgumentException">When <paramref name="channelsToMonitor"/> is empty.</exception>
         /// <param name="channelsToMonitor">A list with channels to monitor.</param>
-        public void SetChannelsByName(List<string> channelsToMonitor)
+        public void SetChannelsByName(ICollection<string> channelsToMonitor)
         {
             SetChannels(channelsToMonitor);
 
@@ -115,7 +115,7 @@ namespace TwitchLib.Api.Services
 
             foreach (var channel in ChannelsToMonitor)
             {
-                List<Follow> newFollowers;
+                ICollection<Follow> newFollowers;
                 var latestFollowers = await GetLatestFollowersAsync(channel);
 
                 if (latestFollowers.Count == 0)
@@ -160,7 +160,7 @@ namespace TwitchLib.Api.Services
                 if (!callEvents)
                     return;
 
-                OnNewFollowersDetected?.Invoke(this, new OnNewFollowersDetectedArgs { Channel = channel, NewFollowers = newFollowers });
+                OnNewFollowersDetected?.Invoke(this, new OnNewFollowersDetectedArgs { Channel = channel, NewFollowers = newFollowers.ToList() });
             }
         }
 
@@ -170,7 +170,7 @@ namespace TwitchLib.Api.Services
             await UpdateLatestFollowersAsync();
         }
 
-        private async Task<List<Follow>> GetLatestFollowersAsync(string channel)
+        private async Task<IList<Follow>> GetLatestFollowersAsync(string channel)
         {
             var resultset = await _monitor.GetUsersFollowsAsync(channel, QueryCountPerRequest);
             

--- a/TwitchLib.Api/Services/LiveStreamMonitorService.cs
+++ b/TwitchLib.Api/Services/LiveStreamMonitorService.cs
@@ -18,7 +18,7 @@ namespace TwitchLib.Api.Services
         /// <summary>
         /// A cache with streams that are currently live.
         /// </summary>
-        public Dictionary<string, Stream> LiveStreams { get; } = new Dictionary<string, Stream>(StringComparer.OrdinalIgnoreCase);
+        public IDictionary<string, Stream> LiveStreams { get; } = new Dictionary<string, Stream>(StringComparer.OrdinalIgnoreCase);
         /// <summary>
         /// The maximum amount of streams to collect per request.
         /// </summary>
@@ -143,7 +143,7 @@ namespace TwitchLib.Api.Services
             OnStreamOffline?.Invoke(this, new OnStreamOfflineArgs { Channel = channel, Stream = cachedLiveStream });
         }
 
-        private async Task<List<Stream>> GetLiveStreamersAsync()
+        private async Task<IList<Stream>> GetLiveStreamersAsync()
         {
             var livestreamers = new List<Stream>();
             var pages = Math.Ceiling((double)ChannelsToMonitor.Count / MaxStreamRequestCountPerRequest);


### PR DESCRIPTION
Hi,

This is a patch that swaps strongly typed collections for their lowest-common denominator interfaces in public methods and properties.  Makes it easier to consume and more generic.