### PR TITLE
Update Chat Auth scope from 'chat:moderate' to 'channel:moderate'

### DIFF
--- a/TwitchLib.Api.Core.Enums/AuthScopesEnum.cs
+++ b/TwitchLib.Api.Core.Enums/AuthScopesEnum.cs
@@ -13,7 +13,7 @@
         Channel_Subscriptions,
         Chat_Read,
         Chat_Edit,
-        Chat_Moderate,
+        Channel_Moderate,
         Collections_Edit,
         Communities_Edit,
         Communities_Moderate,

--- a/TwitchLib.Api.Core/Common/Helpers.cs
+++ b/TwitchLib.Api.Core/Common/Helpers.cs
@@ -38,8 +38,8 @@ namespace TwitchLib.Api.Core.Common
                     return "channel_feed_read";
                 case AuthScopes.Chat_Read:
                     return "chat:read";
-                case AuthScopes.Chat_Moderate:
-                    return "chat:moderate";
+                case AuthScopes.Channel_Moderate:
+                    return "channel:moderate";
                 case AuthScopes.Chat_Edit:
                     return "chat:edit";
                 case AuthScopes.Channel_Read:

--- a/TwitchLib.Api/ThirdParty/AuthorizationFlow/PingResponse.cs
+++ b/TwitchLib.Api/ThirdParty/AuthorizationFlow/PingResponse.cs
@@ -68,7 +68,7 @@ namespace TwitchLib.Api.ThirdParty.AuthorizationFlow
                 case "chat:edit":
                     return AuthScopes.Chat_Edit;
                 case "chat:moderate":
-                    return AuthScopes.Chat_Moderate;
+                    return AuthScopes.Channel_Moderate;
                 case "channel_editor":
                     return AuthScopes.Channel_Editor;
                 case "channel_feed_read":


### PR DESCRIPTION
Hi, 

I noticed that the scope `chat:moderate` is not correct according to the reference. I updated with the correct scope `channel:moderate`. 

ref: https://dev.twitch.tv/docs/authentication/scopes/#chat-and-pubsub-scopes