### PR TITLE
Update ChatSettingsResponseModel.cs

### DIFF
--- a/TwitchLib.Api.Helix.Models/Chat/ChatSettings/ChatSettingsResponseModel.cs
+++ b/TwitchLib.Api.Helix.Models/Chat/ChatSettings/ChatSettingsResponseModel.cs
@@ -35,7 +35,7 @@ public class ChatSettingsResponseModel
     /// The moderator’s ID.
     /// </summary>
     [JsonProperty(PropertyName = "moderator_id")]
-    public bool ModeratorId { get; protected set; }
+    public string ModeratorId { get; protected set; }
 
     /// <summary>
     /// A Boolean value that determines whether the broadcaster adds a short delay before chat messages appear in the chat room. 


### PR DESCRIPTION
Fixed `ModeratorId` incorrectly being a `bool` instead of a `string`