### PR TITLE
Add missing parameter to TwitchLib.Api.Helix.Moderation.GetModeratorsAsync

### DIFF
--- a/TwitchLib.Api.Helix/Moderation.cs
+++ b/TwitchLib.Api.Helix/Moderation.cs
@@ -132,14 +132,17 @@ namespace TwitchLib.Api.Helix
 
         #region GetModerators
 
-        public Task<GetModeratorsResponse> GetModeratorsAsync(string broadcasterId, List<string> userIds = null, string after = null, string accessToken = null)
+        public Task<GetModeratorsResponse> GetModeratorsAsync(string broadcasterId, List<string> userIds = null, int first = 20, string after = null, string accessToken = null)
         {
             if (broadcasterId == null || broadcasterId.Length == 0)
                 throw new BadParameterException("broadcasterId cannot be null and must be greater than 0 length");
+            if (first > 100 || first < 1)
+                throw new BadParameterException("first must be greater than 0 and less than 101");
 
             var getParams = new List<KeyValuePair<string, string>>()
             {
-                new KeyValuePair<string, string>("broadcaster_id", broadcasterId)
+                new KeyValuePair<string, string>("broadcaster_id", broadcasterId),
+                new KeyValuePair<string, string>("first", first.ToString())
             };
 
             if (userIds != null && userIds.Count > 0)


### PR DESCRIPTION
The current implementation was missing the ability to set the 'first' parameter.
With the deprecation of chat commands (relevant here: /mods) we should get the replacement APIs in shape.

Relevant API documentation: https://dev.twitch.tv/docs/api/reference#get-moderators


Sorry about the messed up original pull request, i based it off the wrong branch and then apparently did a series of actions that closed it forever :)