### PR TITLE
Adding support for transparent User Access Tokens to TwitchLib.API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # TwitchLib.Api
 API component of TwitchLib.
 
-For a general overview and example, refer to https://github.com/TwitchLib/TwitchLib/blob/master/README.md
+For a general overview and examples, refer to https://github.com/TwitchLib/TwitchLib/blob/master/README.md
+
+For Helix API Examples, refer to https://github.com/TwitchLib/TwitchLib.Api/tree/master/TwitchLib.Api.Helix/README.MD
 
 ```csharp
 using System;

--- a/TwitchLib.Api.Core.Interfaces/IApiSettings.cs
+++ b/TwitchLib.Api.Core.Interfaces/IApiSettings.cs
@@ -12,6 +12,10 @@ namespace TwitchLib.Api.Core.Interfaces
         bool SkipDynamicScopeValidation { get; set; }
         bool SkipAutoServerTokenGeneration { get; set; }
         List<AuthScopes> Scopes { get; set; }
+        int OAuthResponsePort { get; set; }
+        string OAuthTokenFile { get; set; }
+        bool UseUserTokenForHelixCalls {  get; set; }
+        bool EnableInsecureTokenStorage { get; set; }
 
         event PropertyChangedEventHandler PropertyChanged;
     }

--- a/TwitchLib.Api.Core.Interfaces/IApiSettings.cs
+++ b/TwitchLib.Api.Core.Interfaces/IApiSettings.cs
@@ -4,17 +4,69 @@ using TwitchLib.Api.Core.Enums;
 
 namespace TwitchLib.Api.Core.Interfaces
 {
+    /// <summary>
+    /// These are settings that are shared throughout the application. Define these before
+    /// creating an instance of TwitchAPI
+    /// </summary>
     public interface IApiSettings
     {
+        /// <summary>
+        /// The current client credential access token. Provides limited access to some of the TwitchAPI.
+        /// </summary>
         string AccessToken { get; set; }
+        /// <summary>
+        /// Your application's Secret. Do not expose this to anyone else. This comes from the Twitch developer panel. https://dev.twitch.tv/console
+        /// </summary>
         string Secret { get; set; }
+        /// <summary>
+        /// Your application's client ID. This comes from the Twitch developer panel. https://dev.twitch.tv/console
+        /// </summary>
         string ClientId { get; set; }
+        /// <summary>
+        /// This does not appear to be used.
+        /// </summary>
         bool SkipDynamicScopeValidation { get; set; }
+        /// <summary>
+        /// If AccessToken is null, and this is set to true, then Helix API calls will not attempt to use 
+        /// the ClientID/Secret to generate a client_credential access token.
+        /// </summary>
         bool SkipAutoServerTokenGeneration { get; set; }
+        /// <summary>
+        /// Add scopes that your application will be using to this collection before calling any Helix APIs. 
+        /// A list of scopes can be found here: https://dev.twitch.tv/docs/authentication/scopes/
+        /// See the TwitchAPI reference for the scopes specific to each API. 
+        /// Note: Do not add ALL the scopes, or your account may be banned (see warning here: https://dev.twitch.tv/docs/authentication/scopes/)
+        /// </summary>
         List<AuthScopes> Scopes { get; set; }
+        /// <summary>
+        /// Set this value to another port if you have another application already listening to port 5000 on your machine.
+        /// Defaults to: 5000
+        /// </summary>
         int OAuthResponsePort { get; set; }
+        /// <summary>
+        ///  Set this value to a hostname or IP address if you have a multi-homed machine (more than one IP address) 
+        ///  and you would like to bind the OAuth response listener to a specific IP address. Defaults to 'localhost'
+        /// </summary>
+        string OAuthResponseHostname { get; set; }
+        /// <summary>
+        /// Storage for oAuth refresh token, expiration dates, etc. Defaults to %AppData%\\TwitchLib.API\\[ApplicationName].json
+        /// Set this if you will be running multiple instances of the same application that you would like to use with different 
+        /// user tokens.
+        /// </summary>
         string OAuthTokenFile { get; set; }
+        /// <summary>
+        /// Set this value to true to enable Helix calls that require an oAuth User Token. This requires you to also set
+        /// ApiSettings.ClientID and ApiSettings.Secret. 
+        /// </summary>
         bool UseUserTokenForHelixCalls {  get; set; }
+        /// <summary>
+        /// Setting this value to true will enable storage of the oAuth refresh token and other data. This storage will be done in 
+        /// an unencrypted, insecure local file. Anyone else with access to your computer could read this file and gain access to 
+        /// your Twitch account in unexpected ways. Only set this value to true if you have properly secured your computer.
+        /// If you do not set this value to True, and UseUserTokenForHelixCalls = True, a browser window will always open on the
+        /// first call to any Helix API to perform the OAuth handshake.
+        /// Defaults to: False
+        /// </summary>
         bool EnableInsecureTokenStorage { get; set; }
 
         event PropertyChangedEventHandler PropertyChanged;

--- a/TwitchLib.Api.Core.Interfaces/IUserAccessTokenManager.cs
+++ b/TwitchLib.Api.Core.Interfaces/IUserAccessTokenManager.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using TwitchLib.Api.Core.Interfaces;
+
+namespace TwitchLib.Api.Core.Interfaces
+{
+    public interface IUserAccessTokenManager
+    {
+        /// <summary>
+        /// Uses the Authoization Grant flow to get an access code to get a token and refresh token.
+        /// https://dev.twitch.tv/docs/authentication/getting-tokens-oauth/#authorization-code-grant-flow
+        /// </summary>
+        /// <param name="settings"></param>
+        /// <returns></returns>
+        Task<string> GetUserAccessToken();
+    }
+}

--- a/TwitchLib.Api.Core.Interfaces/IUserAccessTokenManager.cs
+++ b/TwitchLib.Api.Core.Interfaces/IUserAccessTokenManager.cs
@@ -6,13 +6,16 @@ using TwitchLib.Api.Core.Interfaces;
 
 namespace TwitchLib.Api.Core.Interfaces
 {
+    /// <summary>
+    /// Enables API calls to use user access tokens instead of client credentials. Most of the best parts of
+    /// the Twitch API are only available when using user access tokens. 
+    /// </summary>
     public interface IUserAccessTokenManager
     {
         /// <summary>
         /// Uses the Authoization Grant flow to get an access code to get a token and refresh token.
         /// https://dev.twitch.tv/docs/authentication/getting-tokens-oauth/#authorization-code-grant-flow
         /// </summary>
-        /// <param name="settings"></param>
         /// <returns></returns>
         Task<string> GetUserAccessToken();
     }

--- a/TwitchLib.Api.Core/ApiBase.cs
+++ b/TwitchLib.Api.Core/ApiBase.cs
@@ -12,6 +12,10 @@ using TwitchLib.Api.Core.Models;
 
 namespace TwitchLib.Api.Core
 {
+    /// <summary>
+    /// A base class for any method calling the Twitch API. Provides authorization credentials and
+    /// abstracts for calling basic web methods.
+    /// </summary>
     public class ApiBase
     {
         private readonly TwitchLibJsonSerializer _jsonSerializer;
@@ -26,6 +30,13 @@ namespace TwitchLib.Api.Core
         private DateTime? _serverBasedAccessTokenExpiry;
         private string _serverBasedAccessToken;
 
+        /// <summary>
+        /// Standard constructor for all derived API methods.
+        /// </summary>
+        /// <param name="settings">Can be null.</param>
+        /// <param name="rateLimiter">Can be null.</param>
+        /// <param name="http">Can be null.</param>
+        /// <param name="userAccessTokenManager">Can be null.</param>
         public ApiBase(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http, IUserAccessTokenManager userAccessTokenManager)
         {
             Settings = settings; 
@@ -35,7 +46,7 @@ namespace TwitchLib.Api.Core
             _userAccessTokenManager = userAccessTokenManager;
         }
 
-        public async ValueTask<string> GetAccessTokenAsync(string accessToken = null)
+        private async ValueTask<string> GetAccessTokenAsync(string accessToken = null)
         {
             if (!string.IsNullOrWhiteSpace(accessToken))
                 return accessToken;

--- a/TwitchLib.Api.Core/ApiBase.cs
+++ b/TwitchLib.Api.Core/ApiBase.cs
@@ -338,10 +338,18 @@ namespace TwitchLib.Api.Core
             {
                 for (var i = 0; i < getParams.Count; i++)
                 {
+                    // When "after" is null, then Uri.EscapeDataString dies with null exception.
+                    var value = "";
+
+                    if (getParams[i].Value != null)
+                        value = getParams[i].Value;
+
                     if (i == 0)
-                        url += $"?{getParams[i].Key}={Uri.EscapeDataString(getParams[i].Value)}";
+                        url += "?";
                     else
-                        url += $"&{getParams[i].Key}={Uri.EscapeDataString(getParams[i].Value)}";
+                        url += "&";
+
+                    url += $"{getParams[i].Key}={Uri.EscapeDataString(value)}";
                 }
             }
             return url;

--- a/TwitchLib.Api.Core/ApiSettings.cs
+++ b/TwitchLib.Api.Core/ApiSettings.cs
@@ -16,6 +16,7 @@ namespace TwitchLib.Api.Core
         private bool _skipAutoServerTokenGeneration;
         private List<AuthScopes> _scopes = new List<AuthScopes>();
         private int _oauthResponsePort = 5000;
+        private string _oAuthResponseHostname = "localhost";
         private string _oauthTokenFile = System.Environment.ExpandEnvironmentVariables("%AppData%\\TwitchLib.API\\" + System.Diagnostics.Process.GetCurrentProcess().ProcessName + ".json");
         private bool _useUserTokenForHelixCalls = false;
         private bool _enableInsecureTokenStorage = false;
@@ -82,6 +83,12 @@ namespace TwitchLib.Api.Core
                 }
             }
         }
+        /// <summary>
+        /// Add scopes that your application will be using to this collection before calling any Helix APIs. 
+        /// A list of scopes can be found here: https://dev.twitch.tv/docs/authentication/scopes/
+        /// See the TwitchAPI reference for the scopes specific to each API. 
+        /// Note: Do not add ALL the scopes, or your account may be banned (see warning here: https://dev.twitch.tv/docs/authentication/scopes/)
+        /// </summary>
         public List<AuthScopes> Scopes
         {
             get => _scopes;
@@ -110,6 +117,23 @@ namespace TwitchLib.Api.Core
                 if (value != _oauthResponsePort)
                 {
                     _oauthResponsePort = value;
+                    NotifyPropertyChanged();
+                }
+            }
+        }
+
+        /// <summary>
+        ///  Set this value to a hostname or IP address if you have a multi-homed machine (more than one IP address) 
+        ///  and you would like to bind the OAuth response listener to a specific IP address. Defaults to 'localhost'
+        /// </summary>
+        public string OAuthResponseHostname
+        {
+            get => _oAuthResponseHostname;
+            set
+            {
+                if (value != _oAuthResponseHostname)
+                {
+                    _oAuthResponseHostname = value;
                     NotifyPropertyChanged();
                 }
             }
@@ -157,6 +181,9 @@ namespace TwitchLib.Api.Core
         /// Setting this value to true will enable storage of the oAuth refresh token and other data. This storage will be done in 
         /// an unencrypted, insecure local file. Anyone else with access to your computer could read this file and gain access to 
         /// your Twitch account in unexpected ways. Only set this value to true if you have properly secured your computer.
+        /// If you do not set this value to True, and UseUserTokenForHelixCalls = True, a browser window will always open on the
+        /// first call to any Helix API to perform the OAuth handshake.
+        /// Defaults to: False
         /// </summary>
         public bool EnableInsecureTokenStorage
         {
@@ -171,6 +198,11 @@ namespace TwitchLib.Api.Core
             }
         }
 
+
+
+        /// <summary>
+        /// This event fires when ever a property is changed on the settings class.
+        /// </summary>
         public event PropertyChangedEventHandler PropertyChanged;
 
         private void NotifyPropertyChanged([CallerMemberName] string propertyName = "")

--- a/TwitchLib.Api.Core/ApiSettings.cs
+++ b/TwitchLib.Api.Core/ApiSettings.cs
@@ -13,7 +13,7 @@ namespace TwitchLib.Api.Core
         private string _accessToken;
         private bool _skipDynamicScopeValidation;
         private bool _skipAutoServerTokenGeneration;
-        private List<AuthScopes> _scopes;
+        private List<AuthScopes> _scopes = new List<AuthScopes>();
         public string ClientId
         {
             get => _clientId;

--- a/TwitchLib.Api.Core/ApiSettings.cs
+++ b/TwitchLib.Api.Core/ApiSettings.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using TwitchLib.Api.Core.Enums;
@@ -14,6 +15,13 @@ namespace TwitchLib.Api.Core
         private bool _skipDynamicScopeValidation;
         private bool _skipAutoServerTokenGeneration;
         private List<AuthScopes> _scopes = new List<AuthScopes>();
+        private int _oauthResponsePort = 5000;
+        private string _oauthTokenFile = System.Environment.ExpandEnvironmentVariables("%AppData%\\TwitchLib.API\\" + System.Diagnostics.Process.GetCurrentProcess().ProcessName + ".json");
+        private bool _useUserTokenForHelixCalls = false;
+        private bool _enableInsecureTokenStorage = false;
+        private IUserAccessTokenManager _userAccessTokenManager;
+
+
         public string ClientId
         {
             get => _clientId;
@@ -82,6 +90,82 @@ namespace TwitchLib.Api.Core
                 if (value != _scopes)
                 {
                     _scopes = value;
+                    NotifyPropertyChanged();
+                }
+            }
+        }
+
+        /// <summary>
+        /// If you are using TwitchLib.Api and make calls to API endpoints that require a user token, then you can use 
+        /// your ClientSecret and ClientID to establish an OAuth token for your service. Part of this token generation 
+        /// process requires Twitch to authenticate your application using your browser. Twitch will return your browser
+        /// back to this library for token storage so, this library needs to listen for your browser's request on a port. 
+        /// By default, this is port 5000. If you have another application also on port 5000, set this to another open port. 
+        /// </summary>
+        public int OAuthResponsePort
+        {
+            get => _oauthResponsePort;
+            set
+            {
+                if (value != _oauthResponsePort)
+                {
+                    _oauthResponsePort = value;
+                    NotifyPropertyChanged();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Storage for oAuth refresh token, expiration dates, etc. Defaults to %AppData%\\TwitchLib.API\\[ApplicationName].json
+        /// Set this if you will be running multiple instances of the same application that you would like to use with different 
+        /// user tokens.
+        /// </summary>
+        public string OAuthTokenFile
+        {
+            get => _oauthTokenFile;
+            set
+            {
+                if (value != _oauthTokenFile)
+                {
+                    _oauthTokenFile = value;
+                    NotifyPropertyChanged();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Set this value to true to enable Helix calls that require an oAuth User Token. This requires you to also set
+        /// ApiSettings.ClientID and ApiSettings.Secret. 
+        /// </summary>
+        public bool UseUserTokenForHelixCalls
+        {
+            get => _useUserTokenForHelixCalls;
+            set
+            {
+                if (value != _useUserTokenForHelixCalls)
+                {
+                    if (String.IsNullOrWhiteSpace(ClientId) == true || String.IsNullOrWhiteSpace(Secret) == true)
+                        throw new Exception("You must set ApiSettings.ClientId and ApiSettings.Secret before you can enable this setting.");
+
+                    _useUserTokenForHelixCalls = value;
+                    NotifyPropertyChanged();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Setting this value to true will enable storage of the oAuth refresh token and other data. This storage will be done in 
+        /// an unencrypted, insecure local file. Anyone else with access to your computer could read this file and gain access to 
+        /// your Twitch account in unexpected ways. Only set this value to true if you have properly secured your computer.
+        /// </summary>
+        public bool EnableInsecureTokenStorage
+        {
+            get => _enableInsecureTokenStorage;
+            set
+            {
+                if (value != _enableInsecureTokenStorage)
+                {
+                    _enableInsecureTokenStorage = value;
                     NotifyPropertyChanged();
                 }
             }

--- a/TwitchLib.Api.Core/Exceptions/HttpResponseException.cs
+++ b/TwitchLib.Api.Core/Exceptions/HttpResponseException.cs
@@ -12,10 +12,19 @@ namespace TwitchLib.Api.Core.Exceptions
         /// Null if using <see cref="TwitchLib.Api.Core.HttpCallHandlers.TwitchWebRequest"/> or <see cref="TwitchLib.Api.Core.Undocumented.Undocumented"/>
         /// </summary>
         public HttpResponseMessage HttpResponse { get; }
+        public string HttpResponseContent {  get; }
 
         public HttpResponseException(string apiData, HttpResponseMessage httpResponse) : base(apiData)
         {
             HttpResponse = httpResponse;
+
+            try
+            {
+                HttpResponseContent = httpResponse.Content.ReadAsStringAsync().Result;
+            } catch (Exception ex)
+            {
+                HttpResponseContent = $"Couldn't read response from server: {ex.ToString()}";
+            }
         }
     }
 }

--- a/TwitchLib.Api.Core/HttpCallHandlers/TwitchHttpClient.cs
+++ b/TwitchLib.Api.Core/HttpCallHandlers/TwitchHttpClient.cs
@@ -122,30 +122,42 @@ namespace TwitchLib.Api.Core.HttpCallHandlers
 
         private void HandleWebException(HttpResponseMessage errorResp)
         {
+            // Show the actual message that came back from the server. Masking it only makes debugging hard.
+            var actualContent = String.Empty;
+
+            try
+            {
+                actualContent = errorResp.Content.ReadAsStringAsync().Result;
+            }
+            catch (Exception ex)
+            {
+                actualContent = $"Couldn't read response from server: {ex.Message}";
+            }
+
             switch (errorResp.StatusCode)
             {
                 case HttpStatusCode.BadRequest:
-                    throw new BadRequestException("Your request failed because either: \n 1. Your ClientID was invalid/not set. \n 2. Your refresh token was invalid. \n 3. You requested a username when the server was expecting a user ID.", errorResp);
+                    throw new BadRequestException(actualContent + "\n\nYour request may have failed because either: \n 1. Your ClientID was invalid/not set. \n 2. Your refresh token was invalid. \n 3. You requested a username when the server was expecting a user ID.", errorResp);
                 case HttpStatusCode.Unauthorized:
                     var authenticateHeader = errorResp.Headers.WwwAuthenticate;
                     if (authenticateHeader == null || authenticateHeader.Count <= 0)
-                        throw new BadScopeException("Your request was blocked due to bad credentials (Do you have the right scope for your access token?).", errorResp);
-                    throw new TokenExpiredException("Your request was blocked due to an expired Token. Please refresh your token and update your API instance settings.", errorResp);
+                        throw new BadScopeException(actualContent + "\n\nYour request was blocked due to bad credentials (Do you have the right scope for your access token?).", errorResp);
+                    throw new TokenExpiredException(actualContent + "\n\nYour request was blocked due to an expired Token. Please refresh your token and update your API instance settings.", errorResp);
                 case HttpStatusCode.NotFound:
-                    throw new BadResourceException("The resource you tried to access was not valid.", errorResp);
+                    throw new BadResourceException(actualContent + "\n\nThe resource you tried to access was not valid.", errorResp);
                 case (HttpStatusCode)429:
-                    errorResp.Headers.TryGetValues("Ratelimit-Reset", out var resetTime);
-                    throw new TooManyRequestsException("You have reached your rate limit. Too many requests were made", resetTime.FirstOrDefault(), errorResp);
+                    errorResp.Headers.TryGetValues(actualContent + "\n\nRatelimit -Reset", out var resetTime);
+                    throw new TooManyRequestsException(actualContent + "\n\nYou have reached your rate limit. Too many requests were made", resetTime.FirstOrDefault(), errorResp);
                 case HttpStatusCode.BadGateway:
-                    throw new BadGatewayException("The API answered with a 502 Bad Gateway. Please retry your request", errorResp);
+                    throw new BadGatewayException(actualContent + "\n\nThe API answered with a 502 Bad Gateway. Please retry your request", errorResp);
                 case HttpStatusCode.GatewayTimeout:
-                    throw new GatewayTimeoutException("The API answered with a 504 Gateway Timeout. Please retry your request", errorResp);
+                    throw new GatewayTimeoutException(actualContent + "\n\nThe API answered with a 504 Gateway Timeout. Please retry your request", errorResp);
                 case HttpStatusCode.InternalServerError:
-                    throw new InternalServerErrorException("The API answered with a 500 Internal Server Error. Please retry your request", errorResp);
+                    throw new InternalServerErrorException(actualContent + "\n\nThe API answered with a 500 Internal Server Error. Please retry your request", errorResp);
                 case HttpStatusCode.Forbidden:
-                    throw new BadTokenException("The token provided in the request did not match the associated user. Make sure the token you're using is from the resource owner (streamer? viewer?)", errorResp);
+                    throw new BadTokenException(actualContent + "\n\nThe token provided in the request did not match the associated user. Make sure the token you're using is from the resource owner (streamer? viewer?)", errorResp);
                 default:
-                    throw new HttpRequestException("Something went wrong during the request! Please try again later");
+                    throw new HttpRequestException(actualContent + "\n\nSomething went wrong during the request! Please try again later");
             }
         }
 

--- a/TwitchLib.Api.Core/TwitchLib.Api.Core.csproj
+++ b/TwitchLib.Api.Core/TwitchLib.Api.Core.csproj
@@ -24,6 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="EmbedIO" Version="3.5.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
@@ -35,6 +36,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="twitchlib.png" Pack="true" PackagePath="\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="OAuth\" />
   </ItemGroup>
 
 </Project>

--- a/TwitchLib.Api.Core/Undocumented/Undocumented.cs
+++ b/TwitchLib.Api.Core/Undocumented/Undocumented.cs
@@ -15,7 +15,7 @@ namespace TwitchLib.Api.Core.Undocumented
     /// </summary>
     public class Undocumented : ApiBase
     {
-        public Undocumented(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http)
+        public Undocumented(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http, IUserAccessTokenManager userAccessTokenManager) : base(settings, rateLimiter, http, userAccessTokenManager)
         {
         }
 

--- a/TwitchLib.Api.Helix/Ads.cs
+++ b/TwitchLib.Api.Helix/Ads.cs
@@ -12,7 +12,7 @@ namespace TwitchLib.Api.Helix
     /// </summary>
     public class Ads : ApiBase
     {
-        public Ads(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http)
+        public Ads(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http, IUserAccessTokenManager userAccessTokenManager) : base(settings, rateLimiter, http, userAccessTokenManager)
         {
         }
 

--- a/TwitchLib.Api.Helix/Analytics.cs
+++ b/TwitchLib.Api.Helix/Analytics.cs
@@ -14,7 +14,7 @@ namespace TwitchLib.Api.Helix
     /// </summary>
     public class Analytics : ApiBase
     {
-        public Analytics(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http)
+        public Analytics(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http, IUserAccessTokenManager userAccessTokenManager) : base(settings, rateLimiter, http, userAccessTokenManager)
         {
         }
 

--- a/TwitchLib.Api.Helix/Bits.cs
+++ b/TwitchLib.Api.Helix/Bits.cs
@@ -15,7 +15,7 @@ namespace TwitchLib.Api.Helix
     /// </summary>
     public class Bits :ApiBase
     {
-        public Bits(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http)
+        public Bits(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http, IUserAccessTokenManager userAccessTokenManager) : base(settings, rateLimiter, http, userAccessTokenManager)
         {
         }
 

--- a/TwitchLib.Api.Helix/ChannelPoints.cs
+++ b/TwitchLib.Api.Helix/ChannelPoints.cs
@@ -19,7 +19,7 @@ namespace TwitchLib.Api.Helix
     /// </summary>
     public class ChannelPoints : ApiBase
     {
-        public ChannelPoints(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http)
+        public ChannelPoints(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http, IUserAccessTokenManager userAccessTokenManager) : base(settings, rateLimiter, http, userAccessTokenManager)
         {
         }
 

--- a/TwitchLib.Api.Helix/Channels.cs
+++ b/TwitchLib.Api.Helix/Channels.cs
@@ -20,7 +20,7 @@ namespace TwitchLib.Api.Helix
     /// </summary>
     public class Channels : ApiBase
     {
-        public Channels(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http)
+        public Channels(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http, IUserAccessTokenManager userAccessTokenManager) : base(settings, rateLimiter, http, userAccessTokenManager)
         {
         }
 

--- a/TwitchLib.Api.Helix/Charity.cs
+++ b/TwitchLib.Api.Helix/Charity.cs
@@ -15,7 +15,7 @@ namespace TwitchLib.Api.Helix
     public class Charity : ApiBase
     {
 
-        public Charity(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http)
+        public Charity(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http, IUserAccessTokenManager userAccessTokenManager) : base(settings, rateLimiter, http, userAccessTokenManager)
         {
         }
 

--- a/TwitchLib.Api.Helix/Chat.cs
+++ b/TwitchLib.Api.Helix/Chat.cs
@@ -25,7 +25,7 @@ namespace TwitchLib.Api.Helix
     /// </summary>
     public class Chat : ApiBase
     {
-        public Chat(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http)
+        public Chat(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http, IUserAccessTokenManager userAccessTokenManager) : base(settings, rateLimiter, http, userAccessTokenManager)
         { }
 
         #region Badges

--- a/TwitchLib.Api.Helix/Clips.cs
+++ b/TwitchLib.Api.Helix/Clips.cs
@@ -17,7 +17,7 @@ namespace TwitchLib.Api.Helix
     /// </summary>
     public class Clips : ApiBase
     {
-        public Clips(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http)
+        public Clips(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http, IUserAccessTokenManager userAccessTokenManager) : base(settings, rateLimiter, http, userAccessTokenManager)
         { }
 
         #region GetClips

--- a/TwitchLib.Api.Helix/Entitlements.cs
+++ b/TwitchLib.Api.Helix/Entitlements.cs
@@ -18,7 +18,7 @@ namespace TwitchLib.Api.Helix
     /// </summary>
     public class Entitlements : ApiBase
     {
-        public Entitlements(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http)
+        public Entitlements(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http, IUserAccessTokenManager userAccessTokenManager) : base(settings, rateLimiter, http, userAccessTokenManager)
         {
         }
 

--- a/TwitchLib.Api.Helix/EventSub.cs
+++ b/TwitchLib.Api.Helix/EventSub.cs
@@ -13,7 +13,7 @@ namespace TwitchLib.Api.Helix
 {
     public class EventSub : ApiBase
     {
-        public EventSub(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http)
+        public EventSub(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http, IUserAccessTokenManager userAccessTokenManager) : base(settings, rateLimiter, http, userAccessTokenManager)
         {
         }
 

--- a/TwitchLib.Api.Helix/Extensions.cs
+++ b/TwitchLib.Api.Helix/Extensions.cs
@@ -16,7 +16,7 @@ namespace TwitchLib.Api.Helix
     /// </summary>
     public class Extensions : ApiBase
     {
-        public Extensions(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http)
+        public Extensions(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http, IUserAccessTokenManager userAccessTokenManager) : base(settings, rateLimiter, http, userAccessTokenManager)
         { }
 
         #region GetExtensionTransactions

--- a/TwitchLib.Api.Helix/Games.cs
+++ b/TwitchLib.Api.Helix/Games.cs
@@ -14,7 +14,7 @@ namespace TwitchLib.Api.Helix
     /// </summary>
     public class Games : ApiBase
     {
-        public Games(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http)
+        public Games(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http, IUserAccessTokenManager userAccessTokenManager) : base(settings, rateLimiter, http, userAccessTokenManager)
         {
         }
 

--- a/TwitchLib.Api.Helix/Goals.cs
+++ b/TwitchLib.Api.Helix/Goals.cs
@@ -13,7 +13,7 @@ namespace TwitchLib.Api.Helix
     /// </summary>
     public class Goals : ApiBase
     {
-        public Goals(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http)
+        public Goals(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http, IUserAccessTokenManager userAccessTokenManager) : base(settings, rateLimiter, http, userAccessTokenManager)
         {
         }
 

--- a/TwitchLib.Api.Helix/Helix.cs
+++ b/TwitchLib.Api.Helix/Helix.cs
@@ -136,41 +136,41 @@ namespace TwitchLib.Api.Helix
         /// <param name="rateLimiter">Instance Of RateLimiter, otherwise no ratelimiter is used.</param>
         /// <param name="settings">Instance of ApiSettings, otherwise defaults used, can be changed later</param>
         /// <param name="http">Instance of HttpCallHandler, otherwise default handler used</param>
-        public Helix(ILoggerFactory loggerFactory = null, IRateLimiter rateLimiter = null, IApiSettings settings = null, IHttpCallHandler http = null)
+        public Helix(ILoggerFactory loggerFactory = null, IRateLimiter rateLimiter = null, IApiSettings settings = null, IHttpCallHandler http = null, IUserAccessTokenManager userAccessTokenManager = null)
         {
             _logger = loggerFactory?.CreateLogger<Helix>();
             rateLimiter = rateLimiter ?? BypassLimiter.CreateLimiterBypassInstance();
             http = http ?? new TwitchHttpClient(loggerFactory?.CreateLogger<TwitchHttpClient>());
             Settings = settings ?? new ApiSettings();
 
-            Analytics = new Analytics(Settings, rateLimiter, http);
-            Ads = new Ads(Settings, rateLimiter, http);
-            Bits = new Bits(Settings, rateLimiter, http);
-            Chat = new Chat(Settings, rateLimiter, http);
-            Channels = new Channels(Settings, rateLimiter, http);
-            ChannelPoints = new ChannelPoints(Settings, rateLimiter, http);
-            Charity = new Charity(Settings, rateLimiter, http);
-            Clips = new Clips(Settings, rateLimiter, http);
-            Entitlements = new Entitlements(Settings, rateLimiter, http);
-            EventSub = new EventSub(Settings, rateLimiter, http);
-            Extensions = new Extensions(Settings, rateLimiter, http);
-            Games = new Games(Settings, rateLimiter, http);
-            Goals = new Goals(settings, rateLimiter, http);
-            HypeTrain = new HypeTrain(Settings, rateLimiter, http);
-            Moderation = new Moderation(Settings, rateLimiter, http);
-            Polls = new Polls(Settings, rateLimiter, http);
-            Predictions = new Predictions(Settings, rateLimiter, http);
-            Raids = new Raids(settings, rateLimiter, http);
-            Schedule = new Schedule(Settings, rateLimiter, http);
-            Search = new Search(Settings, rateLimiter, http);
-            Soundtrack = new Soundtrack(Settings, rateLimiter, http);
-            Streams = new Streams(Settings, rateLimiter, http);
-            Subscriptions = new Subscriptions(Settings, rateLimiter, http);
-            Tags = new Tags(Settings, rateLimiter, http);
-            Teams = new Teams(Settings, rateLimiter, http);
-            Users = new Users(Settings, rateLimiter, http);
-            Videos = new Videos(Settings, rateLimiter, http);
-            Whispers = new Whispers(Settings, rateLimiter, http);
+            Analytics = new Analytics(Settings, rateLimiter, http, userAccessTokenManager);
+            Ads = new Ads(Settings, rateLimiter, http, userAccessTokenManager);
+            Bits = new Bits(Settings, rateLimiter, http, userAccessTokenManager);
+            Chat = new Chat(Settings, rateLimiter, http, userAccessTokenManager);
+            Channels = new Channels(Settings, rateLimiter, http, userAccessTokenManager);
+            ChannelPoints = new ChannelPoints(Settings, rateLimiter, http, userAccessTokenManager);
+            Charity = new Charity(Settings, rateLimiter, http, userAccessTokenManager);
+            Clips = new Clips(Settings, rateLimiter, http, userAccessTokenManager);
+            Entitlements = new Entitlements(Settings, rateLimiter, http, userAccessTokenManager);
+            EventSub = new EventSub(Settings, rateLimiter, http, userAccessTokenManager);
+            Extensions = new Extensions(Settings, rateLimiter, http, userAccessTokenManager);
+            Games = new Games(Settings, rateLimiter, http, userAccessTokenManager);
+            Goals = new Goals(settings, rateLimiter, http, userAccessTokenManager);
+            HypeTrain = new HypeTrain(Settings, rateLimiter, http, userAccessTokenManager);
+            Moderation = new Moderation(Settings, rateLimiter, http, userAccessTokenManager);
+            Polls = new Polls(Settings, rateLimiter, http, userAccessTokenManager);
+            Predictions = new Predictions(Settings, rateLimiter, http, userAccessTokenManager);
+            Raids = new Raids(settings, rateLimiter, http, userAccessTokenManager);
+            Schedule = new Schedule(Settings, rateLimiter, http, userAccessTokenManager);
+            Search = new Search(Settings, rateLimiter, http, userAccessTokenManager);
+            Soundtrack = new Soundtrack(Settings, rateLimiter, http, userAccessTokenManager);
+            Streams = new Streams(Settings, rateLimiter, http, userAccessTokenManager);
+            Subscriptions = new Subscriptions(Settings, rateLimiter, http, userAccessTokenManager);
+            Tags = new Tags(Settings, rateLimiter, http, userAccessTokenManager);
+            Teams = new Teams(Settings, rateLimiter, http, userAccessTokenManager);
+            Users = new Users(Settings, rateLimiter, http, userAccessTokenManager);
+            Videos = new Videos(Settings, rateLimiter, http, userAccessTokenManager);
+            Whispers = new Whispers(Settings, rateLimiter, http, userAccessTokenManager);
         }
     }
 }

--- a/TwitchLib.Api.Helix/HypeTrain.cs
+++ b/TwitchLib.Api.Helix/HypeTrain.cs
@@ -13,7 +13,7 @@ namespace TwitchLib.Api.Helix
     /// </summary>
     public class HypeTrain : ApiBase
     {
-        public HypeTrain(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http)
+        public HypeTrain(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http, IUserAccessTokenManager userAccessTokenManager) : base(settings, rateLimiter, http, userAccessTokenManager)
         {
         }
 

--- a/TwitchLib.Api.Helix/Moderation.cs
+++ b/TwitchLib.Api.Helix/Moderation.cs
@@ -27,7 +27,7 @@ namespace TwitchLib.Api.Helix
     /// </summary>
     public class Moderation : ApiBase
     {
-        public Moderation(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http)
+        public Moderation(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http, IUserAccessTokenManager userAccessTokenManager) : base(settings, rateLimiter, http, userAccessTokenManager)
         {
         }
         #region ManageHeldAutoModMessage

--- a/TwitchLib.Api.Helix/Polls.cs
+++ b/TwitchLib.Api.Helix/Polls.cs
@@ -14,7 +14,7 @@ namespace TwitchLib.Api.Helix
 {
     public class Polls : ApiBase
     {
-        public Polls(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http)
+        public Polls(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http, IUserAccessTokenManager userAccessTokenManager) : base(settings, rateLimiter, http, userAccessTokenManager)
         {
         }
 

--- a/TwitchLib.Api.Helix/Predictions.cs
+++ b/TwitchLib.Api.Helix/Predictions.cs
@@ -17,7 +17,7 @@ namespace TwitchLib.Api.Helix
     /// </summary>
     public class Predictions : ApiBase
     {
-        public Predictions(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http)
+        public Predictions(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http, IUserAccessTokenManager userAccessTokenManager) : base(settings, rateLimiter, http, userAccessTokenManager)
         {
         }
 

--- a/TwitchLib.Api.Helix/README.md
+++ b/TwitchLib.Api.Helix/README.md
@@ -1,0 +1,119 @@
+<p align="center"> 
+<img src="https://cdn.syzuna-programs.de/images/twitchlib.png" style="max-height: 300px;">
+</p>
+
+## Helix API
+The Twitch Helix API is the main API layer for Twitch services. The Helix API has two levels of security gated by two distinct types of OAuth tokens. The first type is a App Access Token. This token type is directly granted by Twitch's server to your application and does not require a user to be logged in to grant scope level access. Several Twitch API methods can be accessed by this type of token *but not all of them*. Several APIs can only be used with a User Access Token. This token type is scoped to access specific APIs and you must be logged into a Twitch account to allow this token to acceed these scopes. TwitchLib.API now supports direct authentication of User Access tokens to make this easy for you. 
+
+Please refer to the Twitch API to learn more about the two different token types and when to use them. 
+https://dev.twitch.tv/docs/authentication/
+
+
+You can decide which type of token you will need by determining which APIs you would like to use from the Helix API set. A list of all of the APIs can be found here:
+https://dev.twitch.tv/docs/api/reference/
+
+For example, the <a href="https://dev.twitch.tv/docs/api/reference/#get-channel-information" target="_top">Get Channel Information</a> API will work with either an App Acccess Token or a User Access Token because it works with information that is publically accessable without being logged in. Some Channel API methods however, like <a href="https://dev.twitch.tv/docs/api/reference/#start-commercial" target="_top">Start Commercial</a> will only allow the a User Accces Token with the channel:edit:commercial scope assigned to it. You can see what a Helix API method will require by looking at the Authorization section of any API method in the <a href="https://dev.twitch.tv/docs/api/reference/" target="_top">reference</a>.
+
+One final word about scopes. Do not assign ALL of the available scopes to AppSettings.Scopes. Doing so may get your application banned. <a href="https://dev.twitch.tv/docs/authentication/scopes/">See the warning here</a>!
+
+# How it works
+To support User Access Tokens, TwitchLib.API has a small webserver integrated into it. When you authenticate your Client ID and Secret to the Twitch API to get a User Access Token, it will open a browser window that will require you to login with your Twitch account and then grant explicit permissions to your application to do specific actions with the Twitch API. Once you do, Twitch API will forward your browser back to this webserver which hands the credential securly back to TwitchLib.API. These credentials will then be used by all future calls to the Helix API. OAuth complexities like periodic validation and refresh tokens are handled for you by the library. You can also implement this yourself if you need more functionliaty than this built in solution provides. See the section on Settings for more information.  
+
+> ***If you are using User Access Tokens, be sure to set AppSettings.UseUserTokenForHelixCalls to True!***
+
+For App Access Tokens, simply provide your ClientId and Secret. There is no interactive authorization stage for this type of token so this can work better for a server application, or an application that will run as a daemon, service or scheduled task when interacting with a webbrowser is not viable. App Access Tokens are much more limited and much of the Helix API does not work with them, but some public data methods do. Review the Helix API reference to see what type of token you will need.
+
+# Settings
+Authentication is controlled by several settings in the AppSettings class that you pass to TwitchLib.API when your application starts up. 
+
+| Setting Name | Description |
+| --- | --- |
+| AccessToken | The current access token that is being used to access the Helix API. You can specify this yourself to directly control the Access Token in use, or you can let the TwitchLib.API library control it for you. |
+| Secret | This comes from the Twitch Developer console after you set up your application. Used for both App Access and User Access Tokens |
+| ClientId | This comes from the Twitch Developer console after you set up your application. Used for both App Access  and User Access Tokens |
+| SkipAutoServerTokenGeneration | If AccessToken is null, and this is set to true, then Helix API calls will not attempt to use the ClientID/Secret to generate a client_credential access token. Set this to true if you intend to implement your own token management. Defaults to False.|
+| Scopes | Add scopes that your application will be using to this collection before calling any Helix APIs. A list of scopes can be found <a href="https://dev.twitch.tv/docs/authentication/scopes/">here</a>. See the TwitchAPI reference for the scopes specific to each API. Note: Do not add ALL the scopes, or your account may be banned! <a href="https://dev.twitch.tv/docs/authentication/scopes/">See warning here</a>.) |
+| OAuthResponsePort | Set this value to another port if you have another application already listening to port 5000 on your machine. Defaults to: 5000 |
+| OAuthResponseHostname | Set this value to a hostname or IP address if you have a multi-homed machine (more than one IP address) and you would like to bind the OAuth response listener to a specific IP address. Defaults to 'localhost' |
+| OAuthTokenFile | Storage for oAuth refresh token, expiration dates, etc. Defaults to %AppData%\\TwitchLib.API\[ApplicationName].json Set this if you will be running multiple instances of the same application that you would like to use with different user tokens. |
+| UseUserTokenForHelixCalls | Set this value to true to enable Helix calls that require an oAuth User Token. This requires you to also set ApiSettings.ClientID and ApiSettings.Secret. Defaults to False |
+| EnableInsecureTokenStorage | TwitchLib.API keeps OAuthTokenFile in a relativly secure location, but anyone with admin access to your computer could get access to this file and then access to Twitch API using the scopes you have granted to this token. While unlikely, we do want to call out that using this file is insecure. Enabling this setting will enable your app to run without re-authenticating between runs. Defaults to False. |
+
+
+# Prerequisites
+Before you get started with the Helix API, you must first register your application with the Twitch Developer console. Follow the Twitch API guide <a href="https://dev.twitch.tv/docs/authentication/register-app/">here</a>. Come back once you have your Application's ClientId and Secret. 
+
+# Example 1 - App Access Token
+```csharp
+    var settings = new ApiSettings
+    {
+        ClientId = CLIENT_ID,
+        Secret = SECRET
+    };
+
+    // While we are setting the correct scopes, they will not be used becuase we are not
+    // using a User Access Token. 
+    settings.Scopes.Add(Core.Enums.AuthScopes.Helix_Moderation_Read);
+    settings.Scopes.Add(Core.Enums.AuthScopes.Helix_Moderator_Manage_Banned_Users);
+
+    using ILoggerFactory loggerFactory =
+        LoggerFactory.Create(builder =>
+            builder.AddSimpleConsole(options =>
+            {
+                options.IncludeScopes = true;
+                options.SingleLine = true;
+                options.TimestampFormat = "HH:mm:ss ";
+            }));
+
+    var twitchAPI = new TwitchAPI(loggerFactory: loggerFactory, settings: settings);
+
+    var channelInformation = twitchAPI.Helix.Channels.GetChannelInformationAsync(BROADCASTER_ID);
+
+    Console.WriteLine($"Channel Information Returned: {channelInformation.Result.Data.Length}");
+
+    try
+    {
+        // This will fail because an App Access Token cannot be used with the Helix Moderation API.
+        var bannedUsers = twitchAPI.Helix.Moderation.GetBannedUsersAsync(BROADCASTER_ID);
+
+        Console.WriteLine($"Banned user count: {bannedUsers.Result.Data.Length}");
+    }
+    catch (Exception ex)
+    {
+        Console.WriteLine($"\n\n\nCan't use an App Access Token with the Helix Moderation API: {ex.Message}\n\n\n");
+    }```
+
+# Example 2 - User Access Token
+```csharp
+var settings = new ApiSettings
+{
+    ClientId = CLIENT_ID,
+    Secret = SECRET,
+    EnableInsecureTokenStorage = true, // Allows the application to start silently after the first authorization. 
+    UseUserTokenForHelixCalls = true // Enables User Access Tokens to be used for Helix API calls.
+};
+
+// Now that we are using User Access Tokens, the Helix Scopes can also be used.
+settings.Scopes.Add(Core.Enums.AuthScopes.Helix_Moderation_Read);
+settings.Scopes.Add(Core.Enums.AuthScopes.Helix_Moderator_Manage_Banned_Users);
+
+using ILoggerFactory loggerFactory =
+    LoggerFactory.Create(builder =>
+        builder.AddSimpleConsole(options =>
+        {
+            options.IncludeScopes = true;
+            options.SingleLine = true;
+            options.TimestampFormat = "HH:mm:ss ";
+        }));
+
+var twitchAPI = new TwitchAPI(loggerFactory: loggerFactory, settings: settings);
+
+var channelInformation = twitchAPI.Helix.Channels.GetChannelInformationAsync(BROADCASTER_ID);
+
+Console.WriteLine($"Channel Information Returned: {channelInformation.Result.Data.Length}");
+
+// This works fine now because we have a User Access Token with the correct scopes.
+var bannedUsers = twitchAPI.Helix.Moderation.GetBannedUsersAsync(BROADCASTER_ID);
+
+Console.WriteLine($"Banned user count: {bannedUsers.Result.Data.Length}");
+```

--- a/TwitchLib.Api.Helix/README.md
+++ b/TwitchLib.Api.Helix/README.md
@@ -81,7 +81,8 @@ Before you get started with the Helix API, you must first register your applicat
     catch (Exception ex)
     {
         Console.WriteLine($"\n\n\nCan't use an App Access Token with the Helix Moderation API: {ex.Message}\n\n\n");
-    }```
+    }
+```
 
 # Example 2 - User Access Token
 ```csharp

