### PR TITLE
Fix GetStreamMarkers API call

### DIFF
--- a/TwitchLib.Api.Helix/Streams.cs
+++ b/TwitchLib.Api.Helix/Streams.cs
@@ -107,13 +107,16 @@ namespace TwitchLib.Api.Helix
             return TwitchPostGenericAsync<CreateStreamMarkerResponse>("/streams/markers", ApiVersion.Helix, JsonConvert.SerializeObject(request), null, accessToken);
         }
 
-        public Task<GetStreamMarkersResponse> GetStreamMarkersAsync(string userId = null, string videoId = null, string accessToken = null)
+        public Task<GetStreamMarkersResponse> GetStreamMarkersAsync(string userId = null, string videoId = null, int first = 20, string after = null, string accessToken = null)
         {
             if (string.IsNullOrWhiteSpace(userId) && string.IsNullOrWhiteSpace(videoId))
                 throw new BadParameterException("One of userId and videoId has to be specified");
 
             if (!string.IsNullOrWhiteSpace(userId) && !string.IsNullOrWhiteSpace(videoId))
                 throw new BadParameterException("userId and videoId are mutually exclusive");
+
+            if (first < 1 || first > 100)
+                throw new BadParameterException("first cannot be less than 1 or greater than 100");
 
             var getParams = new List<KeyValuePair<string, string>>();
 
@@ -122,6 +125,11 @@ namespace TwitchLib.Api.Helix
 
             if (!string.IsNullOrWhiteSpace(videoId))
                 getParams.Add(new KeyValuePair<string, string>("video_id", videoId));
+
+            getParams.Add(new KeyValuePair<string, string>("first", first.ToString()));
+
+            if (!string.IsNullOrWhiteSpace(after))
+                getParams.Add(new KeyValuePair<string, string>("after", after));
 
             return TwitchGetGenericAsync<GetStreamMarkersResponse>("/stream/markers", ApiVersion.Helix, getParams, accessToken);
         }

--- a/TwitchLib.Api.Helix/Streams.cs
+++ b/TwitchLib.Api.Helix/Streams.cs
@@ -107,13 +107,21 @@ namespace TwitchLib.Api.Helix
             return TwitchPostGenericAsync<CreateStreamMarkerResponse>("/streams/markers", ApiVersion.Helix, JsonConvert.SerializeObject(request), null, accessToken);
         }
 
-        public Task<GetStreamMarkersResponse> GetStreamMarkersAsync(string userId, string videoId, string accessToken = null)
+        public Task<GetStreamMarkersResponse> GetStreamMarkersAsync(string userId = null, string videoId = null, string accessToken = null)
         {
-            var getParams = new List<KeyValuePair<string, string>>
-            {
-                new KeyValuePair<string, string>("user_id", userId),
-                new KeyValuePair<string, string>("video_id", videoId)
-            };
+            if (string.IsNullOrWhiteSpace(userId) && string.IsNullOrWhiteSpace(videoId))
+                throw new BadParameterException("One of userId and videoId has to be specified");
+
+            if (!string.IsNullOrWhiteSpace(userId) && !string.IsNullOrWhiteSpace(videoId))
+                throw new BadParameterException("userId and videoId are mutually exclusive");
+
+            var getParams = new List<KeyValuePair<string, string>>();
+
+            if (!string.IsNullOrWhiteSpace(userId))
+                getParams.Add(new KeyValuePair<string, string>("user_id", userId));
+
+            if (!string.IsNullOrWhiteSpace(videoId))
+                getParams.Add(new KeyValuePair<string, string>("video_id", videoId));
 
             return TwitchGetGenericAsync<GetStreamMarkersResponse>("/stream/markers", ApiVersion.Helix, getParams, accessToken);
         }

--- a/TwitchLib.Api/TwitchLib.Api.csproj
+++ b/TwitchLib.Api/TwitchLib.Api.csproj
@@ -13,7 +13,7 @@
     <PackageProjectUrl>https://github.com/TwitchLib/TwitchLib.Api</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Copyright>Copyright 2022</Copyright>
-    <PackageReleaseNotes>Fixes an ArgumentNullException when not providing a playlist id for the GetPlaylists API call</PackageReleaseNotes>
+    <PackageReleaseNotes>Added GetCharityCampaigns support, fixed GetChannelVip and UserChatColor models, fixed issues with the GetStreamMarkers API call</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/swiftyspiffy/TwitchLib</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
     <PackageTags>twitch library irc chat c# csharp api events pubsub net standard 2.0</PackageTags>


### PR DESCRIPTION
- made userId and videoId params optional
- added validation to ensure one of userId and videoId is specified but not both of them (mutually exclusive)
- only add specified param to URL