### PR TITLE
Add for source only parameter to send chat announcement

### DIFF
--- a/TwitchLib.Api.Helix.Models/Chat/Announcement/SendChatAnnouncementRequest.cs
+++ b/TwitchLib.Api.Helix.Models/Chat/Announcement/SendChatAnnouncementRequest.cs
@@ -1,0 +1,31 @@
+﻿using Newtonsoft.Json;
+namespace TwitchLib.Api.Helix.Models.Chat.Announcement
+{
+    [JsonObject(ItemNullValueHandling = NullValueHandling.Ignore)]
+    public class SendChatAnnouncementRequest
+    {
+        /// <summary>
+        /// The announcement to make in the broadcaster’s chat room. 
+        /// Announcements are limited to a maximum of 500 characters; 
+        /// announcements longer than 500 characters are truncated.
+        /// </summary>
+        [JsonProperty("message")]
+        public string Message { get; set; }
+        /// <summary>
+        /// The color used to highlight the announcement.
+        /// <br/>If color is set to primary or is not set, the channel’s accent color is used to highlight the announcement (see Profile Accent Color under profile settings, Channel and Videos, and Brand).
+        /// </summary>
+        [JsonProperty("color")]
+        public AnnouncementColors? Color { get; set; }
+        /// <summary>
+        /// NOTE: This parameter can only be set when utilizing an App Access Token. 
+        /// <br/>It cannot be specified when a User Access Token is used, and will instead result in an HTTP 400 error.
+        /// <br/><br/>Determines if the chat announcement is sent only to the source channel(defined by broadcaster_id) during a shared chat session.
+        /// <br/>This has no effect if the announcement is not sent during a shared chat session.
+        /// <br/><br/>The default value when using an App Access Token is <see langword="true"/>.
+        /// <br/>If you prefer to send an announcement to all channels in a shared chat session, set this parameter to <see langword="false"/>.
+        /// </summary>
+        [JsonProperty("for_source_only")]
+        public bool? ForSourceOnly { get; set; }
+    }
+}

--- a/TwitchLib.Api.Helix/Chat.cs
+++ b/TwitchLib.Api.Helix/Chat.cs
@@ -13,6 +13,7 @@ using TwitchLib.Api.Core.Exceptions;
 using TwitchLib.Api.Core.Interfaces;
 using TwitchLib.Api.Helix.Models.Channels.SendChatMessage;
 using TwitchLib.Api.Helix.Models.Chat;
+using TwitchLib.Api.Helix.Models.Chat.Announcement;
 using TwitchLib.Api.Helix.Models.Chat.Badges.GetChannelChatBadges;
 using TwitchLib.Api.Helix.Models.Chat.Badges.GetGlobalChatBadges;
 using TwitchLib.Api.Helix.Models.Chat.ChatSettings;
@@ -253,6 +254,7 @@ public class Chat : ApiBase
     /// <param name="message">The announcement to make in the broadcaster’s chat room.</param>
     /// <param name="color">The color used to highlight the announcement. Possible case-sensitive values are: blue/green/orange/purple/primary(default)</param>
     /// <param name="accessToken">optional access token to override the use of the stored one in the TwitchAPI instance</param>
+    [Obsolete("Use SendChatAnnouncementAsync(string, string, SendChatAnnouncementRequest, string) instead.")]
     public Task SendChatAnnouncementAsync(string broadcasterId, string moderatorId, string message, AnnouncementColors color = null, string accessToken = null)
     {
         BadParameterException.ThrowIfNullOrEmpty(broadcasterId);
@@ -279,6 +281,35 @@ public class Chat : ApiBase
             ["message"] = message,
             ["color"] = color.Value
         };
+        
+        return TwitchPostAsync("/chat/announcements", ApiVersion.Helix, json.ToString(), getParams, accessToken);
+    }
+
+    /// <summary>
+    /// Sends an announcement to the broadcaster’s chat room.
+    /// Requires a user access token that includes the moderator:manage:announcements scope.
+    /// The ID in the moderator_id query parameter must match the user ID in the access token.
+    /// </summary>
+    /// <param name="broadcasterId">The ID of the broadcaster that owns the chat room to send the announcement to.</param>
+    /// <param name="moderatorId">The ID of a user who has permission to moderate the broadcaster’s chat room. This ID must match the user ID in the OAuth token, which can be a moderator or the broadcaster.</param>
+    /// <param name="request">The request parameters for sending the announcement.</param>
+    /// <param name="accessToken">optional access token to override the use of the stored one in the TwitchAPI instance</param>
+    public Task SendChatAnnouncementAsync(string broadcasterId, string moderatorId, SendChatAnnouncementRequest request, string accessToken = null)
+    {
+        BadParameterException.ThrowIfNullOrEmpty(broadcasterId);
+        BadParameterException.ThrowIfNullOrEmpty(moderatorId);
+        BadParameterException.ThrowIfNullOrEmpty(request.Message);
+
+        if (request.Message.Length > 500)
+            throw new BadParameterException("message length must be less than or equal to 500 characters");
+
+        var getParams = new List<KeyValuePair<string, string>>
+        {
+            new KeyValuePair<string, string>("broadcaster_id", broadcasterId),
+            new KeyValuePair<string, string>("moderator_id", moderatorId),
+        };
+
+        var json = JObject.FromObject(request);
 
         return TwitchPostAsync("/chat/announcements", ApiVersion.Helix, json.ToString(), getParams, accessToken);
     }


### PR DESCRIPTION
https://dev.twitch.tv/docs/change-log/#:~:text=2026%E2%80%9104%E2%80%9102

- Add the new For Source Only parameter to SendChatAnnouncement by providing a new method for sending Announcements.
- Set the old method to obsolete like it was done with SendChatMessage