### PR TITLE
Add for_source_only to SendChatMessage

### DIFF
--- a/TwitchLib.Api.Helix.Models/Channels/SendChatMessage/SendChatMessageRequest.cs
+++ b/TwitchLib.Api.Helix.Models/Channels/SendChatMessage/SendChatMessageRequest.cs
@@ -1,0 +1,46 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TwitchLib.Api.Helix.Models.Channels.SendChatMessage
+{
+    [JsonObject(ItemNullValueHandling = NullValueHandling.Ignore)]
+    public class SendChatMessageRequest
+    {
+        /// <summary>
+        /// The ID of the broadcaster whose chat room the message will be sent to.
+        /// </summary>
+        [JsonProperty(PropertyName = "broadcaster_id")]
+        public string BroadcasterId { get; set; }
+        /// <summary>
+        /// The ID of the user sending the message. 
+        /// This ID must match the user ID in the user access token.
+        /// </summary>
+        [JsonProperty(PropertyName = "sender_id")]
+        public string SenderId { get; set; }
+        /// <summary>
+        /// The message to send. The message is limited to a maximum of 500 characters. 
+        /// Chat messages can also include emoticons. To include emoticons, use the name of the emote. 
+        /// The names are case sensitive. Don’t include colons around the name (e.g., :bleedPurple:). 
+        /// If Twitch recognizes the name, Twitch converts the name to the emote before writing the chat message to the chat room
+        /// </summary>
+        [JsonProperty(PropertyName = "message")]
+        public string Message { get; set; }
+        /// <summary>
+        /// The ID of the chat message being replied to. 
+        /// If omitted, the message is not a reply
+        /// </summary>
+        [JsonProperty(PropertyName = "reply_parent_message_id")]
+        public string? ReplyParentMessageId { get; set; }
+        /// <summary>
+        /// <para>NOTE: This parameter can only be set when utilizing an App Access Token. It cannot be specified when a User Access Token is used, and will instead result in an HTTP 400 error.</para>
+        /// <para>Determines if the chat message is sent only to the source channel (defined by <see cref="BroadcasterId"/>) during a shared chat session. This has no effect if the message is sent during a shared chat session.</para>
+        /// <para>If this parameter is <c>null</c>, the default value when using an App Access Token is <c>false</c></para>
+        /// </summary>
+        [JsonProperty(PropertyName = "for_source_only")]
+        public bool? ForSourceOnly { get; set; }
+
+    }
+}

--- a/TwitchLib.Api.Helix/Chat.cs
+++ b/TwitchLib.Api.Helix/Chat.cs
@@ -1,5 +1,6 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -163,15 +164,15 @@ namespace TwitchLib.Api.Helix
         {
             if (string.IsNullOrEmpty(userId))
                 throw new BadParameterException("userId must be set");
-            
+
             var getParams = new List<KeyValuePair<string, string>>
             {
                 new KeyValuePair<string, string>("user_id", userId)
             };
-            
+
             if (!string.IsNullOrEmpty(after))
                 getParams.Add(new KeyValuePair<string, string>("after", after));
-            
+
             if (!string.IsNullOrEmpty(broadcasterId))
                 getParams.Add(new KeyValuePair<string, string>("broadcaster_id", broadcasterId));
 
@@ -338,6 +339,7 @@ namespace TwitchLib.Api.Helix
         /// <param name="accessToken"></param>
         /// <returns></returns>
         /// <exception cref="BadParameterException"></exception>
+        [Obsolete("Use SendChatMessage(SendChatMessageRequest, string) instead")]
         public Task<SendChatMessageResponse> SendChatMessage(string broadcasterId, string senderId, string message, string replyParentMessageId = null, string accessToken = null)
         {
             if (string.IsNullOrEmpty(broadcasterId))
@@ -355,12 +357,34 @@ namespace TwitchLib.Api.Helix
                 ["sender_id"] = senderId,
                 ["message"] = message
             };
+
             if (replyParentMessageId != null)
             {
                 json.Add("reply_parent_message_id", replyParentMessageId);
             }
 
             return TwitchPostGenericAsync<SendChatMessageResponse>("/chat/messages", ApiVersion.Helix, json.ToString(), null, accessToken);
+        }
+
+        /// <summary>
+        /// Sends a message to a chat
+        /// </summary>
+        /// <param name="request">Request parameters for the message</param>
+        /// <param name="accessToken"></param>
+        /// <returns></returns>
+        /// <exception cref="BadParameterException"></exception>
+        public Task<SendChatMessageResponse> SendChatMessage(SendChatMessageRequest request, string accessToken = null)
+        {
+            if (string.IsNullOrEmpty(request.BroadcasterId))
+                throw new BadParameterException("BroadcasterId must be set");
+
+            if (string.IsNullOrEmpty(request.SenderId))
+                throw new BadParameterException("SenderId must be set");
+
+            if (string.IsNullOrEmpty(request.Message))
+                throw new BadParameterException("Message must be set");
+
+            return TwitchPostGenericAsync<SendChatMessageResponse>("/chat/messages", ApiVersion.Helix, JsonConvert.SerializeObject(request), null, accessToken);
         }
 
         #endregion


### PR DESCRIPTION
Adds the parameter for_source_only to the SendChatMessage API.

As documented by Twitch this now defaults to false when an app access token is used.
https://dev.twitch.tv/docs/change-log/#:~:text=2025%E2%80%9104%E2%80%9110

It also errors with HTTP 400 when the property is set when called with a user access token.
https://dev.twitch.tv/docs/api/reference/#send-chat-message

These notes have been added to parameter summary.

~**This is kind of a breaking change though.** The last parameter in the signature of the call was the "accesstoken = null". If a user just entered null for that no change should happen, if the user entered a string for the access token without qualifiying the parameter name, then the user will not be able to compile with the new version and has to adjust the call.~