### PR TITLE
Get Channel Chat Badges and Get Global Chat Badges update

### DIFF
--- a/TwitchLib.Api.Helix.Models/Chat/Badges/BadgeVersion.cs
+++ b/TwitchLib.Api.Helix.Models/Chat/Badges/BadgeVersion.cs
@@ -17,8 +17,8 @@ namespace TwitchLib.Api.Helix.Models.Chat.Badges
         [JsonProperty(PropertyName = "description")]
         public string Description { get; protected set; }
         [JsonProperty(PropertyName = "click_action")]
-        public string? ClickAction { get; protected set; }
+        public string ClickAction { get; protected set; }
         [JsonProperty(PropertyName = "click_url")]
-        public string? ClickUrl { get; protected set; }
+        public string ClickUrl { get; protected set; }
     }
 }

--- a/TwitchLib.Api.Helix.Models/Chat/Badges/BadgeVersion.cs
+++ b/TwitchLib.Api.Helix.Models/Chat/Badges/BadgeVersion.cs
@@ -12,5 +12,13 @@ namespace TwitchLib.Api.Helix.Models.Chat.Badges
         public string ImageUrl2x { get; protected set; }
         [JsonProperty(PropertyName = "image_url_4x")]
         public string ImageUrl4x { get; protected set; }
+        [JsonProperty(PropertyName = "title")]
+        public string Title { get; protected set; }
+        [JsonProperty(PropertyName = "description")]
+        public string Description { get; protected set; }
+        [JsonProperty(PropertyName = "click_action")]
+        public string? ClickAction { get; protected set; }
+        [JsonProperty(PropertyName = "click_url")]
+        public string? ClickUrl { get; protected set; }
     }
 }


### PR DESCRIPTION
Add support for the new return information, see [this announcement](https://discuss.dev.twitch.tv/t/legacy-badges-endpoint-shutdown-details-and-timeline-june-2023/44621)

Note: `ClickAction` and `ClickUrl` are nullable because twitch docs say set to `null` if not specified