### PR TITLE
Fix Interpolation error on AuthString

### DIFF
--- a/TwitchLib.Api/Auth/Auth.cs
+++ b/TwitchLib.Api/Auth/Auth.cs
@@ -75,7 +75,7 @@ namespace TwitchLib.Api.Auth
                    "response_type=code&" +
                    $"scope={scopesStr}&" +
                    $"state={state}&" +
-                   $"force_verify={forceVerify}";
+                   $"force_verify={forceVerify.ToString().ToLower()}";
         }
 
         /// <summary>


### PR DESCRIPTION
The boolean was being converted to a string but capitalized. (Tested and confirmed)
This is to fix that error causing the forceverify to fail.