### PR TITLE
Added missing scopes

### DIFF
--- a/TwitchLib.Api.Core.Enums/AuthScopesEnum.cs
+++ b/TwitchLib.Api.Core.Enums/AuthScopesEnum.cs
@@ -71,6 +71,7 @@
         Helix_User_Read_Email,
         Helix_User_Read_Follows,
         Helix_User_Read_Subscriptions,
+        Helix_Moderator_Read_Followers,
         None
     }
 }

--- a/TwitchLib.Api.Core/Common/Helpers.cs
+++ b/TwitchLib.Api.Core/Common/Helpers.cs
@@ -174,6 +174,8 @@ namespace TwitchLib.Api.Core.Common
                     return "moderator:read:chat_settings";
                 case AuthScopes.Helix_Moderator_Read_Chatters:
                     return "moderator:read:chatters";
+                case AuthScopes.Helix_Moderator_Read_Followers:
+                    return "moderator:read:followers"
 
                 case AuthScopes.Any:
                 case AuthScopes.None:


### PR DESCRIPTION
Added missing scopes as documented at  https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#channelfollow 
scope moderator:read:followers