### PR TITLE
Add EventSub Websocket support to EventSub APIs

### DIFF
--- a/TwitchLib.Api.Core.Enums/EventSubTransportMethod.cs
+++ b/TwitchLib.Api.Core.Enums/EventSubTransportMethod.cs
@@ -1,0 +1,8 @@
+﻿namespace TwitchLib.Api.Core.Enums
+{
+    public enum EventSubTransportMethod
+    {
+        Webhook,
+        Websocket
+    }
+}

--- a/TwitchLib.Api.Helix.Models/EventSub/EventSubTransport.cs
+++ b/TwitchLib.Api.Helix.Models/EventSub/EventSubTransport.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
 
 namespace TwitchLib.Api.Helix.Models.EventSub
 {
@@ -8,5 +9,9 @@ namespace TwitchLib.Api.Helix.Models.EventSub
         public string Method { get; protected set; }
         [JsonProperty(PropertyName = "callback")]
         public string Callback { get; protected set; }
+        [JsonProperty(PropertyName = "created_at")]
+        public DateTime? CreatedAt { get; protected set; }
+        [JsonProperty(PropertyName = "disconnected_at")]
+        public DateTime? DisconnectedAt { get; protected set; }
     }
 }

--- a/TwitchLib.Api.Helix/EventSub.cs
+++ b/TwitchLib.Api.Helix/EventSub.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
@@ -22,14 +23,15 @@ namespace TwitchLib.Api.Helix
         /// <param name="type">The type of subscription to create.</param>
         /// <param name="version">The version of the subscription type used in this request.</param>
         /// <param name="condition">The parameter values that are specific to the specified subscription type.</param>
-        /// <param name="method">The transport method. Supported values: webhook.</param>
-        /// <param name="callback">The callback URL where the notification should be sent.</param>
-        /// <param name="secret">The secret used for verifying a signature.</param>
+        /// <param name="method">The transport method. Supported values: Webhook, Websocket.</param>
+        /// <param name="websocketSessionId">The session Id of a websocket connection that you want to subscribe to an event for. Only needed if method is Websocket</param>
+        /// <param name="webhookCallback">The callback URL where the Webhook notification should be sent. Only needed if method is Webhook</param>
+        /// <param name="webhookSecret">The secret used for verifying a Webhooks signature. Only needed if method is Webhook</param>
         /// <param name="clientId">optional Client ID to override the use of the stored one in the TwitchAPI instance</param>
         /// <param name="accessToken">optional access token to override the use of the stored one in the TwitchAPI instance</param>
         /// <returns cref="CreateEventSubSubscriptionResponse"></returns>
-        public Task<CreateEventSubSubscriptionResponse> CreateEventSubSubscriptionAsync(string type, string version, Dictionary<string, string> condition, string method, string callback,
-            string secret, string clientId = null, string accessToken = null)
+        public Task<CreateEventSubSubscriptionResponse> CreateEventSubSubscriptionAsync(string type, string version, Dictionary<string, string> condition, EventSubTransportMethod method, string websocketSessionId = null, string webhookCallback = null,
+            string webhookSecret = null, string clientId = null, string accessToken = null)
         {
             if (string.IsNullOrEmpty(type))
                 throw new BadParameterException("type must be set");
@@ -37,23 +39,50 @@ namespace TwitchLib.Api.Helix
             if (string.IsNullOrEmpty(version))
                 throw new BadParameterException("version must be set");
 
-            if (secret == null || secret.Length < 10 || secret.Length > 100)
-                throw new BadParameterException("secret must be set, and be between 10 (inclusive) and 100 (inclusive)");
+            if (condition == null || condition.Count == 0)
+                throw new BadParameterException("condition must be set");
 
-            var body = new
+            switch (method)
             {
-                type,
-                version,
-                condition,
-                transport = new
-                {
-                    method,
-                    callback,
-                    secret
-                }
-            };
+                case EventSubTransportMethod.Webhook:
+                    if (string.IsNullOrWhiteSpace(webhookCallback))
+                        throw new BadParameterException("webhookCallback must be set");
 
-            return TwitchPostGenericAsync<CreateEventSubSubscriptionResponse>("/eventsub/subscriptions", ApiVersion.Helix, JsonConvert.SerializeObject(body), null, accessToken, clientId);
+                    if (webhookSecret == null || webhookSecret.Length < 10 || webhookSecret.Length > 100)
+                        throw new BadParameterException("webhookSecret must be set, and be between 10 (inclusive) and 100 (inclusive)");
+
+                    var webhookBody = new
+                    {
+                        type,
+                        version,
+                        condition,
+                        transport = new
+                        {
+                            method = method.ToString().ToLowerInvariant(),
+                            callback = webhookCallback,
+                            secret = webhookSecret
+                        }
+                    };
+                    return TwitchPostGenericAsync<CreateEventSubSubscriptionResponse>("/eventsub/subscriptions", ApiVersion.Helix, JsonConvert.SerializeObject(webhookBody), null, accessToken, clientId);
+                case EventSubTransportMethod.Websocket:
+                    if (string.IsNullOrWhiteSpace(websocketSessionId))
+                        throw new BadParameterException("websocketSessionId must be set");
+
+                    var websocketBody = new
+                    {
+                        type,
+                        version,
+                        condition,
+                        transport = new
+                        {
+                            method = method.ToString().ToLowerInvariant(),
+                            session_id = websocketSessionId
+                        }
+                    };
+                    return TwitchPostGenericAsync<CreateEventSubSubscriptionResponse>("/eventsub/subscriptions", ApiVersion.Helix, JsonConvert.SerializeObject(websocketBody), null, accessToken, clientId);
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(method), method, null);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Added support to EventSub APIs according to the changelog from 2022‑11‑01 (https://dev.twitch.tv/docs/change-log)