### PR TITLE
fix: correct primary announcement color value

### DIFF
--- a/TwitchLib.Api.Helix.Models/Chat/AnnouncementColors.cs
+++ b/TwitchLib.Api.Helix.Models/Chat/AnnouncementColors.cs
@@ -10,6 +10,6 @@
         public static AnnouncementColors Green { get { return new AnnouncementColors("green"); } }
         public static AnnouncementColors Orange { get { return new AnnouncementColors("orange"); } }
         public static AnnouncementColors Purple { get { return new AnnouncementColors("purple"); } }
-        public static AnnouncementColors Primary { get { return new AnnouncementColors("primary "); } }
+        public static AnnouncementColors Primary { get { return new AnnouncementColors("primary"); } }
     }
 }


### PR DESCRIPTION
Avoids `BadRequestException` for `SendChatAnnouncementAsync` when `color` is primary (or not specified)
