### PR TITLE
Adjust GetAdSchedule model after Twitch fix

### DIFF
--- a/TwitchLib.Api.Helix.Models/Channels/GetAdSchedule/AdSchedule.cs
+++ b/TwitchLib.Api.Helix.Models/Channels/GetAdSchedule/AdSchedule.cs
@@ -1,7 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace TwitchLib.Api.Helix.Models.Channels.GetAdSchedule
 {
@@ -28,8 +25,8 @@ namespace TwitchLib.Api.Helix.Models.Channels.GetAdSchedule
         /// <summary>
         /// <para>The length in seconds of the scheduled upcoming ad break.</para>
         /// </summary>
-        [JsonProperty(PropertyName = "lengths_seconds")]
-        public int LengthsSeconds { get;protected set; }
+        [JsonProperty(PropertyName = "length_seconds")]
+        public int LengthSeconds { get;protected set; }
         /// <summary>
         /// <para>The UTC timestamp of the broadcaster’s last ad-break, in RFC3339 format. Empty if the channel has not run an ad or is not live.</para>
         /// </summary>

--- a/TwitchLib.Api.Helix.Models/Channels/GetAdSchedule/GetAdScheduleResponse.cs
+++ b/TwitchLib.Api.Helix.Models/Channels/GetAdSchedule/GetAdScheduleResponse.cs
@@ -1,7 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace TwitchLib.Api.Helix.Models.Channels.GetAdSchedule
 {


### PR DESCRIPTION
Turns out the docs were right but the response model of Helix itself was wrong.
So changing "lengths_seconds" to "length_seconds" to be compliant.