### PR TITLE
Updated CreatedMarker ID from int to string

### DIFF
--- a/TwitchLib.Api.Helix.Models/Streams/CreateStreamMarker/CreatedMarker.cs
+++ b/TwitchLib.Api.Helix.Models/Streams/CreateStreamMarker/CreatedMarker.cs
@@ -6,7 +6,7 @@ namespace TwitchLib.Api.Helix.Models.Streams.CreateStreamMarker
     public class CreatedMarker
     {
         [JsonProperty(PropertyName = "id")]
-        public int Id { get; protected set; }
+        public string Id { get; protected set; }
         [JsonProperty(PropertyName = "created_at")]
         public DateTime CreatedAt { get; protected set; }
         [JsonProperty(PropertyName = "description")]


### PR DESCRIPTION
Changed the type of CreatedMarker ID to match the Twitch API: https://dev.twitch.tv/docs/api/reference/#create-stream-marker

When making a request to the TwitchAPI for creating a stream marker, I get an exception that it could not convert a string to an integer.