### PR TITLE
add support for Chat/Emotes/GetUserEmotes

### DIFF
--- a/TwitchLib.Api.Helix.Models/Chat/Emotes/ChannelEmote.cs
+++ b/TwitchLib.Api.Helix.Models/Chat/Emotes/ChannelEmote.cs
@@ -5,6 +5,11 @@ namespace TwitchLib.Api.Helix.Models.Chat.Emotes
     public class ChannelEmote : Emote
     {
         /// <summary>
+        /// Contains the image URLs for the emote.
+        /// </summary>
+        [JsonProperty("images")]
+        public EmoteImages Images { get; protected set; }
+        /// <summary>
         /// The subscriber tier at which the emote is unlocked.
         /// </summary>
         [JsonProperty("tier")]

--- a/TwitchLib.Api.Helix.Models/Chat/Emotes/Emote.cs
+++ b/TwitchLib.Api.Helix.Models/Chat/Emotes/Emote.cs
@@ -15,11 +15,6 @@ namespace TwitchLib.Api.Helix.Models.Chat.Emotes
         [JsonProperty("name")]
         public string Name { get; protected set; }
         /// <summary>
-        /// Contains the image URLs for the emote.
-        /// </summary>
-        [JsonProperty("images")]
-        public EmoteImages Images { get; protected set; }
-        /// <summary>
         /// The formats that the emote is available in.
         /// </summary>
         [JsonProperty("format")]

--- a/TwitchLib.Api.Helix.Models/Chat/Emotes/EmoteSet.cs
+++ b/TwitchLib.Api.Helix.Models/Chat/Emotes/EmoteSet.cs
@@ -15,6 +15,11 @@ namespace TwitchLib.Api.Helix.Models.Chat.Emotes
         [JsonProperty("emote_set_id")]
         public string EmoteSetId { get; protected set; }
         /// <summary>
+        /// Contains the image URLs for the emote.
+        /// </summary>
+        [JsonProperty("images")]
+        public EmoteImages Images { get; protected set; }
+        /// <summary>
         /// The ID of the broadcaster who owns the emote.
         /// </summary>
         [JsonProperty("owner_id")]

--- a/TwitchLib.Api.Helix.Models/Chat/Emotes/GetUserEmotes/GetUserEmotesResponse.cs
+++ b/TwitchLib.Api.Helix.Models/Chat/Emotes/GetUserEmotes/GetUserEmotesResponse.cs
@@ -1,0 +1,14 @@
+using Newtonsoft.Json;
+using TwitchLib.Api.Helix.Models.Common;
+
+namespace TwitchLib.Api.Helix.Models.Chat.Emotes.GetUserEmotes;
+
+public class GetUserEmotesResponse
+{
+    [JsonProperty("data")]
+    public UserEmote[] Data { get; protected set; }
+    [JsonProperty("template")]
+    public string Template { get; protected set; }
+    [JsonProperty("pagination")]
+    public Pagination Pagination { get; protected set; }
+}

--- a/TwitchLib.Api.Helix.Models/Chat/Emotes/GlobalEmote.cs
+++ b/TwitchLib.Api.Helix.Models/Chat/Emotes/GlobalEmote.cs
@@ -1,7 +1,13 @@
-﻿namespace TwitchLib.Api.Helix.Models.Chat.Emotes
+﻿using Newtonsoft.Json;
+
+namespace TwitchLib.Api.Helix.Models.Chat.Emotes
 {
     public class GlobalEmote : Emote
     {
-        // Empty for now as everything is in the base class already
+        /// <summary>
+        /// Contains the image URLs for the emote.
+        /// </summary>
+        [JsonProperty("images")]
+        public EmoteImages Images { get; protected set; }
     }
 }

--- a/TwitchLib.Api.Helix.Models/Chat/Emotes/UserEmote.cs
+++ b/TwitchLib.Api.Helix.Models/Chat/Emotes/UserEmote.cs
@@ -1,0 +1,36 @@
+using Newtonsoft.Json;
+
+namespace TwitchLib.Api.Helix.Models.Chat.Emotes;
+
+public class UserEmote : Emote
+{
+    /// <summary>
+    /// The type of emote. The possible values are:
+    /// none — No emote type was assigned to this emote.
+    /// - bitstier — A Bits tier emote.
+    /// - follower — A follower emote.
+    /// - subscriptions — A subscriber emote.
+    /// - channelpoints — An emote granted by using channel points.
+    /// - rewards — An emote granted to the user through a special event.
+    /// - hypetrain — An emote granted for participation in a Hype Train.
+    /// - An emote granted for linking an Amazon Prime account.
+    /// - An emote granted for having Twitch Turbo.
+    /// - Emoticons supported by Twitch.
+    /// - An emote accessible by everyone.
+    /// - Emotes related to Overwatch League 2019.
+    /// - Emotes granted by enabling two-factor authentication on an account.
+    /// - Emotes that were granted for only a limited time.
+    /// </summary>
+    [JsonProperty("emote_type")]
+    public string EmoteType { get; protected set; }
+    /// <summary>
+    /// An ID that identifies the emote set that the emote belongs to.
+    /// </summary>
+    [JsonProperty("emote_set_id")]
+    public string EmoteSetId { get; protected set; }
+    /// <summary>
+    /// The ID of the broadcaster who owns the emote.
+    /// </summary>
+    [JsonProperty("owner_id")]
+    public string OwnerId { get; protected set; }
+}

--- a/TwitchLib.Api.Helix.Models/Chat/Emotes/UserEmote.cs
+++ b/TwitchLib.Api.Helix.Models/Chat/Emotes/UserEmote.cs
@@ -13,13 +13,13 @@ public class UserEmote : Emote
     /// - channelpoints — An emote granted by using channel points.
     /// - rewards — An emote granted to the user through a special event.
     /// - hypetrain — An emote granted for participation in a Hype Train.
-    /// - An emote granted for linking an Amazon Prime account.
-    /// - An emote granted for having Twitch Turbo.
-    /// - Emoticons supported by Twitch.
-    /// - An emote accessible by everyone.
-    /// - Emotes related to Overwatch League 2019.
-    /// - Emotes granted by enabling two-factor authentication on an account.
-    /// - Emotes that were granted for only a limited time.
+    /// - prime — An emote granted for linking an Amazon Prime account.
+    /// - turbo — An emote granted for having Twitch Turbo.
+    /// - smilies — Emoticons supported by Twitch.
+    /// - globals — An emote accessible by everyone.
+    /// - owl2019 — Emotes related to Overwatch League 2019.
+    /// - twofactor — Emotes granted by enabling two-factor authentication on an account.
+    /// - limitedtime — Emotes that were granted for only a limited time.
     /// </summary>
     [JsonProperty("emote_type")]
     public string EmoteType { get; protected set; }

--- a/TwitchLib.Api.Helix/Chat.cs
+++ b/TwitchLib.Api.Helix/Chat.cs
@@ -16,6 +16,7 @@ using TwitchLib.Api.Helix.Models.Chat.ChatSettings;
 using TwitchLib.Api.Helix.Models.Chat.Emotes.GetChannelEmotes;
 using TwitchLib.Api.Helix.Models.Chat.Emotes.GetEmoteSets;
 using TwitchLib.Api.Helix.Models.Chat.Emotes.GetGlobalEmotes;
+using TwitchLib.Api.Helix.Models.Chat.Emotes.GetUserEmotes;
 using TwitchLib.Api.Helix.Models.Chat.GetChatters;
 using TwitchLib.Api.Helix.Models.Chat.GetUserChatColor;
 
@@ -147,6 +148,35 @@ namespace TwitchLib.Api.Helix
         public Task<GetGlobalEmotesResponse> GetGlobalEmotesAsync(string accessToken = null)
         {
             return TwitchGetGenericAsync<GetGlobalEmotesResponse>("/chat/emotes/global", ApiVersion.Helix, accessToken: accessToken);
+        }
+
+        /// <summary>
+        /// Retrieves emotes available to the user across all channels.
+        /// </summary>
+        /// <param name="userId">The ID of the user. This ID must match the user ID in the user access token.</param>
+        /// <param name="after">The cursor used to get the next page of results. The Pagination object in the response contains the cursor’s value.</param>
+        /// <param name="broadcasterId">The User ID of a broadcaster you wish to get follower emotes of. Using this query parameter will guarantee inclusion of the broadcaster’s follower emotes in the response body.</param>
+        /// <param name="accessToken">optional access token to override the use of the stored one in the TwitchAPI instance</param>
+        /// <returns cref="GetUserEmotesResponse"></returns>
+        public Task<GetUserEmotesResponse> GetUserEmotesAsync(string userId, string after = null,
+            string broadcasterId = null, string accessToken = null)
+        {
+            if (string.IsNullOrEmpty(userId))
+                throw new BadParameterException("userId must be set");
+            
+            var getParams = new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("user_id", userId)
+            };
+            
+            if (!string.IsNullOrEmpty(after))
+                getParams.Add(new KeyValuePair<string, string>("after", after));
+            
+            if (!string.IsNullOrEmpty(broadcasterId))
+                getParams.Add(new KeyValuePair<string, string>("broadcaster_id", broadcasterId));
+
+            return TwitchGetGenericAsync<GetUserEmotesResponse>("/chat/emotes/user", ApiVersion.Helix, getParams,
+                accessToken);
         }
         #endregion
 


### PR DESCRIPTION
This PR adds support for [GetUserEmotes](https://dev.twitch.tv/docs/api/reference/#get-user-emotes).
- Moves the `Images` field of the extendable `Emote` class to `ChannelEmote`, `EmoteSet`, and `GlobalEmote`, the three classes that extend `Emote`
- Adds new `UserEmote` that extends `Emote`
- Adds new `GetUserEmotes` in `Chat/Emote`

Tested.