### PR TITLE
Add Helix GetChatters API support

### DIFF
--- a/TwitchLib.Api.Core.Enums/TwitchLib.Api.Core.Enums.csproj
+++ b/TwitchLib.Api.Core.Enums/TwitchLib.Api.Core.Enums.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>TwitchLib.Api.Core.Enums</PackageId>
-    <VersionPrefix>3.7.1</VersionPrefix>
+    <VersionPrefix>3.8.0</VersionPrefix>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     <Description>Project containing the enums of TwitchLib.Api</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -18,8 +18,8 @@
     <RepositoryType>Git</RepositoryType>
     <PackageTags>twitch library irc chat c# csharp api events pubsub net standard 2.0</PackageTags>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <AssemblyVersion>3.7.1</AssemblyVersion>
-    <FileVersion>3.7.1</FileVersion>
+    <AssemblyVersion>3.8.0</AssemblyVersion>
+    <FileVersion>3.8.0</FileVersion>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>

--- a/TwitchLib.Api.Core.Interfaces/TwitchLib.Api.Core.Interfaces.csproj
+++ b/TwitchLib.Api.Core.Interfaces/TwitchLib.Api.Core.Interfaces.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>TwitchLib.Api.Core.Interfaces</PackageId>
-    <VersionPrefix>3.7.1</VersionPrefix>
+    <VersionPrefix>3.8.0</VersionPrefix>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     <Description>Project containing all of the interfaces used in TwitchLib.Api</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -18,8 +18,8 @@
     <RepositoryType>Git</RepositoryType>
     <PackageTags>twitch library irc chat c# csharp api events pubsub net standard 2.0</PackageTags>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <AssemblyVersion>3.7.1</AssemblyVersion>
-    <FileVersion>3.7.1</FileVersion>
+    <AssemblyVersion>3.8.0</AssemblyVersion>
+    <FileVersion>3.8.0</FileVersion>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>

--- a/TwitchLib.Api.Core.Models/TwitchLib.Api.Core.Models.csproj
+++ b/TwitchLib.Api.Core.Models/TwitchLib.Api.Core.Models.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>TwitchLib.Api.Core.Models</PackageId>
-    <VersionPrefix>3.7.1</VersionPrefix>
+    <VersionPrefix>3.8.0</VersionPrefix>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     <Description>Project containing the core models used in TwitchLib.Api</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -18,8 +18,8 @@
     <RepositoryType>Git</RepositoryType>
     <PackageTags>twitch library irc chat c# csharp api events pubsub net standard 2.0</PackageTags>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <AssemblyVersion>3.7.1</AssemblyVersion>
-    <FileVersion>3.7.1</FileVersion>
+    <AssemblyVersion>3.8.0</AssemblyVersion>
+    <FileVersion>3.8.0</FileVersion>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>

--- a/TwitchLib.Api.Core/TwitchLib.Api.Core.csproj
+++ b/TwitchLib.Api.Core/TwitchLib.Api.Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>TwitchLib.Api.Core</PackageId>
-    <VersionPrefix>3.7.1</VersionPrefix>
+    <VersionPrefix>3.8.0</VersionPrefix>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     <Description>Project containing the core of TwitchLib.Api</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -18,8 +18,8 @@
     <RepositoryType>Git</RepositoryType>
     <PackageTags>twitch library irc chat c# csharp api events pubsub net standard 2.0</PackageTags>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <AssemblyVersion>3.7.1</AssemblyVersion>
-    <FileVersion>3.7.1</FileVersion>
+    <AssemblyVersion>3.8.0</AssemblyVersion>
+    <FileVersion>3.8.0</FileVersion>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/TwitchLib.Api.Core/Undocumented/Undocumented.cs
+++ b/TwitchLib.Api.Core/Undocumented/Undocumented.cs
@@ -125,6 +125,7 @@ namespace TwitchLib.Api.Core.Undocumented
 
         #region GetChatters
 
