### PR TITLE
Adding the "Helix_Moderator_Manage_Shoutouts" scope

### DIFF
--- a/TwitchLib.Api.Core.Enums/AuthScopesEnum.cs
+++ b/TwitchLib.Api.Core.Enums/AuthScopesEnum.cs
@@ -56,6 +56,7 @@
         Helix_Moderator_Manage_Automod_Settings,
         Helix_moderator_Manage_Chat_Messages,
         Helix_Moderator_Manage_Chat_Settings,
+        Helix_Moderator_Manage_Shoutouts,
         Helix_Moderator_Read_Blocked_Terms,
         Helix_Moderator_Read_Automod_Settings,
         Helix_Moderator_Read_Chat_Settings,

--- a/TwitchLib.Api.Core/Common/Helpers.cs
+++ b/TwitchLib.Api.Core/Common/Helpers.cs
@@ -154,6 +154,8 @@ namespace TwitchLib.Api.Core.Common
                     return "moderator:manage:chat_messages";
                 case AuthScopes.Helix_Moderator_Manage_Chat_Settings:
                     return "moderator:manage:chat_settings";
+                case AuthScopes.Helix_Moderator_Manage_Shoutouts:
+                    return "moderator:manage:shoutouts";
                 case AuthScopes.Helix_Moderator_Read_Automod_Settings:
                     return "moderator:read:automod_settings";
                 case AuthScopes.Helix_Moderator_Read_Blocked_Terms:


### PR DESCRIPTION
This scope was missing from TwitchLib's latest version, and the TwitchAPI.Helix.Chat.SendShoutoutAsync() call can't succeed without authenticating outside of TwitchLib's authentication process as a result.  Per Mahsaap's chat in Discord, this and other scopes were accidentally not committed in one of their previous checkins, so I thought I'd quietly come in and contribute.

Note: this is sort of untested 😅