### PR TITLE
Aligned Auth Scopes with Twitch docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -234,3 +234,5 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
+
+.idea/*

--- a/TwitchLib.Api.Core.Enums/AuthScopesEnum.cs
+++ b/TwitchLib.Api.Core.Enums/AuthScopesEnum.cs
@@ -1,77 +1,323 @@
-﻿namespace TwitchLib.Api.Core.Enums
+﻿using System;
+
+namespace TwitchLib.Api.Core.Enums
 {
     public enum AuthScopes
     {
+        /// <summary>
+        /// Any scope.
+        /// </summary>
         Any,
-        Channel_Check_Subscription,
-        Channel_Commercial,
-        Channel_Editor,
-        Channel_Feed_Edit,
-        Channel_Feed_Read,
-        Channel_Read,
-        Channel_Stream,
-        Channel_Subscriptions,
+        
+        /// <summary>
+        /// View live stream chat messages.
+        /// </summary>
         Chat_Read,
+        
+        /// <summary>
+        /// Send live stream chat messages.
+        /// </summary>
         Chat_Edit,
+        
+        /// <summary>
+        /// Perform moderation actions in a channel. The user requesting the scope must be a moderator in the channel.
+        /// </summary>
         Channel_Moderate,
-        Collections_Edit,
-        Communities_Edit,
-        Communities_Moderate,
-        User_Blocks_Edit,
-        User_Blocks_Read,
-        User_Follows_Edit,
-        User_Read,
-        User_Subscriptions,
-        Viewing_Activity_Read,
-        OpenId,
-        Helix_Analytics_Read_Extensions,
-        Helix_Analytics_Read_Games,
-        Helix_Bits_Read,
-        Helix_Channel_Edit_Commercial,
-        Helix_Channel_Manage_Broadcast,
-        Helix_Channel_Manage_Extensions,
-        Helix_Channel_Manage_Moderators,
-        Helix_Channel_Manage_Polls,
-        Helix_Channel_Manage_Predictions,
-        Helix_Channel_Manage_Redemptions,
-        Helix_Channel_Manage_Schedule,
-        Helix_Channel_Manage_Videos,
-        Helix_Channel_Manage_VIPs,
-        Helix_Channel_Read_Charity,
-        Helix_Channel_Read_Editors,
-        Helix_Channel_Read_Goals,
-        Helix_Channel_Read_Hype_Train,
-        Helix_Channel_Read_Polls,
-        Helix_Channel_Read_Predictions,
-        Helix_Channel_Read_Redemptions,
-        Helix_Channel_Read_Stream_Key,
-        Helix_Channel_Read_Subscriptions,
-        Helix_Channel_Read_VIPs,
-        Helix_Clips_Edit,
-        Helix_Moderation_Read,
-        Helix_Moderator_Manage_Banned_Users,
-        Helix_Moderator_Manage_Blocked_Terms,
-        Helix_Moderator_Manage_Announcements,
-        Helix_Moderator_Manage_Automod,
-        Helix_Moderator_Manage_Automod_Settings,
-        Helix_moderator_Manage_Chat_Messages,
-        Helix_Moderator_Manage_Chat_Settings,
-        Helix_Moderator_Read_Blocked_Terms,
-        Helix_Moderator_Read_Automod_Settings,
-        Helix_Moderator_Read_Chat_Settings,
-        Helix_Moderator_Read_Chatters,
-        Helix_User_Edit,
-        Helix_User_Edit_Broadcast,
-        Helix_User_Edit_Follows,
-        Helix_User_Manage_BlockedUsers,
-        Helix_User_Manage_Chat_Color,
-        Helix_User_Manage_Whispers,
-        Helix_User_Read_BlockedUsers,
-        Helix_User_Read_Broadcast,
-        Helix_User_Read_Email,
-        Helix_User_Read_Follows,
-        Helix_User_Read_Subscriptions,
-        Helix_Moderator_Read_Followers,
+        
+        /// <summary>
+        /// View your whisper messages.
+        /// </summary>
+        Whisper_Read,
+        
+        /// <summary>
+        /// Send whisper messages.
+        /// </summary>
+        Whisper_Edit,
+        
+        /// <summary>
+        /// View analytics data for the Twitch Extensions owned by the authenticated account.
+        /// </summary>
+        Analytics_Read_Extensions,
+        
+        /// <summary>
+        /// View analytics data for the games owned by the authenticated account.
+        /// </summary>
+        Analytics_Read_Games,
+        
+        /// <summary>
+        /// View Bits information for a channel.
+        /// </summary>
+        Bits_Read,
+        
+        /// <summary>
+        /// Run commercials on a channel.
+        /// </summary>
+        Channel_Edit_Commercial,
+        
+        /// <summary>
+        /// Manage a channel’s broadcast configuration, including updating channel configuration and managing stream markers and stream tags.
+        /// </summary>
+        Channel_Manage_Broadcast,
+        
+        /// <summary>
+        /// Manage a channel’s Extension configuration, including activating Extensions.
+        /// </summary>
+        Channel_Manage_Extensions,
+        
+        /// <summary>
+        /// Add or remove the moderator role from users in your channel.
+        /// </summary>
+        Channel_Manage_Moderators,
+        
+        /// <summary>
+        /// Manage a channel’s polls.
+        /// </summary>
+        Channel_Manage_Polls,
+        
+        /// <summary>
+        /// Manage of channel’s Channel Points Predictions
+        /// </summary>
+        Channel_Manage_Predictions,
+        
+        /// <summary>
+        /// Manage Channel Points custom rewards and their redemptions on a channel.
+        /// </summary>
+        Channel_Manage_Redemptions,
+        
+        /// <summary>
+        /// Manage a channel’s stream schedule.
+        /// </summary>
+        Channel_Manage_Schedule,
+        
+        /// <summary>
+        /// Manage Guest Star for your channel.
+        /// </summary>
+        Channel_Manage_Guest_Star,
+        
+        /// <summary>
+        /// Manage a channel raiding another channel.
+        /// </summary>
+        Channel_Manage_Raids,
+        
+        /// <summary>
+        /// Manage a channel’s videos, including deleting videos.
+        /// </summary>
+        Channel_Manage_Videos,
+        
+        /// <summary>
+        /// Add or remove the VIP role from users in your channel.
+        /// </summary>
+        Channel_Manage_VIPs,
+        
+        /// <summary>
+        /// Read charity campaign details and user donations on your channel.
+        /// </summary>
+        Channel_Read_Charity,
+        
+        /// <summary>
+        /// View a list of users with the editor role for a channel.
+        /// </summary>
+        Channel_Read_Editors,
+        
+        /// <summary>
+        /// View Creator Goals for a channel.
+        /// </summary>
+        Channel_Read_Goals,
+        
+        /// <summary>
+        /// View Hype Train information for a channel.
+        /// </summary>
+        Channel_Read_Hype_Train,
+        
+        /// <summary>
+        /// View a channel’s polls.
+        /// </summary>
+        Channel_Read_Polls,
+        
+        /// <summary>
+        /// View a channel’s Channel Points Predictions.
+        /// </summary>
+        Channel_Read_Predictions,
+        
+        /// <summary>
+        /// View Channel Points custom rewards and their redemptions on a channel.
+        /// </summary>
+        Channel_Read_Redemptions,
+        
+        /// <summary>
+        /// Read Guest Star details for your channel.
+        /// </summary>
+        Channel_Read_Guest_Star,
+        
+        /// <summary>
+        /// View an authorized user’s stream key.
+        /// </summary>
+        Channel_Read_Stream_Key,
+        
+        /// <summary>
+        /// View a list of all subscribers to a channel and check if a user is subscribed to a channel.
+        /// </summary>
+        Channel_Read_Subscriptions,
+        
+        /// <summary>
+        /// Read the list of VIPs in your channel.
+        /// </summary>
+        Channel_Read_VIPs,
+        
+        /// <summary>
+        /// Manage Clips for a channel.
+        /// </summary>
+        Clips_Edit,
+        
+        /// <summary>
+        /// View a channel’s moderation data including Moderators, Bans, Timeouts, and Automod settings.
+        /// </summary>
+        Moderation_Read,
+        
+        /// <summary>
+        /// Send announcements in channels where you have the moderator role.
+        /// </summary>
+        Moderator_Manage_Announcements,
+        
+        /// <summary>
+        /// Manage messages held for review by AutoMod in channels where you are a moderator.
+        /// </summary>
+        Moderator_Manage_Automod,
+        
+        /// <summary>
+        /// Manage a broadcaster’s AutoMod settings.
+        /// </summary>
+        Moderator_Manage_Automod_Settings,
+        
+        /// <summary>
+        /// Ban and unban users.
+        /// </summary>
+        Moderator_Manage_Banned_Users,
+        
+        /// <summary>
+        /// Manage a broadcaster’s list of blocked terms.
+        /// </summary>
+        Moderator_Manage_Blocked_Terms,
+        
+        /// <summary>
+        /// Delete chat messages in channels where you have the moderator role
+        /// </summary>
+        Moderator_Manage_Chat_Messages,
+        
+        /// <summary>
+        /// Manage a broadcaster’s chat room settings.
+        /// </summary>
+        Moderator_Manage_Chat_Settings,
+        
+        /// <summary>
+        /// Manage Guest Star for channels where you are a Guest Star moderator.
+        /// </summary>
+        Moderator_Manage_Guest_Star,
+        
+        /// <summary>
+        /// Manage a broadcaster’s Shield Mode status.
+        /// </summary>
+        Moderator_Manage_Shield_Mode,
+        
+        /// <summary>
+        /// Manage a broadcaster’s shoutouts.
+        /// </summary>
+        Moderator_Manage_Shoutouts,
+        
+        /// <summary>
+        /// View a broadcaster’s AutoMod settings.
+        /// </summary>
+        Moderator_Read_Automod_Settings,
+        
+        /// <summary>
+        /// View a broadcaster’s list of blocked terms.
+        /// </summary>
+        Moderator_Read_Blocked_Terms,
+        
+        /// <summary>
+        /// View a broadcaster’s chat room settings.
+        /// </summary>
+        Moderator_Read_Chat_Settings,
+        
+        /// <summary>
+        /// View the chatters in a broadcaster’s chat room.
+        /// </summary>
+        Moderator_Read_Chatters,
+        
+        /// <summary>
+        /// Read the followers of a broadcaster.
+        /// </summary>
+        Moderator_Read_Followers,
+        
+        /// <summary>
+        /// Read Guest Star details for channels where you are a Guest Star moderator.
+        /// </summary>
+        Moderator_Read_Guest_Star,
+        
+        /// <summary>
+        /// View a broadcaster’s Shield Mode status.
+        /// </summary>
+        Moderator_Read_Shield_Mode,
+        
+        /// <summary>
+        /// View a broadcaster’s shoutouts.
+        /// </summary>
+        Moderator_Read_Shoutouts,
+        
+        /// <summary>
+        /// Manage a user object.
+        /// </summary>
+        User_Edit,
+        
+        /// <summary>
+        /// Deprecated. Was previously used for “Create User Follows” and “Delete User Follows.”
+        /// </summary>
+        [Obsolete("Deprecated")]
+        User_Edit_Follows,
+        
+        /// <summary>
+        /// Manage the block list of a user.
+        /// </summary>
+        User_Manage_BlockedUsers,
+        
+        /// <summary>
+        /// Update the color used for the user’s name in chat.
+        /// </summary>
+        User_Manage_Chat_Color,
+        
+        /// <summary>
+        /// Read whispers that you send and receive, and send whispers on your behalf.
+        /// </summary>
+        User_Manage_Whispers,
+        
+        /// <summary>
+        /// View the block list of a user.
+        /// </summary>
+        User_Read_BlockedUsers,
+        
+        /// <summary>
+        /// View a user’s broadcasting configuration, including Extension configurations.
+        /// </summary>
+        User_Read_Broadcast,
+        
+        /// <summary>
+        /// View a user’s email address.
+        /// </summary>
+        User_Read_Email,
+        
+        /// <summary>
+        /// View the list of channels a user follows.
+        /// </summary>
+        User_Read_Follows,
+        
+        /// <summary>
+        /// View if an authorized user is subscribed to specific channels.
+        /// </summary>
+        User_Read_Subscriptions,
+        
+        /// <summary>
+        /// No scope
+        /// </summary>
         None
     }
 }

--- a/TwitchLib.Api.Core.Enums/TwitchLib.Api.Core.Enums.csproj
+++ b/TwitchLib.Api.Core.Enums/TwitchLib.Api.Core.Enums.csproj
@@ -21,6 +21,7 @@
     <AssemblyVersion>3.10.0</AssemblyVersion>
     <FileVersion>3.10.0</FileVersion>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/TwitchLib.Api.Core.Interfaces/TwitchLib.Api.Core.Interfaces.csproj
+++ b/TwitchLib.Api.Core.Interfaces/TwitchLib.Api.Core.Interfaces.csproj
@@ -21,6 +21,7 @@
     <AssemblyVersion>3.10.0</AssemblyVersion>
     <FileVersion>3.10.0</FileVersion>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/TwitchLib.Api.Core.Models/TwitchLib.Api.Core.Models.csproj
+++ b/TwitchLib.Api.Core.Models/TwitchLib.Api.Core.Models.csproj
@@ -21,6 +21,7 @@
     <AssemblyVersion>3.10.0</AssemblyVersion>
     <FileVersion>3.10.0</FileVersion>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/TwitchLib.Api.Core/ApiBase.cs
+++ b/TwitchLib.Api.Core/ApiBase.cs
@@ -112,7 +112,7 @@ namespace TwitchLib.Api.Core
             return await _rateLimiter.Perform(async () => JsonConvert.DeserializeObject<T>((await _http.GeneralRequestAsync(url, "PATCH", payload, api, clientId, accessToken).ConfigureAwait(false)).Value, _twitchLibJsonDeserializer)).ConfigureAwait(false);
         }
 
-        protected async Task<string> TwitchPatchAsync(string resource, ApiVersion api, string payload, List<KeyValuePair<string, string>> getParams = null, string accessToken = null, string clientId = null, string customBase = null)
+        protected async Task<KeyValuePair<int, string>> TwitchPatchAsync(string resource, ApiVersion api, string payload, List<KeyValuePair<string, string>> getParams = null, string accessToken = null, string clientId = null, string customBase = null)
         {
             var url = ConstructResourceUrl(resource, getParams, api, customBase);
 
@@ -122,7 +122,7 @@ namespace TwitchLib.Api.Core
             accessToken = await GetAccessTokenAsync(accessToken).ConfigureAwait(false);
             ForceAccessTokenAndClientIdForHelix(clientId, accessToken, api);
 
-            return await _rateLimiter.Perform(async () => (await _http.GeneralRequestAsync(url, "PATCH", payload, api, clientId, accessToken).ConfigureAwait(false)).Value).ConfigureAwait(false);
+            return await _rateLimiter.Perform(async () => (await _http.GeneralRequestAsync(url, "PATCH", payload, api, clientId, accessToken).ConfigureAwait(false))).ConfigureAwait(false);
         }
 
         protected async Task<KeyValuePair<int, string>> TwitchDeleteAsync(string resource, ApiVersion api, List<KeyValuePair<string, string>> getParams = null, string accessToken = null, string clientId = null, string customBase = null)

--- a/TwitchLib.Api.Core/Common/Helpers.cs
+++ b/TwitchLib.Api.Core/Common/Helpers.cs
@@ -24,135 +24,73 @@ namespace TwitchLib.Api.Core.Common
         /// <returns>Twitch scope string</returns>
         public static string AuthScopesToString(AuthScopes scope)
         {
-            switch (scope)
+            return scope switch
             {
-                case AuthScopes.Chat_Read:
-                    return "chat:read";
-                case AuthScopes.Channel_Moderate:
-                    return "channel:moderate";
-                case AuthScopes.Chat_Edit:
-                    return "chat:edit";
-                case AuthScopes.Whisper_Read:
-                    return "whispers:read";
-                case AuthScopes.Whisper_Edit:
-                    return "whispers:edit";
-                case AuthScopes.Analytics_Read_Extensions:
-                    return "analytics:read:extensions";
-                case AuthScopes.Analytics_Read_Games:
-                    return "analytics:read:games";
-                case AuthScopes.Bits_Read:
-                    return "bits:read";
-                case AuthScopes.Channel_Edit_Commercial:
-                    return "channel:edit:commercial";
-                case AuthScopes.Channel_Manage_Broadcast:
-                    return "channel:manage:broadcast";
-                case AuthScopes.Channel_Manage_Extensions:
-                    return "channel:manage:extensions";
-                case AuthScopes.Channel_Manage_Moderators:
-                    return "channel:manage:moderators";
-                case AuthScopes.Channel_Manage_Redemptions:
-                    return "channel:manage:redemptions";
-                case AuthScopes.Channel_Manage_Polls:
-                    return "channel:manage:polls";
-                case AuthScopes.Channel_Manage_Predictions:
-                    return "channel:manage:predictions";
-                case AuthScopes.Channel_Manage_Schedule:
-                    return "channel:manage:schedule";
-                case AuthScopes.Channel_Manage_Videos:
-                    return "channel:manage:videos";
-                case AuthScopes.Channel_Manage_VIPs:
-                    return "channel:manage:vips";
-                case AuthScopes.Channel_Manage_Guest_Star:
-                    return "channel:manage:guest_star";
-                case AuthScopes.Channel_Manage_Raids:
-                    return "channel:manage:raids";
-                case AuthScopes.Channel_Read_Charity:
-                    return "channel:read:charity";
-                case AuthScopes.Channel_Read_Editors:
-                    return "channel:read:editors";
-                case AuthScopes.Channel_Read_Goals:
-                    return "channel:read:goals";
-                case AuthScopes.Channel_Read_Hype_Train:
-                    return "channel:read:hype_train";
-                case AuthScopes.Channel_Read_Polls:
-                    return "channel:read:polls";
-                case AuthScopes.Channel_Read_Predictions:
-                    return "channel:read:predictions";
-                case AuthScopes.Channel_Read_Redemptions:
-                    return "channel:read:redemptions";
-                case AuthScopes.Channel_Read_Stream_Key:
-                    return "channel:read:stream_key";
-                case AuthScopes.Channel_Read_Subscriptions:
-                    return "channel:read:subscriptions";
-                case AuthScopes.Channel_Read_VIPs:
-                    return "channel:read:vips";
-                case AuthScopes.Channel_Read_Guest_Star:
-                    return "channel:read:guest_star";
-                case AuthScopes.Clips_Edit:
-                    return "clips:edit";
-                case AuthScopes.Moderation_Read:
-                    return "moderation:read";
-                case AuthScopes.User_Edit:
-                    return "user:edit";
-                case AuthScopes.User_Edit_Follows:
-                    return "user:edit:follows";
-                case AuthScopes.User_Read_BlockedUsers:
-                    return "user:read:blocked_users";
-                case AuthScopes.User_Read_Broadcast:
-                    return "user:read:broadcast";
-                case AuthScopes.User_Read_Email:
-                    return "user:read:email";
-                case AuthScopes.User_Read_Follows:
-                    return "user:read:follows";
-                case AuthScopes.User_Read_Subscriptions:
-                    return "user:read:subscriptions";
-                case AuthScopes.User_Manage_BlockedUsers:
-                    return "user:manage:blocked_users";
-                case AuthScopes.User_Manage_Chat_Color:
-                    return "user:manage:chat_color";
-                case AuthScopes.User_Manage_Whispers:
-                    return "user:manage:whispers";
-                case AuthScopes.Moderator_Manage_Announcements:
-                    return "moderator:manage:announcements";
-                case AuthScopes.Moderator_Manage_Automod:
-                    return "moderator:manage:automod";
-                case AuthScopes.Moderator_Manage_Automod_Settings:
-                    return "moderator:manage:automod_settings";
-                case AuthScopes.Moderator_Manage_Banned_Users:
-                    return "moderator:manage:banned_users";
-                case AuthScopes.Moderator_Manage_Blocked_Terms:
-                    return "moderator:manage:blocked_terms";
-                case AuthScopes.Moderator_Manage_Chat_Messages:
-                    return "moderator:manage:chat_messages";
-                case AuthScopes.Moderator_Manage_Chat_Settings:
-                    return "moderator:manage:chat_settings";
-                case AuthScopes.Moderator_Read_Automod_Settings:
-                    return "moderator:read:automod_settings";
-                case AuthScopes.Moderator_Read_Blocked_Terms:
-                    return "moderator:read:blocked_terms";
-                case AuthScopes.Moderator_Read_Chat_Settings:
-                    return "moderator:read:chat_settings";
-                case AuthScopes.Moderator_Read_Chatters:
-                    return "moderator:read:chatters";
-                case AuthScopes.Moderator_Read_Followers:
-                    return "moderator:read:followers";
-                case AuthScopes.Moderator_Read_Guest_Star:
-                    return "moderator:read:guest_star";
-                case AuthScopes.Moderator_Read_Shield_Mode:
-                    return "moderator:read:shield_mode";
-                case AuthScopes.Moderator_Read_Shoutouts:
-                    return "moderator:read:shoutouts";
-                case AuthScopes.Moderator_Manage_Guest_Star:
-                    return "moderator:manage:guest_star";
-                case AuthScopes.Moderator_Manage_Shield_Mode:
-                    return "moderator:manage:shield_mode";
-                case AuthScopes.Moderator_Manage_Shoutouts:
-                    return "moderator:manage:shoutouts";
-                case AuthScopes.Any:
-                case AuthScopes.None:
-                default:
-                    return string.Empty;
-            }
+                AuthScopes.Chat_Read => "chat:read",
+                AuthScopes.Channel_Moderate => "channel:moderate",
+                AuthScopes.Chat_Edit => "chat:edit",
+                AuthScopes.Whisper_Read => "whispers:read",
+                AuthScopes.Whisper_Edit => "whispers:edit",
+                AuthScopes.Analytics_Read_Extensions => "analytics:read:extensions",
+                AuthScopes.Analytics_Read_Games => "analytics:read:games",
+                AuthScopes.Bits_Read => "bits:read",
+                AuthScopes.Channel_Edit_Commercial => "channel:edit:commercial",
+                AuthScopes.Channel_Manage_Broadcast => "channel:manage:broadcast",
+                AuthScopes.Channel_Manage_Extensions => "channel:manage:extensions",
+                AuthScopes.Channel_Manage_Moderators => "channel:manage:moderators",
+                AuthScopes.Channel_Manage_Redemptions => "channel:manage:redemptions",
+                AuthScopes.Channel_Manage_Polls => "channel:manage:polls",
+                AuthScopes.Channel_Manage_Predictions => "channel:manage:predictions",
+                AuthScopes.Channel_Manage_Schedule => "channel:manage:schedule",
+                AuthScopes.Channel_Manage_Videos => "channel:manage:videos",
+                AuthScopes.Channel_Manage_VIPs => "channel:manage:vips",
+                AuthScopes.Channel_Manage_Guest_Star => "channel:manage:guest_star",
+                AuthScopes.Channel_Manage_Raids => "channel:manage:raids",
+                AuthScopes.Channel_Read_Charity => "channel:read:charity",
+                AuthScopes.Channel_Read_Editors => "channel:read:editors",
+                AuthScopes.Channel_Read_Goals => "channel:read:goals",
+                AuthScopes.Channel_Read_Hype_Train => "channel:read:hype_train",
+                AuthScopes.Channel_Read_Polls => "channel:read:polls",
+                AuthScopes.Channel_Read_Predictions => "channel:read:predictions",
+                AuthScopes.Channel_Read_Redemptions => "channel:read:redemptions",
+                AuthScopes.Channel_Read_Stream_Key => "channel:read:stream_key",
+                AuthScopes.Channel_Read_Subscriptions => "channel:read:subscriptions",
+                AuthScopes.Channel_Read_VIPs => "channel:read:vips",
+                AuthScopes.Channel_Read_Guest_Star => "channel:read:guest_star",
+                AuthScopes.Clips_Edit => "clips:edit",
+                AuthScopes.Moderation_Read => "moderation:read",
+                AuthScopes.User_Edit => "user:edit",
+                AuthScopes.User_Edit_Follows => "user:edit:follows",
+                AuthScopes.User_Read_BlockedUsers => "user:read:blocked_users",
+                AuthScopes.User_Read_Broadcast => "user:read:broadcast",
+                AuthScopes.User_Read_Email => "user:read:email",
+                AuthScopes.User_Read_Follows => "user:read:follows",
+                AuthScopes.User_Read_Subscriptions => "user:read:subscriptions",
+                AuthScopes.User_Manage_BlockedUsers => "user:manage:blocked_users",
+                AuthScopes.User_Manage_Chat_Color => "user:manage:chat_color",
+                AuthScopes.User_Manage_Whispers => "user:manage:whispers",
+                AuthScopes.Moderator_Manage_Announcements => "moderator:manage:announcements",
+                AuthScopes.Moderator_Manage_Automod => "moderator:manage:automod",
+                AuthScopes.Moderator_Manage_Automod_Settings => "moderator:manage:automod_settings",
+                AuthScopes.Moderator_Manage_Banned_Users => "moderator:manage:banned_users",
+                AuthScopes.Moderator_Manage_Blocked_Terms => "moderator:manage:blocked_terms",
+                AuthScopes.Moderator_Manage_Chat_Messages => "moderator:manage:chat_messages",
+                AuthScopes.Moderator_Manage_Chat_Settings => "moderator:manage:chat_settings",
+                AuthScopes.Moderator_Read_Automod_Settings => "moderator:read:automod_settings",
+                AuthScopes.Moderator_Read_Blocked_Terms => "moderator:read:blocked_terms",
+                AuthScopes.Moderator_Read_Chat_Settings => "moderator:read:chat_settings",
+                AuthScopes.Moderator_Read_Chatters => "moderator:read:chatters",
+                AuthScopes.Moderator_Read_Followers => "moderator:read:followers",
+                AuthScopes.Moderator_Read_Guest_Star => "moderator:read:guest_star",
+                AuthScopes.Moderator_Read_Shield_Mode => "moderator:read:shield_mode",
+                AuthScopes.Moderator_Read_Shoutouts => "moderator:read:shoutouts",
+                AuthScopes.Moderator_Manage_Guest_Star => "moderator:manage:guest_star",
+                AuthScopes.Moderator_Manage_Shield_Mode => "moderator:manage:shield_mode",
+                AuthScopes.Moderator_Manage_Shoutouts => "moderator:manage:shoutouts",
+                AuthScopes.Any => string.Empty,
+                AuthScopes.None => string.Empty,
+                _ => string.Empty
+            };
         }
 
         /// <summary>
@@ -162,135 +100,72 @@ namespace TwitchLib.Api.Core.Common
         /// <returns>Twitch scope as AuthScope</returns>
         public static AuthScopes StringToScope(string scope)
         {
-            switch (scope)
+            return scope switch
             {
-                case "chat:read":
-                    return AuthScopes.Chat_Read;
-                case "channel:moderate":
-                    return AuthScopes.Channel_Moderate;
-                case "chat:edit":
-                    return AuthScopes.Chat_Edit;
-                case "whispers:read":
-                    return AuthScopes.Whisper_Read;
-                case "whispers:edit":
-                    return AuthScopes.Whisper_Edit;
-                case "analytics:read:extensions":
-                    return AuthScopes.Analytics_Read_Extensions;
-                case "analytics:read:games":
-                    return AuthScopes.Analytics_Read_Games;
-                case "bits:read":
-                    return AuthScopes.Bits_Read;
-                case "channel:edit:commercial":
-                    return AuthScopes.Channel_Edit_Commercial;
-                case "channel:manage:broadcast":
-                    return AuthScopes.Channel_Manage_Broadcast;
-                case "channel:manage:extensions":
-                    return AuthScopes.Channel_Manage_Extensions;
-                case "channel:manage:moderators":
-                    return AuthScopes.Channel_Manage_Moderators;
-                case "channel:manage:redemptions":
-                    return AuthScopes.Channel_Manage_Redemptions;
-                case "channel:manage:polls":
-                    return AuthScopes.Channel_Manage_Polls;
-                case "channel:manage:predictions":
-                    return AuthScopes.Channel_Manage_Predictions;
-                case "channel:manage:schedule":
-                    return AuthScopes.Channel_Manage_Schedule;
-                case "channel:manage:videos":
-                    return AuthScopes.Channel_Manage_Videos;
-                case "channel:manage:vips":
-                    return AuthScopes.Channel_Manage_VIPs;
-                case "channel:manage:guest_star":
-                    return AuthScopes.Channel_Manage_Guest_Star;
-                case "channel:manage:raids":
-                    return AuthScopes.Channel_Manage_Raids;
-                case "channel:read:charity":
-                    return AuthScopes.Channel_Read_Charity;
-                case "channel:read:editors":
-                    return AuthScopes.Channel_Read_Editors;
-                case "channel:read:goals":
-                    return AuthScopes.Channel_Read_Goals;
-                case "channel:read:hype_train":
-                    return AuthScopes.Channel_Read_Hype_Train;
-                case "channel:read:polls":
-                    return AuthScopes.Channel_Read_Polls;
-                case "channel:read:predictions":
-                    return AuthScopes.Channel_Read_Predictions;
-                case "channel:read:redemptions":
-                    return AuthScopes.Channel_Read_Redemptions;
-                case "channel:read:stream_key":
-                    return AuthScopes.Channel_Read_Stream_Key;
-                case "channel:read:subscriptions":
-                    return AuthScopes.Channel_Read_Subscriptions;
-                case "channel:read:vips":
-                    return AuthScopes.Channel_Read_VIPs;
-                case "channel:read:guest_star":
-                    return AuthScopes.Channel_Read_Guest_Star;
-                case "clips:edit":
-                    return AuthScopes.Clips_Edit;
-                case "moderation:read":
-                    return AuthScopes.Moderation_Read;
-                case "user:edit":
-                    return AuthScopes.User_Edit;
-                case "user:edit:follows":
-                    return AuthScopes.User_Edit_Follows;
-                case "user:read:blocked_users":
-                    return AuthScopes.User_Read_BlockedUsers;
-                case "user:read:broadcast":
-                    return AuthScopes.User_Read_Broadcast;
-                case "user:read:email":
-                    return AuthScopes.User_Read_Email;
-                case "user:read:follows":
-                    return AuthScopes.User_Read_Follows;
-                case "user:read:subscriptions":
-                    return AuthScopes.User_Read_Subscriptions;
-                case "user:manage:blocked_users":
-                    return AuthScopes.User_Manage_BlockedUsers;
-                case "user:manage:chat_color":
-                    return AuthScopes.User_Manage_Chat_Color;
-                case "user:manage:whispers":
-                    return AuthScopes.User_Manage_Whispers;
-                case "moderator:manage:announcements":
-                    return AuthScopes.Moderator_Manage_Announcements;
-                case "moderator:manage:automod":
-                    return AuthScopes.Moderator_Manage_Automod;
-                case "moderator:manage:automod_settings":
-                    return AuthScopes.Moderator_Manage_Automod_Settings;
-                case "moderator:manage:banned_users":
-                    return AuthScopes.Moderator_Manage_Banned_Users;
-                case "moderator:manage:blocked_terms":
-                    return AuthScopes.Moderator_Manage_Blocked_Terms;
-                case "moderator:manage:chat_messages":
-                    return AuthScopes.Moderator_Manage_Chat_Messages;
-                case "moderator:manage:chat_settings":
-                    return AuthScopes.Moderator_Manage_Chat_Settings;
-                case "moderator:manage:guest_star":
-                    return AuthScopes.Moderator_Manage_Guest_Star;
-                case "moderator:manage:shield_mode":
-                    return AuthScopes.Moderator_Manage_Shield_Mode;
-                case "moderator:manage:shoutouts":
-                    return AuthScopes.Moderator_Manage_Shoutouts;
-                case "moderator:read:automod_settings":
-                    return AuthScopes.Moderator_Read_Automod_Settings;
-                case "moderator:read:blocked_terms":
-                    return AuthScopes.Moderator_Read_Blocked_Terms;
-                case "moderator:read:chat_settings":
-                    return AuthScopes.Moderator_Read_Chat_Settings;
-                case "moderator:read:chatters":
-                    return AuthScopes.Moderator_Read_Chatters;
-                case "moderator:read:followers":
-                    return AuthScopes.Moderator_Read_Followers;
-                case "moderator:read:guest_star":
-                    return AuthScopes.Moderator_Read_Guest_Star;
-                case "moderator:read:shield_mode":
-                    return AuthScopes.Moderator_Read_Shield_Mode;
-                case "moderator:read:shoutouts":
-                    return AuthScopes.Moderator_Read_Shoutouts;
-                case "":
-                    return AuthScopes.None;
-                default:
-                    throw new Exception("Unknown scope");
-            }
+                "chat:read" => AuthScopes.Chat_Read,
+                "channel:moderate" => AuthScopes.Channel_Moderate,
+                "chat:edit" => AuthScopes.Chat_Edit,
+                "whispers:read" => AuthScopes.Whisper_Read,
+                "whispers:edit" => AuthScopes.Whisper_Edit,
+                "analytics:read:extensions" => AuthScopes.Analytics_Read_Extensions,
+                "analytics:read:games" => AuthScopes.Analytics_Read_Games,
+                "bits:read" => AuthScopes.Bits_Read,
+                "channel:edit:commercial" => AuthScopes.Channel_Edit_Commercial,
+                "channel:manage:broadcast" => AuthScopes.Channel_Manage_Broadcast,
+                "channel:manage:extensions" => AuthScopes.Channel_Manage_Extensions,
+                "channel:manage:moderators" => AuthScopes.Channel_Manage_Moderators,
+                "channel:manage:redemptions" => AuthScopes.Channel_Manage_Redemptions,
+                "channel:manage:polls" => AuthScopes.Channel_Manage_Polls,
+                "channel:manage:predictions" => AuthScopes.Channel_Manage_Predictions,
+                "channel:manage:schedule" => AuthScopes.Channel_Manage_Schedule,
+                "channel:manage:videos" => AuthScopes.Channel_Manage_Videos,
+                "channel:manage:vips" => AuthScopes.Channel_Manage_VIPs,
+                "channel:manage:guest_star" => AuthScopes.Channel_Manage_Guest_Star,
+                "channel:manage:raids" => AuthScopes.Channel_Manage_Raids,
+                "channel:read:charity" => AuthScopes.Channel_Read_Charity,
+                "channel:read:editors" => AuthScopes.Channel_Read_Editors,
+                "channel:read:goals" => AuthScopes.Channel_Read_Goals,
+                "channel:read:hype_train" => AuthScopes.Channel_Read_Hype_Train,
+                "channel:read:polls" => AuthScopes.Channel_Read_Polls,
+                "channel:read:predictions" => AuthScopes.Channel_Read_Predictions,
+                "channel:read:redemptions" => AuthScopes.Channel_Read_Redemptions,
+                "channel:read:stream_key" => AuthScopes.Channel_Read_Stream_Key,
+                "channel:read:subscriptions" => AuthScopes.Channel_Read_Subscriptions,
+                "channel:read:vips" => AuthScopes.Channel_Read_VIPs,
+                "channel:read:guest_star" => AuthScopes.Channel_Read_Guest_Star,
+                "clips:edit" => AuthScopes.Clips_Edit,
+                "moderation:read" => AuthScopes.Moderation_Read,
+                "user:edit" => AuthScopes.User_Edit,
+                "user:edit:follows" => AuthScopes.User_Edit_Follows,
+                "user:read:blocked_users" => AuthScopes.User_Read_BlockedUsers,
+                "user:read:broadcast" => AuthScopes.User_Read_Broadcast,
+                "user:read:email" => AuthScopes.User_Read_Email,
+                "user:read:follows" => AuthScopes.User_Read_Follows,
+                "user:read:subscriptions" => AuthScopes.User_Read_Subscriptions,
+                "user:manage:blocked_users" => AuthScopes.User_Manage_BlockedUsers,
+                "user:manage:chat_color" => AuthScopes.User_Manage_Chat_Color,
+                "user:manage:whispers" => AuthScopes.User_Manage_Whispers,
+                "moderator:manage:announcements" => AuthScopes.Moderator_Manage_Announcements,
+                "moderator:manage:automod" => AuthScopes.Moderator_Manage_Automod,
+                "moderator:manage:automod_settings" => AuthScopes.Moderator_Manage_Automod_Settings,
+                "moderator:manage:banned_users" => AuthScopes.Moderator_Manage_Banned_Users,
+                "moderator:manage:blocked_terms" => AuthScopes.Moderator_Manage_Blocked_Terms,
+                "moderator:manage:chat_messages" => AuthScopes.Moderator_Manage_Chat_Messages,
+                "moderator:manage:chat_settings" => AuthScopes.Moderator_Manage_Chat_Settings,
+                "moderator:manage:guest_star" => AuthScopes.Moderator_Manage_Guest_Star,
+                "moderator:manage:shield_mode" => AuthScopes.Moderator_Manage_Shield_Mode,
+                "moderator:manage:shoutouts" => AuthScopes.Moderator_Manage_Shoutouts,
+                "moderator:read:automod_settings" => AuthScopes.Moderator_Read_Automod_Settings,
+                "moderator:read:blocked_terms" => AuthScopes.Moderator_Read_Blocked_Terms,
+                "moderator:read:chat_settings" => AuthScopes.Moderator_Read_Chat_Settings,
+                "moderator:read:chatters" => AuthScopes.Moderator_Read_Chatters,
+                "moderator:read:followers" => AuthScopes.Moderator_Read_Followers,
+                "moderator:read:guest_star" => AuthScopes.Moderator_Read_Guest_Star,
+                "moderator:read:shield_mode" => AuthScopes.Moderator_Read_Shield_Mode,
+                "moderator:read:shoutouts" => AuthScopes.Moderator_Read_Shoutouts,
+                "" => AuthScopes.None,
+                _ => throw new Exception("Unknown scope")
+            };
         }
 
         /// <summary>

--- a/TwitchLib.Api.Core/Common/Helpers.cs
+++ b/TwitchLib.Api.Core/Common/Helpers.cs
@@ -26,148 +26,270 @@ namespace TwitchLib.Api.Core.Common
         {
             switch (scope)
             {
-                case AuthScopes.Channel_Check_Subscription:
-                    return "channel_check_subscription";
-                case AuthScopes.Channel_Commercial:
-                    return "channel_commercial";
-                case AuthScopes.Channel_Editor:
-                    return "channel_editor";
-                case AuthScopes.Channel_Feed_Edit:
-                    return "channel_feed_edit";
-                case AuthScopes.Channel_Feed_Read:
-                    return "channel_feed_read";
                 case AuthScopes.Chat_Read:
                     return "chat:read";
                 case AuthScopes.Channel_Moderate:
                     return "channel:moderate";
                 case AuthScopes.Chat_Edit:
                     return "chat:edit";
-                case AuthScopes.Channel_Read:
-                    return "channel_read";
-                case AuthScopes.Channel_Stream:
-                    return "channel_stream";
-                case AuthScopes.Channel_Subscriptions:
-                    return "channel_subscriptions";
-                case AuthScopes.Collections_Edit:
-                    return "collections_edit";
-                case AuthScopes.Communities_Edit:
-                    return "communities_edit";
-                case AuthScopes.Communities_Moderate:
-                    return "communities_moderate";
-                case AuthScopes.OpenId:
-                    return "openid";
-                case AuthScopes.User_Blocks_Edit:
-                    return "user_blocks_edit";
-                case AuthScopes.User_Blocks_Read:
-                    return "user_blocks_read";
-                case AuthScopes.User_Follows_Edit:
-                    return "user_follows_edit";
-                case AuthScopes.User_Read:
-                    return "user_read";
-                case AuthScopes.User_Subscriptions:
-                    return "user_subscriptions";
-                case AuthScopes.Viewing_Activity_Read:
-                    return "viewing_activity_read";
-                case AuthScopes.Helix_Analytics_Read_Extensions:
+                case AuthScopes.Whisper_Read:
+                    return "whispers:read";
+                case AuthScopes.Whisper_Edit:
+                    return "whispers:edit";
+                case AuthScopes.Analytics_Read_Extensions:
                     return "analytics:read:extensions";
-                case AuthScopes.Helix_Analytics_Read_Games:
+                case AuthScopes.Analytics_Read_Games:
                     return "analytics:read:games";
-                case AuthScopes.Helix_Bits_Read:
+                case AuthScopes.Bits_Read:
                     return "bits:read";
-                case AuthScopes.Helix_Channel_Edit_Commercial:
+                case AuthScopes.Channel_Edit_Commercial:
                     return "channel:edit:commercial";
-                case AuthScopes.Helix_Channel_Manage_Broadcast:
+                case AuthScopes.Channel_Manage_Broadcast:
                     return "channel:manage:broadcast";
-                case AuthScopes.Helix_Channel_Manage_Extensions:
+                case AuthScopes.Channel_Manage_Extensions:
                     return "channel:manage:extensions";
-                case AuthScopes.Helix_Channel_Manage_Moderators:
+                case AuthScopes.Channel_Manage_Moderators:
                     return "channel:manage:moderators";
-                case AuthScopes.Helix_Channel_Manage_Redemptions:
+                case AuthScopes.Channel_Manage_Redemptions:
                     return "channel:manage:redemptions";
-                case AuthScopes.Helix_Channel_Manage_Polls:
+                case AuthScopes.Channel_Manage_Polls:
                     return "channel:manage:polls";
-                case AuthScopes.Helix_Channel_Manage_Predictions:
+                case AuthScopes.Channel_Manage_Predictions:
                     return "channel:manage:predictions";
-                case AuthScopes.Helix_Channel_Manage_Schedule:
+                case AuthScopes.Channel_Manage_Schedule:
                     return "channel:manage:schedule";
-                case AuthScopes.Helix_Channel_Manage_Videos:
+                case AuthScopes.Channel_Manage_Videos:
                     return "channel:manage:videos";
-                case AuthScopes.Helix_Channel_Manage_VIPs:
+                case AuthScopes.Channel_Manage_VIPs:
                     return "channel:manage:vips";
-                case AuthScopes.Helix_Channel_Read_Charity:
+                case AuthScopes.Channel_Manage_Guest_Star:
+                    return "channel:manage:guest_star";
+                case AuthScopes.Channel_Manage_Raids:
+                    return "channel:manage:raids";
+                case AuthScopes.Channel_Read_Charity:
                     return "channel:read:charity";
-                case AuthScopes.Helix_Channel_Read_Editors:
+                case AuthScopes.Channel_Read_Editors:
                     return "channel:read:editors";
-                case AuthScopes.Helix_Channel_Read_Goals:
+                case AuthScopes.Channel_Read_Goals:
                     return "channel:read:goals";
-                case AuthScopes.Helix_Channel_Read_Hype_Train:
+                case AuthScopes.Channel_Read_Hype_Train:
                     return "channel:read:hype_train";
-                case AuthScopes.Helix_Channel_Read_Polls:
+                case AuthScopes.Channel_Read_Polls:
                     return "channel:read:polls";
-                case AuthScopes.Helix_Channel_Read_Predictions:
+                case AuthScopes.Channel_Read_Predictions:
                     return "channel:read:predictions";
-                case AuthScopes.Helix_Channel_Read_Redemptions:
+                case AuthScopes.Channel_Read_Redemptions:
                     return "channel:read:redemptions";
-                case AuthScopes.Helix_Channel_Read_Stream_Key:
+                case AuthScopes.Channel_Read_Stream_Key:
                     return "channel:read:stream_key";
-                case AuthScopes.Helix_Channel_Read_Subscriptions:
+                case AuthScopes.Channel_Read_Subscriptions:
                     return "channel:read:subscriptions";
-                case AuthScopes.Helix_Channel_Read_VIPs:
+                case AuthScopes.Channel_Read_VIPs:
                     return "channel:read:vips";
-                case AuthScopes.Helix_Clips_Edit:
+                case AuthScopes.Channel_Read_Guest_Star:
+                    return "channel:read:guest_star";
+                case AuthScopes.Clips_Edit:
                     return "clips:edit";
-                case AuthScopes.Helix_Moderation_Read:
+                case AuthScopes.Moderation_Read:
                     return "moderation:read";
-                case AuthScopes.Helix_User_Edit:
+                case AuthScopes.User_Edit:
                     return "user:edit";
-                case AuthScopes.Helix_User_Edit_Broadcast:
-                    return "user:edit:broadcast";
-                case AuthScopes.Helix_User_Edit_Follows:
+                case AuthScopes.User_Edit_Follows:
                     return "user:edit:follows";
-                case AuthScopes.Helix_User_Read_BlockedUsers:
+                case AuthScopes.User_Read_BlockedUsers:
                     return "user:read:blocked_users";
-                case AuthScopes.Helix_User_Read_Broadcast:
+                case AuthScopes.User_Read_Broadcast:
                     return "user:read:broadcast";
-                case AuthScopes.Helix_User_Read_Email:
+                case AuthScopes.User_Read_Email:
                     return "user:read:email";
-                case AuthScopes.Helix_User_Read_Follows:
+                case AuthScopes.User_Read_Follows:
                     return "user:read:follows";
-                case AuthScopes.Helix_User_Read_Subscriptions:
+                case AuthScopes.User_Read_Subscriptions:
                     return "user:read:subscriptions";
-                case AuthScopes.Helix_User_Manage_BlockedUsers:
+                case AuthScopes.User_Manage_BlockedUsers:
                     return "user:manage:blocked_users";
-                case AuthScopes.Helix_User_Manage_Chat_Color:
+                case AuthScopes.User_Manage_Chat_Color:
                     return "user:manage:chat_color";
-                case AuthScopes.Helix_User_Manage_Whispers:
+                case AuthScopes.User_Manage_Whispers:
                     return "user:manage:whispers";
-                case AuthScopes.Helix_Moderator_Manage_Announcements:
+                case AuthScopes.Moderator_Manage_Announcements:
                     return "moderator:manage:announcements";
-                case AuthScopes.Helix_Moderator_Manage_Automod:
+                case AuthScopes.Moderator_Manage_Automod:
                     return "moderator:manage:automod";
-                case AuthScopes.Helix_Moderator_Manage_Automod_Settings:
+                case AuthScopes.Moderator_Manage_Automod_Settings:
                     return "moderator:manage:automod_settings";
-                case AuthScopes.Helix_Moderator_Manage_Banned_Users:
+                case AuthScopes.Moderator_Manage_Banned_Users:
                     return "moderator:manage:banned_users";
-                case AuthScopes.Helix_Moderator_Manage_Blocked_Terms:
+                case AuthScopes.Moderator_Manage_Blocked_Terms:
                     return "moderator:manage:blocked_terms";
-                case AuthScopes.Helix_moderator_Manage_Chat_Messages:
+                case AuthScopes.Moderator_Manage_Chat_Messages:
                     return "moderator:manage:chat_messages";
-                case AuthScopes.Helix_Moderator_Manage_Chat_Settings:
+                case AuthScopes.Moderator_Manage_Chat_Settings:
                     return "moderator:manage:chat_settings";
-                case AuthScopes.Helix_Moderator_Read_Automod_Settings:
+                case AuthScopes.Moderator_Read_Automod_Settings:
                     return "moderator:read:automod_settings";
-                case AuthScopes.Helix_Moderator_Read_Blocked_Terms:
+                case AuthScopes.Moderator_Read_Blocked_Terms:
                     return "moderator:read:blocked_terms";
-                case AuthScopes.Helix_Moderator_Read_Chat_Settings:
+                case AuthScopes.Moderator_Read_Chat_Settings:
                     return "moderator:read:chat_settings";
-                case AuthScopes.Helix_Moderator_Read_Chatters:
+                case AuthScopes.Moderator_Read_Chatters:
                     return "moderator:read:chatters";
-                case AuthScopes.Helix_Moderator_Read_Followers:
+                case AuthScopes.Moderator_Read_Followers:
                     return "moderator:read:followers";
+                case AuthScopes.Moderator_Read_Guest_Star:
+                    return "moderator:read:guest_star";
+                case AuthScopes.Moderator_Read_Shield_Mode:
+                    return "moderator:read:shield_mode";
+                case AuthScopes.Moderator_Read_Shoutouts:
+                    return "moderator:read:shoutouts";
+                case AuthScopes.Moderator_Manage_Guest_Star:
+                    return "moderator:manage:guest_star";
+                case AuthScopes.Moderator_Manage_Shield_Mode:
+                    return "moderator:manage:shield_mode";
+                case AuthScopes.Moderator_Manage_Shoutouts:
+                    return "moderator:manage:shoutouts";
                 case AuthScopes.Any:
                 case AuthScopes.None:
                 default:
-                    return "";
+                    return string.Empty;
+            }
+        }
+
+        /// <summary>
+        /// Converts Twitch string to AuthScope enum.
+        /// </summary>
+        /// <param name="scope">Scope as twitch string</param>
+        /// <returns>Twitch scope as AuthScope</returns>
+        public static AuthScopes StringToScope(string scope)
+        {
+            switch (scope)
+            {
+                case "chat:read":
+                    return AuthScopes.Chat_Read;
+                case "channel:moderate":
+                    return AuthScopes.Channel_Moderate;
+                case "chat:edit":
+                    return AuthScopes.Chat_Edit;
+                case "whispers:read":
+                    return AuthScopes.Whisper_Read;
+                case "whispers:edit":
+                    return AuthScopes.Whisper_Edit;
+                case "analytics:read:extensions":
+                    return AuthScopes.Analytics_Read_Extensions;
+                case "analytics:read:games":
+                    return AuthScopes.Analytics_Read_Games;
+                case "bits:read":
+                    return AuthScopes.Bits_Read;
+                case "channel:edit:commercial":
+                    return AuthScopes.Channel_Edit_Commercial;
+                case "channel:manage:broadcast":
+                    return AuthScopes.Channel_Manage_Broadcast;
+                case "channel:manage:extensions":
+                    return AuthScopes.Channel_Manage_Extensions;
+                case "channel:manage:moderators":
+                    return AuthScopes.Channel_Manage_Moderators;
+                case "channel:manage:redemptions":
+                    return AuthScopes.Channel_Manage_Redemptions;
+                case "channel:manage:polls":
+                    return AuthScopes.Channel_Manage_Polls;
+                case "channel:manage:predictions":
+                    return AuthScopes.Channel_Manage_Predictions;
+                case "channel:manage:schedule":
+                    return AuthScopes.Channel_Manage_Schedule;
+                case "channel:manage:videos":
+                    return AuthScopes.Channel_Manage_Videos;
+                case "channel:manage:vips":
+                    return AuthScopes.Channel_Manage_VIPs;
+                case "channel:manage:guest_star":
+                    return AuthScopes.Channel_Manage_Guest_Star;
+                case "channel:manage:raids":
+                    return AuthScopes.Channel_Manage_Raids;
+                case "channel:read:charity":
+                    return AuthScopes.Channel_Read_Charity;
+                case "channel:read:editors":
+                    return AuthScopes.Channel_Read_Editors;
+                case "channel:read:goals":
+                    return AuthScopes.Channel_Read_Goals;
+                case "channel:read:hype_train":
+                    return AuthScopes.Channel_Read_Hype_Train;
+                case "channel:read:polls":
+                    return AuthScopes.Channel_Read_Polls;
+                case "channel:read:predictions":
+                    return AuthScopes.Channel_Read_Predictions;
+                case "channel:read:redemptions":
+                    return AuthScopes.Channel_Read_Redemptions;
+                case "channel:read:stream_key":
+                    return AuthScopes.Channel_Read_Stream_Key;
+                case "channel:read:subscriptions":
+                    return AuthScopes.Channel_Read_Subscriptions;
+                case "channel:read:vips":
+                    return AuthScopes.Channel_Read_VIPs;
+                case "channel:read:guest_star":
+                    return AuthScopes.Channel_Read_Guest_Star;
+                case "clips:edit":
+                    return AuthScopes.Clips_Edit;
+                case "moderation:read":
+                    return AuthScopes.Moderation_Read;
+                case "user:edit":
+                    return AuthScopes.User_Edit;
+                case "user:edit:follows":
+                    return AuthScopes.User_Edit_Follows;
+                case "user:read:blocked_users":
+                    return AuthScopes.User_Read_BlockedUsers;
+                case "user:read:broadcast":
+                    return AuthScopes.User_Read_Broadcast;
+                case "user:read:email":
+                    return AuthScopes.User_Read_Email;
+                case "user:read:follows":
+                    return AuthScopes.User_Read_Follows;
+                case "user:read:subscriptions":
+                    return AuthScopes.User_Read_Subscriptions;
+                case "user:manage:blocked_users":
+                    return AuthScopes.User_Manage_BlockedUsers;
+                case "user:manage:chat_color":
+                    return AuthScopes.User_Manage_Chat_Color;
+                case "user:manage:whispers":
+                    return AuthScopes.User_Manage_Whispers;
+                case "moderator:manage:announcements":
+                    return AuthScopes.Moderator_Manage_Announcements;
+                case "moderator:manage:automod":
+                    return AuthScopes.Moderator_Manage_Automod;
+                case "moderator:manage:automod_settings":
+                    return AuthScopes.Moderator_Manage_Automod_Settings;
+                case "moderator:manage:banned_users":
+                    return AuthScopes.Moderator_Manage_Banned_Users;
+                case "moderator:manage:blocked_terms":
+                    return AuthScopes.Moderator_Manage_Blocked_Terms;
+                case "moderator:manage:chat_messages":
+                    return AuthScopes.Moderator_Manage_Chat_Messages;
+                case "moderator:manage:chat_settings":
+                    return AuthScopes.Moderator_Manage_Chat_Settings;
+                case "moderator:manage:guest_star":
+                    return AuthScopes.Moderator_Manage_Guest_Star;
+                case "moderator:manage:shield_mode":
+                    return AuthScopes.Moderator_Manage_Shield_Mode;
+                case "moderator:manage:shoutouts":
+                    return AuthScopes.Moderator_Manage_Shoutouts;
+                case "moderator:read:automod_settings":
+                    return AuthScopes.Moderator_Read_Automod_Settings;
+                case "moderator:read:blocked_terms":
+                    return AuthScopes.Moderator_Read_Blocked_Terms;
+                case "moderator:read:chat_settings":
+                    return AuthScopes.Moderator_Read_Chat_Settings;
+                case "moderator:read:chatters":
+                    return AuthScopes.Moderator_Read_Chatters;
+                case "moderator:read:followers":
+                    return AuthScopes.Moderator_Read_Followers;
+                case "moderator:read:guest_star":
+                    return AuthScopes.Moderator_Read_Guest_Star;
+                case "moderator:read:shield_mode":
+                    return AuthScopes.Moderator_Read_Shield_Mode;
+                case "moderator:read:shoutouts":
+                    return AuthScopes.Moderator_Read_Shoutouts;
+                case "":
+                    return AuthScopes.None;
+                default:
+                    throw new Exception("Unknown scope");
             }
         }
 

--- a/TwitchLib.Api.Core/TwitchLib.Api.Core.csproj
+++ b/TwitchLib.Api.Core/TwitchLib.Api.Core.csproj
@@ -21,6 +21,7 @@
     <AssemblyVersion>3.10.0</AssemblyVersion>
     <FileVersion>3.10.0</FileVersion>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TwitchLib.Api.Helix.Models/TwitchLib.Api.Helix.Models.csproj
+++ b/TwitchLib.Api.Helix.Models/TwitchLib.Api.Helix.Models.csproj
@@ -21,6 +21,7 @@
     <AssemblyVersion>3.10.0</AssemblyVersion>
     <FileVersion>3.10.0</FileVersion>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TwitchLib.Api.Helix/Channels.cs
+++ b/TwitchLib.Api.Helix/Channels.cs
@@ -56,7 +56,7 @@ namespace TwitchLib.Api.Helix
         /// <param name="accessToken">optional access token to override the use of the stored one in the TwitchAPI instance</param>
         /// <returns></returns>
         /// <exception cref="BadParameterException"></exception>
-        public Task ModifyChannelInformationAsync(string broadcasterId, ModifyChannelInformationRequest request, string accessToken = null)
+        public async Task<bool> ModifyChannelInformationAsync(string broadcasterId, ModifyChannelInformationRequest request, string accessToken = null)
         {
             if (string.IsNullOrEmpty(broadcasterId))
                 throw new BadParameterException("broadcasterId must be set");
@@ -66,7 +66,10 @@ namespace TwitchLib.Api.Helix
                 new KeyValuePair<string, string>("broadcaster_id", broadcasterId)
             };
 
-            return TwitchPatchAsync("/channels", ApiVersion.Helix, JsonConvert.SerializeObject(request), getParams, accessToken);
+            var response = await TwitchPatchAsync("/channels", ApiVersion.Helix, JsonConvert.SerializeObject(request), getParams, accessToken);
+
+            // Successfully updated the channel's properties if return code is 204 (No Content)
+            return response.Key == 204;
         }
         #endregion
 

--- a/TwitchLib.Api.Helix/TwitchLib.Api.Helix.csproj
+++ b/TwitchLib.Api.Helix/TwitchLib.Api.Helix.csproj
@@ -21,6 +21,7 @@
     <AssemblyVersion>3.10.0</AssemblyVersion>
     <FileVersion>3.10.0</FileVersion>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\TwitchLib.Api.Core\TwitchLib.Api.Core.csproj" />

--- a/TwitchLib.Api.Test/TwitchLib.Api.Test.csproj
+++ b/TwitchLib.Api.Test/TwitchLib.Api.Test.csproj
@@ -6,6 +6,8 @@
     <IsPackable>false</IsPackable>
 
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
+
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TwitchLib.Api/ThirdParty/AuthorizationFlow/PingResponse.cs
+++ b/TwitchLib.Api/ThirdParty/AuthorizationFlow/PingResponse.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 using TwitchLib.Api.Core.Enums;
 
@@ -31,106 +30,12 @@ namespace TwitchLib.Api.ThirdParty.AuthorizationFlow
             {
                 Scopes = new List<AuthScopes>();
                 foreach (var scope in json.SelectToken("scopes"))
-                    Scopes.Add(StringToScope(scope.ToString()));
+                    Scopes.Add(Core.Common.Helpers.StringToScope(scope.ToString()));
                 Token = json.SelectToken("token").ToString();
                 Refresh = json.SelectToken("refresh").ToString();
                 Username = json.SelectToken("username").ToString();
                 ClientId = json.SelectToken("client_id").ToString();
             }
         }
-
-        private AuthScopes StringToScope(string scope)
-        {
-            switch (scope)
-            {
-                case "user_read":
-                    return AuthScopes.User_Read;
-                case "user_blocks_edit":
-                    return AuthScopes.User_Blocks_Edit;
-                case "user_blocks_read":
-                    return AuthScopes.User_Blocks_Read;
-                case "user_follows_edit":
-                    return AuthScopes.User_Follows_Edit;
-                case "channel_read":
-                    return AuthScopes.Channel_Read;
-                case "channel_commercial":
-                    return AuthScopes.Channel_Commercial;
-                case "channel_stream":
-                    return AuthScopes.Channel_Subscriptions;
-                case "channel_subscriptions":
-                    return AuthScopes.Channel_Subscriptions;
-                case "user_subscriptions":
-                    return AuthScopes.User_Subscriptions;
-                case "channel_check_subscription":
-                    return AuthScopes.Channel_Check_Subscription;
-                case "chat:read":
-                    return AuthScopes.Chat_Read;
-                case "chat:edit":
-                    return AuthScopes.Chat_Edit;
-                case "chat:moderate":
-                    return AuthScopes.Channel_Moderate;
-                case "channel_editor":
-                    return AuthScopes.Channel_Editor;
-                case "channel_feed_read":
-                    return AuthScopes.Channel_Feed_Read;
-                case "channel_feed_edit":
-                    return AuthScopes.Channel_Feed_Edit;
-                case "collections_edit":
-                    return AuthScopes.Collections_Edit;
-                case "communities_edit":
-                    return AuthScopes.Communities_Edit;
-                case "communities_moderate":
-                    return AuthScopes.Communities_Moderate;
-                case "viewing_activity_read":
-                    return AuthScopes.Viewing_Activity_Read;
-                case "user:edit":
-                    return AuthScopes.Helix_User_Edit;
-                case "user:read:email":
-                    return AuthScopes.Helix_User_Read_Email;
-                case "clips:edit":
-                    return AuthScopes.Helix_Clips_Edit;
-                case "analytics:read:games":
-                    return AuthScopes.Helix_Analytics_Read_Games;
-                case "bits:read":
-                    return AuthScopes.Helix_Bits_Read;
-                case "channel:read:subscriptions":
-                    return AuthScopes.Helix_Channel_Read_Subscriptions;
-                case "channel:read:hype_train":
-                    return AuthScopes.Helix_Channel_Read_Hype_Train;
-                case "channel:manage:redemptions":
-                    return AuthScopes.Helix_Channel_Manage_Redemptions;
-                case "channel:edit:commercial":
-                    return AuthScopes.Helix_Channel_Edit_Commercial;
-                case "channel:read:stream_key":
-                    return AuthScopes.Helix_Channel_Read_Stream_Key;
-                case "channel:read:editors":
-                    return AuthScopes.Helix_Channel_Read_Editors;
-                case "channel:manage:videos":
-                    return AuthScopes.Helix_Channel_Manage_Videos;
-                case "user:read:blocked_users":
-                    return AuthScopes.Helix_User_Read_BlockedUsers;
-                case "user:manage:blocked_users":
-                    return AuthScopes.Helix_User_Manage_BlockedUsers;
-                case "user:read:subscriptions":
-                    return AuthScopes.Helix_User_Read_Subscriptions;
-                case "channel:manage:polls":
-                    return AuthScopes.Helix_Channel_Manage_Polls;
-                case "channel:manage:predictions":
-                    return AuthScopes.Helix_Channel_Manage_Predictions;
-                case "channel:read:polls":
-                    return AuthScopes.Helix_Channel_Read_Polls;
-                case "channel:read:predictions":
-                    return AuthScopes.Helix_Channel_Read_Predictions;
-                case "moderator:manage:automod":
-                    return AuthScopes.Helix_Moderator_Manage_Automod;
-                case "moderator:read:chatters":
-                    return AuthScopes.Helix_Moderator_Read_Chatters;
-                case "":
-                    return AuthScopes.None;
-                default:
-                    throw new Exception("Unknown scope");
-            }
-        }
-
     }
 }

--- a/TwitchLib.Api/TwitchLib.Api.csproj
+++ b/TwitchLib.Api/TwitchLib.Api.csproj
@@ -21,6 +21,7 @@
     <AssemblyVersion>3.10.0</AssemblyVersion>
     <FileVersion>3.10.0</FileVersion>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />


### PR DESCRIPTION
## Auth Scopes fixes

* Added documentation to Auth Scopes
* Moved `ScopeToString` method from `PingResponse` to `Helpers` so it's together with other parsing method
* Corrected old `chat:moderate` to `channel:moderate` in `ScopeToString` (this was forgotten in the previous PR)
* Removed scope `user:edit:broadcast` which is no longer valid
* Removed all old v5 scopes (like `openid`, `channel_read`, or `channel_editor`)
* Added new Auth scopes:
   * Channel_Read_Guest_Star - `channel:read:guest_star`
   * Channel_Manage_Guest_Star - `channel:manage:guest_star`
   * Channel_Manage_Raids - `channel:manage:raids`
   * Moderator_Read_Guest_Star - `moderator:read:guest_star`
   * Moderator_Read_Shield_Mode - `moderator:read:shield_mode`
   * Moderator_Read_Shoutouts - `moderator:read:shoutouts`
   * Moderator_Manage_Guest_Star - `moderator:manage:shield_mode`
   * Moderator_Manage_Shield_Mode - `moderator:manage:guest_star`
   * Moderator_Manage_Shoutouts - `moderator:manage:shoutouts`
   * Whisper_Read - `whispers:read`
   * Whisper_Edit - `whispers:edit`

## Minor improvements
* Updated `TwitchPatchAsync` in `ApiBase` to return KeyValuePair
* Updated `ModifyChannelInformationAsync` in `Channel` to return bool if the modification was successful.
* Extended `.gitignore` to ignore JetBrain's Rider files
* Updated C# language from 7.3 to latest