--- a/TwitchLib.Api.Helix/README.md
+++ b/TwitchLib.Api.Helix/README.md
@@ -3,7 +3,7 @@
 </p>
 
 ## Helix API
-The Twitch Helix API is the main API layer for Twitch services. The Helix API has two levels of security gated by two distinct types of OAuth tokens. The first type is a App Access Token. This token type is directly granted by Twitch's server to your application and does not require a user to be logged in to grant scope level access. Several Twitch API methods can be accessed by this type of token *but not all of them*. Several APIs can only be used with a User Access Token. This token type is scoped to access specific APIs and you must be logged into a Twitch account to allow this token to acceed these scopes. TwitchLib.API now supports direct authentication of User Access tokens to make this easy for you. 
+The Twitch Helix API is the main API layer for Twitch services. The Helix API has two levels of security gated by two distinct types of OAuth tokens. The first type is a App Access Token. This token type is directly granted by Twitch's server to your application and does not require a user to be logged in to grant scope level access. Several Twitch API methods can be accessed by this type of token *but not all of them*. Several APIs can only be used with a User Access Token. This token type is scoped to access specific APIs and you must be logged into a Twitch account to allow this token to access these scopes. TwitchLib.API now supports direct authentication of User Access tokens to make this easy for you. 
 
 Please refer to the Twitch API to learn more about the two different token types and when to use them. 
 https://dev.twitch.tv/docs/authentication/
