### PR TITLE
Fixed endpoint for GetStreamMarkers in Streams.cs

### DIFF
--- a/TwitchLib.Api.Helix/Streams.cs
+++ b/TwitchLib.Api.Helix/Streams.cs
@@ -135,7 +135,7 @@ namespace TwitchLib.Api.Helix
             if (!string.IsNullOrWhiteSpace(after))
                 getParams.Add(new KeyValuePair<string, string>("after", after));
 
-            return TwitchGetGenericAsync<GetStreamMarkersResponse>("/stream/markers", ApiVersion.Helix, getParams, accessToken);
+            return TwitchGetGenericAsync<GetStreamMarkersResponse>("/streams/markers", ApiVersion.Helix, getParams, accessToken);
         }
 
         public Task<GetFollowedStreamsResponse> GetFollowedStreamsAsync(string userId, int first = 100, string after = null, string accessToken = null)


### PR DESCRIPTION
changed to streams/markers/ to match https://dev.twitch.tv/docs/api/reference#get-stream-markers