### PR TITLE
Update ChatSettings.cs

### DIFF
--- a/TwitchLib.Api.Helix.Models/Chat/ChatSettings/ChatSettings.cs
+++ b/TwitchLib.Api.Helix.Models/Chat/ChatSettings/ChatSettings.cs
@@ -8,21 +8,21 @@ namespace TwitchLib.Api.Helix.Models.Chat.ChatSettings
     public class ChatSettings
     {
         [JsonProperty(PropertyName = "slow_mode")]
-        public bool SlowMode;
+        public bool? SlowMode;
         [JsonProperty(PropertyName = "slow_mode_wait_time")]
         public int? SlowModeWaitTime;
         [JsonProperty(PropertyName = "follower_mode")]
-        public bool FollowerMode;
+        public bool? FollowerMode;
         [JsonProperty(PropertyName = "follower_mode_duration")]
         public int? FollowerModeDuration;
         [JsonProperty(PropertyName = "subscriber_mode")]
-        public bool SubscriberMode;
+        public bool? SubscriberMode;
         [JsonProperty(PropertyName = "emote_mode")]
-        public bool EmoteMode;
+        public bool? EmoteMode;
         [JsonProperty(PropertyName = "unique_chat_mode")]
-        public bool UniqueChatMode;
+        public bool? UniqueChatMode;
         [JsonProperty(PropertyName = "non_moderator_chat_delay")]
-        public bool NonModeratorChatDelay;
+        public bool? NonModeratorChatDelay;
         [JsonProperty(PropertyName = "non_moderator_chat_delay_duration")]
         public int? NonModeratorChatDelayDuration;
     }


### PR DESCRIPTION
Primitive type `bool` defaults to `false` when not nullable. Making them nullable to prevent accidentally changing unwanted settings.

Test code:
```cs
TwitchLib.Api.Helix.Models.Chat.ChatSettings.ChatSettings chatSettings = new();
Console.WriteLine(JsonConvert.SerializeObject(chatSettings));
```
Old output:
```json
{
  "slow_mode": false,
  "slow_mode_wait_time": null,
  "follower_mode": false,
  "follower_mode_duration": null,
  "subscriber_mode": false,
  "emote_mode": false,
  "unique_chat_mode": false,
  "non_moderator_chat_delay": false,
  "non_moderator_chat_delay_duration": null
}
```
New output:
```json
{
  "slow_mode": null,
  "slow_mode_wait_time": null,
  "follower_mode": null,
  "follower_mode_duration": null,
  "subscriber_mode": null,
  "emote_mode": null,
  "unique_chat_mode": null,
  "non_moderator_chat_delay": null,
  "non_moderator_chat_delay_duration": null
}
```

Tested the reported issue by `Ill.Skillz#6218` - Chat with slow mode and follower mode enabled, turned emote only on/off, no longer removes slow mode and follower mode

*Attempt 2 because targeting dev branch is difficult*