@@ -12,16 +12,16 @@ https://dev.twitch.tv/docs/authentication/
 You can decide which type of token you will need by determining which APIs you would like to use from the Helix API set. A list of all of the APIs can be found here:
 https://dev.twitch.tv/docs/api/reference/
 
-For example, the <a href="https://dev.twitch.tv/docs/api/reference/#get-channel-information" target="_top">Get Channel Information</a> API will work with either an App Acccess Token or a User Access Token because it works with information that is publically accessable without being logged in. Some Channel API methods however, like <a href="https://dev.twitch.tv/docs/api/reference/#start-commercial" target="_top">Start Commercial</a> will only allow the a User Accces Token with the channel:edit:commercial scope assigned to it. You can see what a Helix API method will require by looking at the Authorization section of any API method in the <a href="https://dev.twitch.tv/docs/api/reference/" target="_top">reference</a>.
+For example, the <a href="https://dev.twitch.tv/docs/api/reference/#get-channel-information" target="_top">Get Channel Information</a> API will work with either an App Access Token or a User Access Token because it works with information that is publicly accessible without being logged in. Some Channel API methods however, like <a href="https://dev.twitch.tv/docs/api/reference/#start-commercial" target="_top">Start Commercial</a> will only allow the a User Access Token with the channel:edit:commercial scope assigned to it. You can see what a Helix API method will require by looking at the Authorization section of any API method in the <a href="https://dev.twitch.tv/docs/api/reference/" target="_top">reference</a>.
 
 One final word about scopes. Do not assign ALL of the available scopes to AppSettings.Scopes. Doing so may get your application banned. <a href="https://dev.twitch.tv/docs/authentication/scopes/">See the warning here</a>!
 
 # How it works
