### PR TITLE
Fixing wrong userId param in GetVIPsAsync

### DIFF
--- a/TwitchLib.Api.Helix/Channels.cs
+++ b/TwitchLib.Api.Helix/Channels.cs
@@ -140,7 +140,7 @@ namespace TwitchLib.Api.Helix
                 if (userIds.Count == 0)
                     throw new BadParameterException("userIds must contain at least 1 userId if a list is included in the call");
 
-                getParams.AddRange(userIds.Select(userId => new KeyValuePair<string, string>("userId", userId)));
+                getParams.AddRange(userIds.Select(userId => new KeyValuePair<string, string>("user_id", userId)));
             }
 
             if (!string.IsNullOrWhiteSpace(after))


### PR DESCRIPTION
It didn't returned a single value or multiple values by ID, because the parameter was not correct here so it always was just returning the full list then. :3 