+        [Obsolete("Please use the new official Helix GetChatters Endpoint (api.Helix.Chat.GetChattersAsync) instead of this undocumented and unsupported endpoint.")]
         public async Task<List<ChatterFormatted>> GetChattersAsync(string channelName)
         {
             var resp = await GetGenericAsync<ChattersResponse>($"https://tmi.twitch.tv/group/user/{channelName.ToLower()}/chatters");

--- a/TwitchLib.Api.Helix.Models/Chat/GetChatters/Chatter.cs
+++ b/TwitchLib.Api.Helix.Models/Chat/GetChatters/Chatter.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+
+namespace TwitchLib.Api.Helix.Models.Chat.GetChatters
+{
+    public class Chatter
+    {
+        /// <summary>
+        /// The login name of a user that’s connected to the broadcaster’s chat room.
+        /// </summary>
+        [JsonProperty("user_login")]
+        public string UserLogin { get; set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/Chat/GetChatters/Chatter.cs
+++ b/TwitchLib.Api.Helix.Models/Chat/GetChatters/Chatter.cs
@@ -8,6 +8,6 @@ namespace TwitchLib.Api.Helix.Models.Chat.GetChatters
         /// The login name of a user that’s connected to the broadcaster’s chat room.
         /// </summary>
         [JsonProperty("user_login")]
-        public string UserLogin { get; set; }
+        public string UserLogin { get; protected set; }
     }
 }

--- a/TwitchLib.Api.Helix.Models/Chat/GetChatters/GetChattersResponse.cs
+++ b/TwitchLib.Api.Helix.Models/Chat/GetChatters/GetChattersResponse.cs
@@ -9,12 +9,19 @@ namespace TwitchLib.Api.Helix.Models.Chat.GetChatters
         /// List of login names that are connected to the broadcaster’s chat room.
         /// </summary>
         [JsonProperty("data")]
-        public Chatter[] Data { get; set; }
+        public Chatter[] Data { get; protected set; }
 
         /// <summary>
         /// Contains the information used to page through the list of results. The object is empty if there are no more pages left to page through.
         /// </summary>
         [JsonProperty(PropertyName = "pagination")]
         public Pagination Pagination { get; protected set; }
+
+        /// <summary>
+        /// The total number of users that are connected to the broadcaster’s chat room.
+        /// <para>As you page through the list, the number of users may change as users join and leave the chat room.</para>
+        /// </summary>
+        [JsonProperty("total")]
+        public int Total { get; protected set; }
     }
 }

--- a/TwitchLib.Api.Helix.Models/Chat/GetChatters/GetChattersResponse.cs
+++ b/TwitchLib.Api.Helix.Models/Chat/GetChatters/GetChattersResponse.cs
@@ -1,0 +1,20 @@
+﻿using Newtonsoft.Json;
+using TwitchLib.Api.Helix.Models.Common;
+
+namespace TwitchLib.Api.Helix.Models.Chat.GetChatters
+{
+    public class GetChattersResponse
+    {
+        /// <summary>
+        /// List of login names that are connected to the broadcaster’s chat room.
+        /// </summary>
+        [JsonProperty("data")]
+        public Chatter[] Data { get; set; }
+
+        /// <summary>
+        /// Contains the information used to page through the list of results. The object is empty if there are no more pages left to page through.
+        /// </summary>
+        [JsonProperty(PropertyName = "pagination")]
+        public Pagination Pagination { get; protected set; }
+    }
+}

--- a/TwitchLib.Api.Helix.Models/TwitchLib.Api.Helix.Models.csproj
+++ b/TwitchLib.Api.Helix.Models/TwitchLib.Api.Helix.Models.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>TwitchLib.Api.Helix.Models</PackageId>
-    <VersionPrefix>3.7.1</VersionPrefix>
+    <VersionPrefix>3.8.0</VersionPrefix>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     <Description>Project containing the Helix models used in TwitchLib.Api</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -18,8 +18,8 @@
     <RepositoryType>Git</RepositoryType>
     <PackageTags>twitch library irc chat c# csharp api events pubsub net standard 2.0</PackageTags>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <AssemblyVersion>3.7.1</AssemblyVersion>
-    <FileVersion>3.7.1</FileVersion>
+    <AssemblyVersion>3.8.0</AssemblyVersion>
+    <FileVersion>3.8.0</FileVersion>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
 
@@ -33,5 +33,8 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="twitchlib.png" Pack="true" PackagePath="\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Chat\GetChatters\" />
   </ItemGroup>
 </Project>

--- a/TwitchLib.Api.Helix/Chat.cs
+++ b/TwitchLib.Api.Helix/Chat.cs
@@ -14,6 +14,7 @@ using TwitchLib.Api.Helix.Models.Chat.ChatSettings;
 using TwitchLib.Api.Helix.Models.Chat.Emotes.GetChannelEmotes;
 using TwitchLib.Api.Helix.Models.Chat.Emotes.GetEmoteSets;
 using TwitchLib.Api.Helix.Models.Chat.Emotes.GetGlobalEmotes;