-To support User Access Tokens, TwitchLib.API has a small webserver integrated into it. When you authenticate your Client ID and Secret to the Twitch API to get a User Access Token, it will open a browser window that will require you to login with your Twitch account and then grant explicit permissions to your application to do specific actions with the Twitch API. Once you do, Twitch API will forward your browser back to this webserver which hands the credential securly back to TwitchLib.API. These credentials will then be used by all future calls to the Helix API. OAuth complexities like periodic validation and refresh tokens are handled for you by the library. You can also implement this yourself if you need more functionliaty than this built in solution provides. See the section on Settings for more information.  
+To support User Access Tokens, TwitchLib.API has a small web server integrated into it. When you authenticate your Client ID and Secret to the Twitch API to get a User Access Token, it will open a browser window that will require you to login with your Twitch account and then grant explicit permissions to your application to do specific actions with the Twitch API. Once you do, Twitch API will forward your browser back to this web server which hands the credential securely back to TwitchLib.API. These credentials will then be used by all future calls to the Helix API. OAuth complexities like periodic validation and refresh tokens are handled for you by the library. You can also implement this yourself if you need more functionality than this built in solution provides. See the section on Settings for more information.  
 
 > ***If you are using User Access Tokens, be sure to set AppSettings.UseUserTokenForHelixCalls to True!***
 
