### PR TITLE
Send message via API: add `reply_parent_message_id` for reply functionality

### DIFF
--- a/TwitchLib.Api.Helix/Chat.cs
+++ b/TwitchLib.Api.Helix/Chat.cs
@@ -304,10 +304,11 @@ namespace TwitchLib.Api.Helix
         /// <param name="broadcasterId">The ID of the broadcaster whose chat room the message will be sent to.</param>
         /// <param name="senderId">	The ID of the user sending the message. This ID must match the user ID in the user access token.</param>
         /// <param name="message">	The message to send. The message is limited to a maximum of 500 characters. Chat messages can also include emoticons. To include emoticons, use the name of the emote. The names are case sensitive. Don’t include colons around the name (e.g., :bleedPurple:). If Twitch recognizes the name, Twitch converts the name to the emote before writing the chat message to the chat room</param>
+        /// <param name="replyParentMessageId">The ID of the chat message being replied to. If omitted, the message is not a reply</param>
         /// <param name="accessToken"></param>
         /// <returns></returns>
         /// <exception cref="BadParameterException"></exception>
-        public Task<SendChatMessageResponse> SendChatMessage(string broadcasterId, string senderId, string message, string accessToken = null)
+        public Task<SendChatMessageResponse> SendChatMessage(string broadcasterId, string senderId, string message, string replyParentMessageId = null, string accessToken = null)
         {
             if (string.IsNullOrEmpty(broadcasterId))
                 throw new BadParameterException("broadcasterId must be set");
@@ -324,6 +325,10 @@ namespace TwitchLib.Api.Helix
                 ["sender_id"] = senderId,
                 ["message"] = message
             };
+            if (replyParentMessageId != null)
+            {
+                json.Add("reply_parent_message_id", replyParentMessageId);
+            }
 
             return TwitchPostGenericAsync<SendChatMessageResponse>("/chat/messages", ApiVersion.Helix, json.ToString(), null, accessToken);
         }


### PR DESCRIPTION
This seems to be the only thing missing from this endpoint for it to be a replacement for e.g. irc-based message sending