+using TwitchLib.Api.Helix.Models.Chat.GetChatters;
 using TwitchLib.Api.Helix.Models.Chat.GetUserChatColor;
 
 namespace TwitchLib.Api.Helix
@@ -38,6 +39,34 @@ namespace TwitchLib.Api.Helix
         {
             return TwitchGetGenericAsync<GetGlobalChatBadgesResponse>("/chat/badges/global", ApiVersion.Helix, accessToken: accessToken);
         }
+        #endregion
+
+        #region Chatters
+
+        public Task<GetChattersResponse> GetChattersAsync(string broadcasterId, string moderatorId, int first = 100, string after = null, string accessToken = null)
+        {
+            if (string.IsNullOrWhiteSpace(broadcasterId))
+                throw new BadParameterException("broadcasterId cannot be null/empty/whitespace");
+
+            if (string.IsNullOrWhiteSpace(moderatorId))
+                throw new BadParameterException("broadcasterId cannot be null/empty/whitespace");
+
+            if (first < 1 || first > 1000)
+                throw new BadParameterException("first cannot be less than 1 or greater than 1000");
+
+            var getParams = new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("broadcaster_id", broadcasterId),
+                new KeyValuePair<string, string>("moderator_id", moderatorId),
+                new KeyValuePair<string, string>("first", first.ToString()),
+            };
+
+            if (!string.IsNullOrWhiteSpace(after))
+                getParams.Add(new KeyValuePair<string, string>("after", after));
+
+            return TwitchGetGenericAsync<GetChattersResponse>("/chat/chatters", ApiVersion.Helix, getParams, accessToken: accessToken);
+        }
+
         #endregion
 
         #region Emotes

--- a/TwitchLib.Api.Helix/Chat.cs
+++ b/TwitchLib.Api.Helix/Chat.cs
@@ -49,7 +49,7 @@ namespace TwitchLib.Api.Helix
                 throw new BadParameterException("broadcasterId cannot be null/empty/whitespace");
 
             if (string.IsNullOrWhiteSpace(moderatorId))
-                throw new BadParameterException("broadcasterId cannot be null/empty/whitespace");
+                throw new BadParameterException("moderatorId cannot be null/empty/whitespace");
 
             if (first < 1 || first > 1000)
                 throw new BadParameterException("first cannot be less than 1 or greater than 1000");

--- a/TwitchLib.Api.Helix/TwitchLib.Api.Helix.csproj
+++ b/TwitchLib.Api.Helix/TwitchLib.Api.Helix.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>TwitchLib.Api.Helix</PackageId>
-    <VersionPrefix>3.7.1</VersionPrefix>
+    <VersionPrefix>3.8.0</VersionPrefix>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     <Description>Project containing the Helix section of TwitchLib.Api</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -18,8 +18,8 @@
     <RepositoryType>Git</RepositoryType>
     <PackageTags>twitch library irc chat c# csharp api events pubsub net standard 2.0</PackageTags>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <AssemblyVersion>3.7.1</AssemblyVersion>
-    <FileVersion>3.7.1</FileVersion>
+    <AssemblyVersion>3.8.0</AssemblyVersion>
+    <FileVersion>3.8.0</FileVersion>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>

--- a/TwitchLib.Api/TwitchLib.Api.csproj
+++ b/TwitchLib.Api/TwitchLib.Api.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>TwitchLib.Api</PackageId>
-    <VersionPrefix>3.7.1</VersionPrefix>
+    <VersionPrefix>3.8.0</VersionPrefix>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     <Description>Api component of TwitchLib. This component allows you to access the Twitch API, as well as undocumented and third party APIs.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -18,8 +18,8 @@
     <RepositoryType>Git</RepositoryType>
     <PackageTags>twitch library irc chat c# csharp api events pubsub net standard 2.0</PackageTags>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <AssemblyVersion>3.7.1</AssemblyVersion>
-    <FileVersion>3.7.1</FileVersion>
+    <AssemblyVersion>3.8.0</AssemblyVersion>
+    <FileVersion>3.8.0</FileVersion>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
- Added support for the new Helix GetChatters API (beta)
- Marked undocumented GetChatters endpoint as obsolete and directed users to the new official endpoint
- bumped version to 3.8.0