-For App Access Tokens, simply provide your ClientId and Secret. There is no interactive authorization stage for this type of token so this can work better for a server application, or an application that will run as a daemon, service or scheduled task when interacting with a webbrowser is not viable. App Access Tokens are much more limited and much of the Helix API does not work with them, but some public data methods do. Review the Helix API reference to see what type of token you will need.
+For App Access Tokens, simply provide your ClientId and Secret. There is no interactive authorization stage for this type of token so this can work better for a server application, or an application that will run as a daemon, service or scheduled task when interacting with a web browser is not viable. App Access Tokens are much more limited and much of the Helix API does not work with them, but some public data methods do. Review the Helix API reference to see what type of token you will need.
 
 # Settings
 Authentication is controlled by several settings in the AppSettings class that you pass to TwitchLib.API when your application starts up. 
@@ -34,10 +34,10 @@ Authentication is controlled by several settings in the AppSettings class that y
 | SkipAutoServerTokenGeneration | If AccessToken is null, and this is set to true, then Helix API calls will not attempt to use the ClientID/Secret to generate a client_credential access token. Set this to true if you intend to implement your own token management. Defaults to False.|
 | Scopes | Add scopes that your application will be using to this collection before calling any Helix APIs. A list of scopes can be found <a href="https://dev.twitch.tv/docs/authentication/scopes/">here</a>. See the TwitchAPI reference for the scopes specific to each API. Note: Do not add ALL the scopes, or your account may be banned! <a href="https://dev.twitch.tv/docs/authentication/scopes/">See warning here</a>.) |
 | OAuthResponsePort | Set this value to another port if you have another application already listening to port 5000 on your machine. Defaults to: 5000 |
-| OAuthResponseHostname | Set this value to a hostname or IP address if you have a multi-homed machine (more than one IP address) and you would like to bind the OAuth response listener to a specific IP address. Defaults to 'localhost' |
+| OAuthResponseHostname | Set this value to a host name or IP address if you have a multi-homed machine (more than one IP address) and you would like to bind the OAuth response listener to a specific IP address. Defaults to 'localhost' |
 | OAuthTokenFile | Storage for oAuth refresh token, expiration dates, etc. Defaults to %AppData%\\TwitchLib.API\[ApplicationName].json Set this if you will be running multiple instances of the same application that you would like to use with different user tokens. |
 | UseUserTokenForHelixCalls | Set this value to true to enable Helix calls that require an oAuth User Token. This requires you to also set ApiSettings.ClientID and ApiSettings.Secret. Defaults to False |
-| EnableInsecureTokenStorage | TwitchLib.API keeps OAuthTokenFile in a relativly secure location, but anyone with admin access to your computer could get access to this file and then access to Twitch API using the scopes you have granted to this token. While unlikely, we do want to call out that using this file is insecure. Enabling this setting will enable your app to run without re-authenticating between runs. Defaults to False. |
+| EnableInsecureTokenStorage | TwitchLib.API keeps OAuthTokenFile in a relatively secure location, but anyone with administrator access to your computer could get access to this file and then access to Twitch API using the scopes you have granted to this token. While unlikely, we do want to call out that using this file is insecure. Enabling this setting will enable your app to run without re-authenticating between runs. Defaults to False. |
 
 
 # Prerequisites
@@ -51,7 +51,7 @@ Before you get started with the Helix API, you must first register your applicat
         Secret = SECRET
     };
 
-    // While we are setting the correct scopes, they will not be used becuase we are not
+    // While we are setting the correct scopes, they will not be used because we are not
     // using a User Access Token. 
     settings.Scopes.Add(Core.Enums.AuthScopes.Helix_Moderation_Read);
     settings.Scopes.Add(Core.Enums.AuthScopes.Helix_Moderator_Manage_Banned_Users);

--- a/TwitchLib.Api.Helix/README.md
+++ b/TwitchLib.Api.Helix/README.md
@@ -41,7 +41,7 @@ Authentication is controlled by several settings in the AppSettings class that y
 
 
 # Prerequisites
-Before you get started with the Helix API, you must first register your application with the Twitch Developer console. Follow the Twitch API guide <a href="https://dev.twitch.tv/docs/authentication/register-app/">here</a>. Come back once you have your Application's ClientId and Secret. 
+Before you get started with the Helix API, you must first register your application with the Twitch Developer console. Follow the Twitch API guide <a href="https://dev.twitch.tv/docs/authentication/register-app/">here</a>. Use http://localhost:5000/api/callback for your OAuth Redirect URL. Come back once you have your Application's ClientId and Secret. 
 
 # Example 1 - App Access Token
 ```csharp

--- a/TwitchLib.Api.Helix/Raids.cs
+++ b/TwitchLib.Api.Helix/Raids.cs
@@ -12,7 +12,7 @@ namespace TwitchLib.Api.Helix
     /// </summary>
     public class Raids : ApiBase
     {
-        public Raids(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http)
+        public Raids(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http, IUserAccessTokenManager userAccessTokenManager) : base(settings, rateLimiter, http, userAccessTokenManager)
         {
         }
 

--- a/TwitchLib.Api.Helix/Schedule.cs
+++ b/TwitchLib.Api.Helix/Schedule.cs
@@ -18,7 +18,7 @@ namespace TwitchLib.Api.Helix
     /// </summary>
     public class Schedule : ApiBase
     {
-        public Schedule(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http)
+        public Schedule(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http, IUserAccessTokenManager userAccessTokenManager) : base(settings, rateLimiter, http, userAccessTokenManager)
         { }
 
         /// <summary>

--- a/TwitchLib.Api.Helix/Search.cs
+++ b/TwitchLib.Api.Helix/Search.cs
@@ -13,7 +13,7 @@ namespace TwitchLib.Api.Helix
     /// </summary>
     public class Search : ApiBase
     {
-        public Search(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http)
+        public Search(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http, IUserAccessTokenManager userAccessTokenManager) : base(settings, rateLimiter, http, userAccessTokenManager)
         {
         }
 

--- a/TwitchLib.Api.Helix/Soundtrack.cs
+++ b/TwitchLib.Api.Helix/Soundtrack.cs
@@ -15,7 +15,7 @@ namespace TwitchLib.Api.Helix
     /// </summary>
     public class Soundtrack : ApiBase
     {
-        public Soundtrack(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http)
+        public Soundtrack(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http, IUserAccessTokenManager userAccessTokenManager) : base(settings, rateLimiter, http, userAccessTokenManager)
         {
         }
 

--- a/TwitchLib.Api.Helix/Streams.cs
+++ b/TwitchLib.Api.Helix/Streams.cs
@@ -21,7 +21,7 @@ namespace TwitchLib.Api.Helix
     /// </summary>
     public class Streams : ApiBase
     {
-        public Streams(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http)
+        public Streams(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http, IUserAccessTokenManager userAccessTokenManager) : base(settings, rateLimiter, http, userAccessTokenManager)
         {
         }
 

--- a/TwitchLib.Api.Helix/Subscriptions.cs
+++ b/TwitchLib.Api.Helix/Subscriptions.cs
@@ -14,7 +14,7 @@ namespace TwitchLib.Api.Helix
     /// </summary>
     public class Subscriptions : ApiBase
     {
-        public Subscriptions(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http)
+        public Subscriptions(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http, IUserAccessTokenManager userAccessTokenManager) : base(settings, rateLimiter, http, userAccessTokenManager)
         {
         }
 

--- a/TwitchLib.Api.Helix/Tags.cs
+++ b/TwitchLib.Api.Helix/Tags.cs
@@ -14,7 +14,7 @@ namespace TwitchLib.Api.Helix
     /// </summary>
     public class Tags : ApiBase
     {
-        public Tags(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http)
+        public Tags(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http, IUserAccessTokenManager userAccessTokenManager) : base(settings, rateLimiter, http, userAccessTokenManager)
         {
         }
 

--- a/TwitchLib.Api.Helix/Teams.cs
+++ b/TwitchLib.Api.Helix/Teams.cs
@@ -12,7 +12,7 @@ namespace TwitchLib.Api.Helix
     /// </summary>
     public class Teams : ApiBase
     {
-        public Teams(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http)
+        public Teams(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http, IUserAccessTokenManager userAccessTokenManager) : base(settings, rateLimiter, http, userAccessTokenManager)
         {
         }
 

--- a/TwitchLib.Api.Helix/Users.cs
+++ b/TwitchLib.Api.Helix/Users.cs
@@ -22,7 +22,7 @@ namespace TwitchLib.Api.Helix
     /// </summary>
     public class Users : ApiBase
     {
-        public Users(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http)
+        public Users(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http, IUserAccessTokenManager userAccessTokenManager) : base(settings, rateLimiter, http, userAccessTokenManager)
         {
         }
 

--- a/TwitchLib.Api.Helix/Videos.cs
+++ b/TwitchLib.Api.Helix/Videos.cs
@@ -16,7 +16,7 @@ namespace TwitchLib.Api.Helix
     /// </summary>
     public class Videos : ApiBase
     {
-        public Videos(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http)
+        public Videos(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http, IUserAccessTokenManager userAccessTokenManager) : base(settings, rateLimiter, http, userAccessTokenManager)
         {
         }
 

--- a/TwitchLib.Api.Helix/Whispers.cs
+++ b/TwitchLib.Api.Helix/Whispers.cs
@@ -13,7 +13,7 @@ namespace TwitchLib.Api.Helix
     /// </summary>
     public class Whispers : ApiBase
     {
-        public Whispers(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http)
+        public Whispers(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http, IUserAccessTokenManager userAccessTokenManager) : base(settings, rateLimiter, http, userAccessTokenManager)
         { }
 
         #region SendWhisper

--- a/TwitchLib.Api/Auth/AccessCodeResponse.cs
+++ b/TwitchLib.Api/Auth/AccessCodeResponse.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+
+namespace TwitchLib.Api.Auth
+{
+    public class AccessCodeResponse
+    {
+        [JsonProperty(PropertyName = "access_code")]
+        public string AccessCode { get; set; }
+
+        [JsonProperty(PropertyName = "scope")]
+        public string[] Scopes { get; set; }
+
+        [JsonProperty(PropertyName = "state")]
+        public string State { get; set; }
+    }
+}

--- a/TwitchLib.Api/Auth/Auth.cs
+++ b/TwitchLib.Api/Auth/Auth.cs
@@ -16,22 +16,19 @@ namespace TwitchLib.Api.Auth
     public class Auth : ApiBase
     {
         private ILogger _logger;
+        private IApiSettings _settings;
 
         public Auth(ILogger logger, IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http, null)
         {
             _logger = logger;
+            _settings = settings;
         }
 
         internal AccessCodeResponse GetAccessCodeFromClientIdAndSecret(CancellationTokenSource cancellationToken, string clientId, string secret, int listenerPort = 5000)
         {
-            // TODO: Clean up the scopes!
-            List<AuthScopes> scopes = new List<AuthScopes>();
-            scopes.Add(AuthScopes.Helix_Channel_Manage_Polls);
-            scopes.Add(AuthScopes.Helix_Channel_Read_Polls);
+            string authorizationUrl = GetAuthorizationCodeUrl($"http://localhost:{listenerPort}/api/callback", _settings.Scopes, forceVerify: false, state: Guid.NewGuid().ToString(), clientId: clientId);
 
-            string authorizationUrl = GetAuthorizationCodeUrl($"http://localhost:{listenerPort}/api/callback", scopes, forceVerify: false, state: Guid.NewGuid().ToString(), clientId: clientId);
-
-            Console.WriteLine($"authorizationUrl: {authorizationUrl}");
+            _logger.LogTrace($"Auth::GetAccessCodeFromClientIdAndSecret(): authorizationUrl = {authorizationUrl}");
 
             // Launch a browser to authorize the user's scope and trigger Twitch to return an access code.
             Process process = new Process();

--- a/TwitchLib.Api/Auth/Auth.cs
+++ b/TwitchLib.Api/Auth/Auth.cs
@@ -18,15 +18,15 @@ namespace TwitchLib.Api.Auth
         private ILogger _logger;
         private IApiSettings _settings;
 
-        public Auth(ILogger logger, IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http, null)
+        internal Auth(ILogger logger, IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http, null)
         {
             _logger = logger;
             _settings = settings;
         }
 
-        internal AccessCodeResponse GetAccessCodeFromClientIdAndSecret(CancellationTokenSource cancellationToken, string clientId, string secret, int listenerPort = 5000)
+        internal AccessCodeResponse GetAccessCodeFromClientIdAndSecret(CancellationTokenSource cancellationToken, string clientId, string secret)
         {
-            string authorizationUrl = GetAuthorizationCodeUrl($"http://localhost:{listenerPort}/api/callback", _settings.Scopes, forceVerify: false, state: Guid.NewGuid().ToString(), clientId: clientId);
+            string authorizationUrl = GetAuthorizationCodeUrl($"http://{_settings.OAuthResponseHostname}:{_settings.OAuthResponsePort}/api/callback", _settings.Scopes, forceVerify: false, state: Guid.NewGuid().ToString(), clientId: clientId);
 
             _logger.LogTrace($"Auth::GetAccessCodeFromClientIdAndSecret(): authorizationUrl = {authorizationUrl}");
 
@@ -38,7 +38,7 @@ namespace TwitchLib.Api.Auth
 
             var authenticationServerManager = new AuthenticationServerManager(_logger);
 
-            AccessCodeResponse response = authenticationServerManager.WaitForAuthorizationCodeCallback(cancellationToken, listenerPort);
+            AccessCodeResponse response = authenticationServerManager.WaitForAuthorizationCodeCallback(cancellationToken, _settings.OAuthResponseHostname, _settings.OAuthResponsePort);
 
             return response;
         }

--- a/TwitchLib.Api/Auth/AuthenticationServerManager.cs
+++ b/TwitchLib.Api/Auth/AuthenticationServerManager.cs
@@ -1,0 +1,105 @@
+﻿
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using EmbedIO;
+using EmbedIO.Routing;
+using EmbedIO.WebApi;
+using Microsoft.Extensions.Logging;
+using Swan.Logging;
+
+
+// TODO: Clean up this whole class!
+
+namespace TwitchLib.Api.Auth
+{
+    /// <summary>
+    /// Controls a private WebAPI service that can receive authentication results from oAuth.
+    /// </summary>
+    public class AuthenticationServerManager
+    {
+        public event EventHandler<AccessCodeResponse> AccessCodeReceived;
+
+        internal AccessCodeResponse WaitForAuthorizationCodeCallback(Microsoft.Extensions.Logging.ILogger logger, CancellationTokenSource cancellationToken, int listenerPort)
+        {
+            AccessCodeResponse returnValue = null;
+            AutoResetEvent waitHandle = new AutoResetEvent(false);
+
+            AccessCodeReceived += (source, accessCodeResponse) =>
+            {
+                returnValue = accessCodeResponse;
+                waitHandle.Set();
+            };
+
+            StartLocalServiceAsync(logger, cancellationToken.Token, listenerPort);
+
+            // Wait for oAuth to complete and Twitch to call us back with the Access Code.
+            if (waitHandle.WaitOne(30 * 1000) == false)
+            {
+                cancellationToken.Cancel();
+                throw new TimeoutException("More than 30 seconds elapsed without receiving an Access Code from Twitch. Check https://dev.twitch.tv/console to ensure the callback URL is in the oAuth Redirect URLs list.");
+            }
+
+            // Shutdown the web server.
+            cancellationToken.Cancel();
+
+            return returnValue;
+        }
+
+        private class LoggerBridge : Swan.Logging.ILogger
+        {
+            private Microsoft.Extensions.Logging.ILogger _logger;
+
+            public LoggerBridge(Microsoft.Extensions.Logging.ILogger logger) => _logger = logger; 
+
+            public Swan.Logging.LogLevel LogLevel => Swan.Logging.LogLevel.None;
+
+            public void Dispose()
+            {
+            }
+
+            public void Log(LogMessageReceivedEventArgs logEvent)
+            {
+                _logger.Log( Microsoft.Extensions.Logging.LogLevel.Trace, logEvent.ToString());
+            }
+        }
+
+        public async void StartLocalServiceAsync(Microsoft.Extensions.Logging.ILogger logger, CancellationToken cancellationToken, int port = 5000)
+        {
+            Logger.UnregisterLogger<ConsoleLogger>();
+
+            if (logger != null)
+                Logger.RegisterLogger(new LoggerBridge(logger));
+            
+            WebServer ws = new WebServer(o => o
+                .WithUrlPrefix($"http://localhost:{port}")
+                .WithMode(HttpListenerMode.EmbedIO))
+                .WithWebApi("/api", m => m
+                .WithController<ApiController>(() => { return new ApiController(AccessCodeReceived); }));
+
+            var task = ws.RunAsync(cancellationToken);
+        }
+
+        class ApiController : WebApiController
+        {
+            EventHandler<AccessCodeResponse> AccessCodeReceived;
+
+            public ApiController(EventHandler<AccessCodeResponse> accessCodeReceived) : base()
+            {
+                AccessCodeReceived = accessCodeReceived;
+            }
+
+            [Route(HttpVerbs.Get, "/callback")]
+            public async Task Callback([QueryField] string code, [QueryField] string scope, [QueryField] string state)
+            {
+                //await HttpContext.SendDataAsync($"code: {code}, scope: {scope}, state: {state}");
+                AccessCodeReceived?.Invoke(this, new AccessCodeResponse
+                {
+                    AccessCode = code,
+                    Scopes = scope.Split(' '),
+                    State = state
+                });
+            }
+        }
+    }
+}

--- a/TwitchLib.Api/Auth/AuthenticationServerManager.cs
+++ b/TwitchLib.Api/Auth/AuthenticationServerManager.cs
@@ -3,35 +3,39 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using EmbedIO;
-using EmbedIO.Routing;
 using EmbedIO.WebApi;
 using Microsoft.Extensions.Logging;
 using Swan.Logging;
-
-
-// TODO: Clean up this whole class!
 
 namespace TwitchLib.Api.Auth
 {
     /// <summary>
     /// Controls a private WebAPI service that can receive authentication results from oAuth.
     /// </summary>
-    public class AuthenticationServerManager
+    internal class AuthenticationServerManager
     {
-        public event EventHandler<AccessCodeResponse> AccessCodeReceived;
+        internal AuthenticationServerManager(Microsoft.Extensions.Logging.ILogger logger)
+        {
+            Logger.UnregisterLogger<ConsoleLogger>();
 
-        internal AccessCodeResponse WaitForAuthorizationCodeCallback(Microsoft.Extensions.Logging.ILogger logger, CancellationTokenSource cancellationToken, int listenerPort)
+            if (logger != null)
+                Logger.RegisterLogger(new LoggerBridge(logger));
+        }
+
+        private event EventHandler<AccessCodeResponse> _accessCodeReceived;
+
+        internal AccessCodeResponse WaitForAuthorizationCodeCallback(CancellationTokenSource cancellationToken, int listenerPort)
         {
             AccessCodeResponse returnValue = null;
             AutoResetEvent waitHandle = new AutoResetEvent(false);
 
-            AccessCodeReceived += (source, accessCodeResponse) =>
+            _accessCodeReceived += (source, accessCodeResponse) =>
             {
                 returnValue = accessCodeResponse;
                 waitHandle.Set();
             };
 
-            StartLocalServiceAsync(logger, cancellationToken.Token, listenerPort);
+            StartLocalService(cancellationToken.Token, listenerPort);
 
             // Wait for oAuth to complete and Twitch to call us back with the Access Code.
             if (waitHandle.WaitOne(30 * 1000) == false)
@@ -46,60 +50,15 @@ namespace TwitchLib.Api.Auth
             return returnValue;
         }
 
-        private class LoggerBridge : Swan.Logging.ILogger
+        private void StartLocalService(CancellationToken cancellationToken, int port = 5000)
         {
-            private Microsoft.Extensions.Logging.ILogger _logger;
-
-            public LoggerBridge(Microsoft.Extensions.Logging.ILogger logger) => _logger = logger; 
-
-            public Swan.Logging.LogLevel LogLevel => Swan.Logging.LogLevel.None;
-
-            public void Dispose()
-            {
-            }
-
-            public void Log(LogMessageReceivedEventArgs logEvent)
-            {
-                _logger.Log( Microsoft.Extensions.Logging.LogLevel.Trace, logEvent.ToString());
-            }
-        }
-
-        public async void StartLocalServiceAsync(Microsoft.Extensions.Logging.ILogger logger, CancellationToken cancellationToken, int port = 5000)
-        {
-            Logger.UnregisterLogger<ConsoleLogger>();
-
-            if (logger != null)
-                Logger.RegisterLogger(new LoggerBridge(logger));
-            
             WebServer ws = new WebServer(o => o
                 .WithUrlPrefix($"http://localhost:{port}")
                 .WithMode(HttpListenerMode.EmbedIO))
                 .WithWebApi("/api", m => m
-                .WithController<ApiController>(() => { return new ApiController(AccessCodeReceived); }));
+                .WithController<ApiController>(() => { return new ApiController(_accessCodeReceived); }));
 
-            var task = ws.RunAsync(cancellationToken);
-        }
-
-        class ApiController : WebApiController
-        {
-            EventHandler<AccessCodeResponse> AccessCodeReceived;
-
-            public ApiController(EventHandler<AccessCodeResponse> accessCodeReceived) : base()
-            {
-                AccessCodeReceived = accessCodeReceived;
-            }
-
-            [Route(HttpVerbs.Get, "/callback")]
-            public async Task Callback([QueryField] string code, [QueryField] string scope, [QueryField] string state)
-            {
-                //await HttpContext.SendDataAsync($"code: {code}, scope: {scope}, state: {state}");
-                AccessCodeReceived?.Invoke(this, new AccessCodeResponse
-                {
-                    AccessCode = code,
-                    Scopes = scope.Split(' '),
-                    State = state
-                });
-            }
+            ws.RunAsync(cancellationToken);
         }
     }
 }

--- a/TwitchLib.Api/Auth/AuthenticationServerManager.cs
+++ b/TwitchLib.Api/Auth/AuthenticationServerManager.cs
@@ -24,7 +24,7 @@ namespace TwitchLib.Api.Auth
 
         private event EventHandler<AccessCodeResponse> _accessCodeReceived;
 
-        internal AccessCodeResponse WaitForAuthorizationCodeCallback(CancellationTokenSource cancellationToken, int listenerPort)
+        internal AccessCodeResponse WaitForAuthorizationCodeCallback(CancellationTokenSource cancellationToken, string hostname, int listenerPort)
         {
             AccessCodeResponse returnValue = null;
             AutoResetEvent waitHandle = new AutoResetEvent(false);
@@ -35,7 +35,7 @@ namespace TwitchLib.Api.Auth
                 waitHandle.Set();
             };
 
-            StartLocalService(cancellationToken.Token, listenerPort);
+            StartLocalService(cancellationToken.Token, hostname, listenerPort);
 
             // Wait for oAuth to complete and Twitch to call us back with the Access Code.
             if (waitHandle.WaitOne(30 * 1000) == false)
@@ -50,10 +50,10 @@ namespace TwitchLib.Api.Auth
             return returnValue;
         }
 
-        private void StartLocalService(CancellationToken cancellationToken, int port = 5000)
+        private void StartLocalService(CancellationToken cancellationToken, string hostname, int port = 5000)
         {
             WebServer ws = new WebServer(o => o
-                .WithUrlPrefix($"http://localhost:{port}")
+                .WithUrlPrefix($"http://{hostname}:{port}")
                 .WithMode(HttpListenerMode.EmbedIO))
                 .WithWebApi("/api", m => m
                 .WithController<ApiController>(() => { return new ApiController(_accessCodeReceived); }));

--- a/TwitchLib.Api/Auth/LoggerBridge.cs
+++ b/TwitchLib.Api/Auth/LoggerBridge.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.Extensions.Logging;
+using Swan.Logging;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.Api.Auth
+{
+    internal class LoggerBridge : Swan.Logging.ILogger
+    {
+        private Microsoft.Extensions.Logging.ILogger _logger;
+
+        public LoggerBridge(Microsoft.Extensions.Logging.ILogger logger) => _logger = logger;
+
+        public Swan.Logging.LogLevel LogLevel => Swan.Logging.LogLevel.Info;
+
+        public void Dispose()
+        {
+        }
+
+        public void Log(LogMessageReceivedEventArgs logEvent)
+        {
+            _logger.LogInformation(logEvent.Message);
+        }
+    }
+}

--- a/TwitchLib.Api/Auth/UserAccessTokenManager.cs
+++ b/TwitchLib.Api/Auth/UserAccessTokenManager.cs
@@ -1,0 +1,97 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using TwitchLib.Api.Core;
+using TwitchLib.Api.Core.Interfaces;
+using TwitchLib.Api.Helix.Models.Extensions.ReleasedExtensions;
+using TwitchLib.Api.Interfaces;
+using static Swan.Terminal;
+
+namespace TwitchLib.Api.Auth
+{
+    internal class UserAccessTokenManager : IUserAccessTokenManager
+    {
+        IApiSettings _settings;
+        private Auth _auth;
+        private DateTime _tokenExpiration = DateTime.MinValue;
+        private string _refreshToken = null;
+        private string _accessToken = null;
+        private string[] _scopes;
+
+        public UserAccessTokenManager(IApiSettings settings, Auth auth) 
+        {
+            _settings = settings;   
+            _auth = auth;
+
+            if (Directory.Exists(Path.GetDirectoryName(_settings.OAuthTokenFile)) == false)
+                Directory.CreateDirectory(Path.GetDirectoryName(_settings.OAuthTokenFile));
+        }
+
+        public async Task<string> GetUserAccessToken()
+        {
+            // First, see if the stored refresh token is still valid.
+            if (_refreshToken == null)
+            {
+                if (File.Exists(_settings.OAuthTokenFile) == true)
+                {
+                    RefreshResponse refreshData = JsonConvert.DeserializeObject<RefreshResponse>(File.ReadAllText(_settings.OAuthTokenFile));
+                    _tokenExpiration = File.GetCreationTime(_settings.OAuthTokenFile).AddSeconds(refreshData.ExpiresIn);
+
+                    _refreshToken = refreshData.RefreshToken;
+                    _scopes = refreshData.Scopes;
+                    _accessToken = refreshData.AccessToken;                        
+                }
+            }
+
+            // If we couldn't read the refresh token, then do a full reauthorize.
+            if (_refreshToken == null)
+            {
+                await Reauthorize();
+            }
+
+            // If the token hasn't expired yet, then we can return it.
+            if (_tokenExpiration > DateTime.Now.AddMinutes(5))
+                return _accessToken;
+
+            // If the token has expired, then do a refresh
+            await Refresh();
+
+            return _accessToken;
+        }
+
+        private async Task Reauthorize()
+        {
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+
+            var accessCodeResponse = _auth.GetAccessCodeFromClientIdAndSecret(cancellationTokenSource, _settings.ClientId, _settings.Secret);
+            Console.WriteLine($"code: {accessCodeResponse.AccessCode}");
+
+            var accessTokenReponse = await _auth.GetAccessTokenFromCodeAsync(accessCodeResponse.AccessCode, _settings.Secret, $"http://localhost:{_settings.OAuthResponsePort}/api/callback", _settings.ClientId);
+            Console.WriteLine($"accessToken: {accessTokenReponse.AccessToken}, Expiration: {DateTime.Now.AddSeconds(accessTokenReponse.ExpiresIn)}");
+
+            _accessToken = accessTokenReponse.AccessToken;
+            _scopes = accessTokenReponse.Scopes;
+            _refreshToken = accessTokenReponse.RefreshToken;
+            _tokenExpiration = DateTime.Now.AddSeconds(accessTokenReponse.ExpiresIn);
+
+            File.WriteAllText(_settings.OAuthTokenFile, JsonConvert.SerializeObject(accessTokenReponse));
+        }
+
+        private async Task Refresh()
+        {
+            var refreshResponse = await _auth.RefreshAuthTokenAsync(_refreshToken, _settings.Secret, _settings.ClientId);
+
+            _accessToken = refreshResponse.AccessToken;
+            _scopes = refreshResponse.Scopes;
+            _refreshToken = refreshResponse.RefreshToken;
+            _tokenExpiration = DateTime.Now.AddSeconds(refreshResponse.ExpiresIn);
+
+            File.WriteAllText(_settings.OAuthTokenFile, JsonConvert.SerializeObject(refreshResponse));
+        }
+    }
+}

--- a/TwitchLib.Api/Auth/WebApiController.cs
+++ b/TwitchLib.Api/Auth/WebApiController.cs
@@ -1,0 +1,32 @@
+﻿using EmbedIO.Routing;
+using EmbedIO.WebApi;
+using EmbedIO;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TwitchLib.Api.Auth
+{
+    internal class ApiController : WebApiController
+    {
+        EventHandler<AccessCodeResponse> AccessCodeReceived;
+
+        public ApiController(EventHandler<AccessCodeResponse> accessCodeReceived) : base()
+        {
+            AccessCodeReceived = accessCodeReceived;
+        }
+
+        [Route(HttpVerbs.Get, "/callback")]
+        public void Callback([QueryField] string code, [QueryField] string scope, [QueryField] string state)
+        {
+            //await HttpContext.SendDataAsync($"code: {code}, scope: {scope}, state: {state}");
+            AccessCodeReceived?.Invoke(this, new AccessCodeResponse
+            {
+                AccessCode = code,
+                Scopes = scope.Split(' '),
+                State = state
+            });
+        }
+    }
+}

--- a/TwitchLib.Api/ThirdParty/ThirdParty.cs
+++ b/TwitchLib.Api/ThirdParty/ThirdParty.cs
@@ -30,7 +30,7 @@ namespace TwitchLib.Api.ThirdParty
 
         public class UsernameChangeApi : ApiBase
         {
-            public UsernameChangeApi(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http)
+            public UsernameChangeApi(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http, null)
             {
             }
 
@@ -52,7 +52,7 @@ namespace TwitchLib.Api.ThirdParty
 
         public class ModLookupApi : ApiBase
         {
-            public ModLookupApi(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http)
+            public ModLookupApi(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http, null)
             {
             }
 
@@ -92,7 +92,7 @@ namespace TwitchLib.Api.ThirdParty
             private string _apiId;
             private Timer _pingTimer;
 
-            public AuthorizationFlowApi(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http)
+            public AuthorizationFlowApi(IApiSettings settings, IRateLimiter rateLimiter, IHttpCallHandler http) : base(settings, rateLimiter, http, null)
             {
             }
 

--- a/TwitchLib.Api/TwitchAPI.cs
+++ b/TwitchLib.Api/TwitchAPI.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using EmbedIO.Authentication;
 using Microsoft.Extensions.Logging;
 using TwitchLib.Api.Auth;
 using TwitchLib.Api.Core;

--- a/TwitchLib.Api/TwitchAPI.cs
+++ b/TwitchLib.Api/TwitchAPI.cs
@@ -32,7 +32,7 @@ namespace TwitchLib.Api
             http = http ?? new TwitchHttpClient(loggerFactory?.CreateLogger<TwitchHttpClient>());
             Settings = settings ?? new ApiSettings();
 
-            Auth = new Auth.Auth(Settings, rateLimiter, http);
+            Auth = new Auth.Auth(_logger, Settings, rateLimiter, http);
             Helix = new Helix.Helix(loggerFactory, rateLimiter, Settings, http);
             ThirdParty = new ThirdParty.ThirdParty(Settings, rateLimiter, http);
             Undocumented = new Undocumented(Settings, rateLimiter, http);

--- a/TwitchLib.Api/TwitchAPI.cs
+++ b/TwitchLib.Api/TwitchAPI.cs
@@ -38,7 +38,7 @@ namespace TwitchLib.Api
 
             Auth = new Auth.Auth(_logger, Settings, rateLimiter, http);
 
-            var userAccessTokenManager = new UserAccessTokenManager(settings, Auth);
+            var userAccessTokenManager = new UserAccessTokenManager(settings, Auth, _logger);
 
             Helix = new Helix.Helix(loggerFactory, rateLimiter, Settings, http, userAccessTokenManager);
             ThirdParty = new ThirdParty.ThirdParty(Settings, rateLimiter, http);

--- a/TwitchLib.Api/TwitchAPI.cs
+++ b/TwitchLib.Api/TwitchAPI.cs
@@ -1,5 +1,7 @@
 using System.ComponentModel;
+using EmbedIO.Authentication;
 using Microsoft.Extensions.Logging;
+using TwitchLib.Api.Auth;
 using TwitchLib.Api.Core;
 using TwitchLib.Api.Core.HttpCallHandlers;
 using TwitchLib.Api.Core.Interfaces;
@@ -32,10 +34,15 @@ namespace TwitchLib.Api
             http = http ?? new TwitchHttpClient(loggerFactory?.CreateLogger<TwitchHttpClient>());
             Settings = settings ?? new ApiSettings();
 
+            
+
             Auth = new Auth.Auth(_logger, Settings, rateLimiter, http);
-            Helix = new Helix.Helix(loggerFactory, rateLimiter, Settings, http);
+
+            var userAccessTokenManager = new UserAccessTokenManager(settings, Auth);
+
+            Helix = new Helix.Helix(loggerFactory, rateLimiter, Settings, http, userAccessTokenManager);
             ThirdParty = new ThirdParty.ThirdParty(Settings, rateLimiter, http);
-            Undocumented = new Undocumented(Settings, rateLimiter, http);
+            Undocumented = new Undocumented(Settings, rateLimiter, http, userAccessTokenManager);
 
             Settings.PropertyChanged += SettingsPropertyChanged;
         }

--- a/TwitchLib.Api/TwitchLib.Api.csproj
+++ b/TwitchLib.Api/TwitchLib.Api.csproj
@@ -23,6 +23,7 @@
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="EmbedIO" Version="3.5.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>


### PR DESCRIPTION
Uses EmbedIO (MIT License) as an embedded web server to receive access token call backs for interactive scope authorizations. Adds support for refresh tokens so that applications can use User Access tokens without user interaction. Enables full usage of Helix API without requiring extra consumer implementation per usage. 

Thanks for a great library, hope you like it! :)